### PR TITLE
Add CI/CD workflows, release process, and supporting scripts

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,65 @@
+name: Build
+description: Setup .NET, restore, build the solution, and optionally validate a NativeAOT publish
+
+inputs:
+  version:
+    description: Semantic version to inject into the build.
+    required: false
+    default: ''
+  validate-native-aot:
+    description: Whether to validate a NativeAOT publish on the current runner.
+    required: false
+    default: 'false'
+  aot-runtime-identifier:
+    description: Runtime identifier to use when validate-native-aot is enabled.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Setup .NET
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
+      with:
+        dotnet-version: '10.0.x'
+
+    - name: Restore
+      shell: bash
+      run: dotnet restore copilotd.slnx --nologo --tl:off
+
+    - name: Build
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.version }}" ]; then
+          dotnet build copilotd.slnx --configuration Release --no-restore --nologo --tl:off -p:Version=${{ inputs.version }} -p:ContinuousIntegrationBuild=true
+        else
+          dotnet build copilotd.slnx --configuration Release --no-restore --nologo --tl:off -p:ContinuousIntegrationBuild=true
+        fi
+
+    - name: Validate NativeAOT publish
+      if: inputs.validate-native-aot == 'true'
+      shell: pwsh
+      run: |
+        if ('${{ inputs.aot-runtime-identifier }}' -eq '') {
+          throw "The 'aot-runtime-identifier' input is required when validate-native-aot is enabled."
+        }
+
+        $arguments = @(
+          'publish',
+          './src/copilotd/copilotd.csproj',
+          '--configuration', 'Release',
+          '--runtime', '${{ inputs.aot-runtime-identifier }}',
+          '--self-contained', 'true',
+          '--nologo',
+          '--tl:off',
+          '-p:ContinuousIntegrationBuild=true'
+        )
+
+        if ('${{ inputs.version }}' -ne '') {
+          $arguments += "-p:Version=${{ inputs.version }}"
+        }
+
+        & dotnet @arguments
+        if ($LASTEXITCODE -ne 0) {
+          throw "dotnet publish failed for runtime '${{ inputs.aot-runtime-identifier }}'."
+        }

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,325 @@
+name: Bump Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_bump:
+        description: Version bump type (auto, patch, minor, major)
+        required: true
+        default: auto
+        type: choice
+        options:
+          - auto
+          - patch
+          - minor
+          - major
+      phase:
+        description: Target release phase
+        required: true
+        type: choice
+        options:
+          - pre
+          - rc
+          - rtm
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      actions: read
+
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      rc_version: ${{ steps.version.outputs.rc_version }}
+      next_state: ${{ steps.version.outputs.next_state }}
+      state_json: ${{ steps.version.outputs.state_json }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Calculate new version state
+        id: version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          DEV_RELEASE_BODY=$(gh release view dev --repo "${{ github.repository }}" --json body --jq '.body // empty' 2>/dev/null || echo "")
+
+          if [ -n "$DEV_RELEASE_BODY" ]; then
+            STATE_JSON=$(dotnet scripts/version.cs state --body "$DEV_RELEASE_BODY")
+          else
+            RELEASES_JSON=$(gh release list --repo "${{ github.repository }}" --json tagName,isDraft,isPrerelease --limit 100 2>/dev/null || echo "[]")
+            STATE_JSON=$(dotnet scripts/version.cs state --releases-json "$RELEASES_JSON")
+          fi
+
+          RELEASES_JSON=$(gh release list --repo "${{ github.repository }}" --json tagName,isDraft,isPrerelease --limit 100 2>/dev/null || echo "[]")
+          NEW_STATE_JSON=$(dotnet scripts/version.cs bump --state "$STATE_JSON" --version-bump "${{ github.event.inputs.version_bump }}" --phase "${{ github.event.inputs.phase }}" --releases-json "$RELEASES_JSON")
+          VERSIONS_JSON=$(dotnet scripts/version.cs calculate --state "$NEW_STATE_JSON")
+
+          DEV_VERSION=$(echo "$VERSIONS_JSON" | jq -r '.devVersion')
+          RC_VERSION=$(echo "$VERSIONS_JSON" | jq -r '.rcVersion')
+          NEXT_STATE=$(echo "$VERSIONS_JSON" | jq -r '.nextState')
+          NEW_STATE_JSON_COMPACT=$(echo "$NEW_STATE_JSON" | jq -c '.')
+
+          echo "version=${DEV_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "rc_version=${RC_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "next_state=${NEXT_STATE}" >> "$GITHUB_OUTPUT"
+          echo "state_json=${NEW_STATE_JSON_COMPACT}" >> "$GITHUB_OUTPUT"
+
+          echo "## Version Bump" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Bump Type:** ${{ github.event.inputs.version_bump }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Target Phase:** ${{ github.event.inputs.phase }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Dev Version:** ${DEV_VERSION}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **RC Version:** ${RC_VERSION}" >> "$GITHUB_STEP_SUMMARY"
+
+  build:
+    runs-on: ubuntu-latest
+    needs: version
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Build
+        uses: ./.github/actions/build
+        with:
+          version: ${{ needs.version.outputs.version }}
+
+  publish-dev:
+    needs: [version, build]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: windows-latest
+            rid: win-x64
+          - runner: windows-latest
+            rid: win-arm64
+          - runner: ubuntu-22.04
+            rid: linux-x64
+          - runner: ubuntu-22.04
+            rid: linux-arm64
+          - runner: macos-latest
+            rid: osx-x64
+          - runner: macos-latest
+            rid: osx-arm64
+
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Install linux-arm64 prerequisites
+        if: matrix.rid == 'linux-arm64'
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo dpkg --add-architecture arm64
+          sudo bash -c 'cat > /etc/apt/sources.list.d/arm64.list <<EOF
+          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy main restricted
+          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main restricted
+          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-backports main restricted universe multiverse
+          EOF'
+          sudo sed -i -e 's/^deb /deb [arch=amd64] /g' /etc/apt/sources.list
+          sudo apt update
+          sudo apt install -y clang llvm binutils-aarch64-linux-gnu gcc-aarch64-linux-gnu zlib1g-dev:arm64
+
+      - name: Publish native asset
+        shell: pwsh
+        run: ./scripts/Publish-NativeAsset.ps1 -RuntimeIdentifier '${{ matrix.rid }}' -Version '${{ needs.version.outputs.version }}' -ArtifactsDirectory './artifacts/dev'
+
+      - name: Upload dev artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: native-dev-${{ matrix.rid }}
+          path: ./artifacts/dev/*
+          retention-days: 90
+
+  publish-rc:
+    needs: [version, build]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: windows-latest
+            rid: win-x64
+          - runner: windows-latest
+            rid: win-arm64
+          - runner: ubuntu-22.04
+            rid: linux-x64
+          - runner: ubuntu-22.04
+            rid: linux-arm64
+          - runner: macos-latest
+            rid: osx-x64
+          - runner: macos-latest
+            rid: osx-arm64
+
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Install linux-arm64 prerequisites
+        if: matrix.rid == 'linux-arm64'
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo dpkg --add-architecture arm64
+          sudo bash -c 'cat > /etc/apt/sources.list.d/arm64.list <<EOF
+          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy main restricted
+          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main restricted
+          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-backports main restricted universe multiverse
+          EOF'
+          sudo sed -i -e 's/^deb /deb [arch=amd64] /g' /etc/apt/sources.list
+          sudo apt update
+          sudo apt install -y clang llvm binutils-aarch64-linux-gnu gcc-aarch64-linux-gnu zlib1g-dev:arm64
+
+      - name: Publish native asset
+        shell: pwsh
+        run: ./scripts/Publish-NativeAsset.ps1 -RuntimeIdentifier '${{ matrix.rid }}' -Version '${{ needs.version.outputs.rc_version }}' -ArtifactsDirectory './artifacts/rc'
+
+      - name: Upload RC artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: native-rc-${{ matrix.rid }}
+          path: ./artifacts/rc/*
+          retention-days: 90
+
+  bundle-dev:
+    runs-on: ubuntu-latest
+    needs: [version, publish-dev]
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Download dev artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          pattern: native-dev-*
+          path: ./artifacts/dev
+          merge-multiple: true
+
+      - name: Create dev bundle
+        shell: pwsh
+        run: ./scripts/Merge-ReleaseBundle.ps1 -InputDirectory './artifacts/dev' -OutputDirectory './bundle/dev' -Version '${{ needs.version.outputs.version }}'
+
+      - name: Upload dev bundle artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: native-dev-bundle
+          path: ./bundle/dev/*
+          retention-days: 90
+
+      - name: Update dev draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          VERSION='${{ needs.version.outputs.version }}'
+          RC_VERSION='${{ needs.version.outputs.rc_version }}'
+          NEXT_STATE='${{ needs.version.outputs.next_state }}'
+          NOTES=$(cat <<EOF
+          ## Development Build
+
+          **Dev Version:** ${VERSION}
+          **RC Version:** ${RC_VERSION}
+          **Commit:** ${{ github.sha }}
+          **Build:** [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+          Version bumped via workflow dispatch.
+
+          <!-- VERSION_STATE: ${NEXT_STATE} -->
+          <!-- RC_VERSION: ${RC_VERSION} -->
+          <!-- CI_RUN_ID: ${{ github.run_id }} -->
+          EOF
+          )
+
+          if gh release view dev --repo "${{ github.repository }}" --json isDraft &>/dev/null; then
+            gh release edit dev \
+              --repo "${{ github.repository }}" \
+              --draft \
+              --prerelease \
+              --title "Development Build" \
+              --notes "$NOTES"
+
+            while IFS= read -r asset; do
+              if [ -n "$asset" ]; then
+                gh release delete-asset dev "$asset" --repo "${{ github.repository }}" --yes
+              fi
+            done < <(gh release view dev --repo "${{ github.repository }}" --json assets --jq '.assets[].name')
+
+            gh release upload dev \
+              --repo "${{ github.repository }}" \
+              ./bundle/dev/* \
+              --clobber
+          else
+            gh release create dev \
+              --repo "${{ github.repository }}" \
+              --target "${{ github.sha }}" \
+              --draft \
+              --prerelease \
+              --title "Development Build" \
+              --notes "$NOTES" \
+              ./bundle/dev/*
+          fi
+
+  bundle-rc:
+    runs-on: ubuntu-latest
+    needs: [version, publish-rc]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Download RC artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          pattern: native-rc-*
+          path: ./artifacts/rc
+          merge-multiple: true
+
+      - name: Create RC bundle
+        shell: pwsh
+        run: ./scripts/Merge-ReleaseBundle.ps1 -InputDirectory './artifacts/rc' -OutputDirectory './bundle/rc' -Version '${{ needs.version.outputs.rc_version }}'
+
+      - name: Upload RC bundle artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: native-rc-bundle
+          path: ./bundle/rc/*
+          retention-days: 90

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,321 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**/*.md'
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      actions: read
+
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      rc_version: ${{ steps.version.outputs.rc_version }}
+      next_state: ${{ steps.version.outputs.next_state }}
+      state_json: ${{ steps.version.outputs.state_json }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Calculate version
+        id: version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          DEV_RELEASE_BODY=$(gh release view dev --repo "${{ github.repository }}" --json body --jq '.body // empty' 2>/dev/null || echo "")
+
+          if [ -n "$DEV_RELEASE_BODY" ]; then
+            STATE_JSON=$(dotnet scripts/version.cs state --body "$DEV_RELEASE_BODY")
+          else
+            RELEASES_JSON=$(gh release list --repo "${{ github.repository }}" --json tagName,isDraft,isPrerelease --limit 100 2>/dev/null || echo "[]")
+            STATE_JSON=$(dotnet scripts/version.cs state --releases-json "$RELEASES_JSON")
+          fi
+
+          echo "Current state: $STATE_JSON"
+
+          VERSIONS_JSON=$(dotnet scripts/version.cs calculate --state "$STATE_JSON")
+          echo "Calculated versions: $VERSIONS_JSON"
+
+          DEV_VERSION=$(echo "$VERSIONS_JSON" | jq -r '.devVersion')
+          RC_VERSION=$(echo "$VERSIONS_JSON" | jq -r '.rcVersion')
+          NEXT_STATE=$(echo "$VERSIONS_JSON" | jq -r '.nextState')
+          STATE_JSON_COMPACT=$(echo "$STATE_JSON" | jq -c '.')
+
+          echo "version=${DEV_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "rc_version=${RC_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "next_state=${NEXT_STATE}" >> "$GITHUB_OUTPUT"
+          echo "state_json=${STATE_JSON_COMPACT}" >> "$GITHUB_OUTPUT"
+
+          echo "## Version Information" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Dev Version:** ${DEV_VERSION}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **RC Version:** ${RC_VERSION}" >> "$GITHUB_STEP_SUMMARY"
+
+  validate-powershell-scripts:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Validate PowerShell script syntax
+        shell: pwsh
+        run: ./scripts/Verify-PowerShellSyntax.ps1
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [version, validate-powershell-scripts]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Build
+        uses: ./.github/actions/build
+        with:
+          version: ${{ needs.version.outputs.version }}
+          validate-native-aot: 'true'
+          aot-runtime-identifier: linux-x64
+
+  publish-dev:
+    needs: [version, build]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: windows-latest
+            rid: win-x64
+          - runner: windows-latest
+            rid: win-arm64
+          - runner: ubuntu-22.04
+            rid: linux-x64
+          - runner: ubuntu-22.04
+            rid: linux-arm64
+          - runner: macos-latest
+            rid: osx-x64
+          - runner: macos-latest
+            rid: osx-arm64
+
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Install linux-arm64 prerequisites
+        if: matrix.rid == 'linux-arm64'
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo dpkg --add-architecture arm64
+          sudo bash -c 'cat > /etc/apt/sources.list.d/arm64.list <<EOF
+          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy main restricted
+          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main restricted
+          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-backports main restricted universe multiverse
+          EOF'
+          sudo sed -i -e 's/^deb /deb [arch=amd64] /g' /etc/apt/sources.list
+          sudo apt update
+          sudo apt install -y clang llvm binutils-aarch64-linux-gnu gcc-aarch64-linux-gnu zlib1g-dev:arm64
+
+      - name: Publish native asset
+        shell: pwsh
+        run: ./scripts/Publish-NativeAsset.ps1 -RuntimeIdentifier '${{ matrix.rid }}' -Version '${{ needs.version.outputs.version }}' -ArtifactsDirectory './artifacts/dev'
+
+      - name: Upload dev artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: native-dev-${{ matrix.rid }}
+          path: ./artifacts/dev/*
+          retention-days: 90
+
+  publish-rc:
+    needs: [version, build]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: windows-latest
+            rid: win-x64
+          - runner: windows-latest
+            rid: win-arm64
+          - runner: ubuntu-22.04
+            rid: linux-x64
+          - runner: ubuntu-22.04
+            rid: linux-arm64
+          - runner: macos-latest
+            rid: osx-x64
+          - runner: macos-latest
+            rid: osx-arm64
+
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Install linux-arm64 prerequisites
+        if: matrix.rid == 'linux-arm64'
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo dpkg --add-architecture arm64
+          sudo bash -c 'cat > /etc/apt/sources.list.d/arm64.list <<EOF
+          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy main restricted
+          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main restricted
+          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-backports main restricted universe multiverse
+          EOF'
+          sudo sed -i -e 's/^deb /deb [arch=amd64] /g' /etc/apt/sources.list
+          sudo apt update
+          sudo apt install -y clang llvm binutils-aarch64-linux-gnu gcc-aarch64-linux-gnu zlib1g-dev:arm64
+
+      - name: Publish native asset
+        shell: pwsh
+        run: ./scripts/Publish-NativeAsset.ps1 -RuntimeIdentifier '${{ matrix.rid }}' -Version '${{ needs.version.outputs.rc_version }}' -ArtifactsDirectory './artifacts/rc'
+
+      - name: Upload RC artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: native-rc-${{ matrix.rid }}
+          path: ./artifacts/rc/*
+          retention-days: 90
+
+  bundle-dev:
+    runs-on: ubuntu-latest
+    needs: [version, publish-dev]
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Download dev artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          pattern: native-dev-*
+          path: ./artifacts/dev
+          merge-multiple: true
+
+      - name: Create dev bundle
+        shell: pwsh
+        run: ./scripts/Merge-ReleaseBundle.ps1 -InputDirectory './artifacts/dev' -OutputDirectory './bundle/dev' -Version '${{ needs.version.outputs.version }}'
+
+      - name: Upload dev bundle artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: native-dev-bundle
+          path: ./bundle/dev/*
+          retention-days: 90
+
+      - name: Update dev draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          VERSION='${{ needs.version.outputs.version }}'
+          RC_VERSION='${{ needs.version.outputs.rc_version }}'
+          NEXT_STATE='${{ needs.version.outputs.next_state }}'
+          NOTES=$(cat <<EOF
+          ## Development Build
+
+          **Dev Version:** ${VERSION}
+          **RC Version:** ${RC_VERSION}
+          **Commit:** ${{ github.sha }}
+          **Build:** [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+          This draft release contains the latest native development assets and carries the workflow-managed version state.
+
+          <!-- VERSION_STATE: ${NEXT_STATE} -->
+          <!-- RC_VERSION: ${RC_VERSION} -->
+          <!-- CI_RUN_ID: ${{ github.run_id }} -->
+          EOF
+          )
+
+          if gh release view dev --repo "${{ github.repository }}" --json isDraft &>/dev/null; then
+            gh release edit dev \
+              --repo "${{ github.repository }}" \
+              --draft \
+              --prerelease \
+              --title "Development Build" \
+              --notes "$NOTES"
+
+            while IFS= read -r asset; do
+              if [ -n "$asset" ]; then
+                gh release delete-asset dev "$asset" --repo "${{ github.repository }}" --yes
+              fi
+            done < <(gh release view dev --repo "${{ github.repository }}" --json assets --jq '.assets[].name')
+
+            gh release upload dev \
+              --repo "${{ github.repository }}" \
+              ./bundle/dev/* \
+              --clobber
+          else
+            gh release create dev \
+              --repo "${{ github.repository }}" \
+              --target "${{ github.sha }}" \
+              --draft \
+              --prerelease \
+              --title "Development Build" \
+              --notes "$NOTES" \
+              ./bundle/dev/*
+          fi
+
+  bundle-rc:
+    runs-on: ubuntu-latest
+    needs: [version, publish-rc]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Download RC artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          pattern: native-rc-*
+          path: ./artifacts/rc
+          merge-multiple: true
+
+      - name: Create RC bundle
+        shell: pwsh
+        run: ./scripts/Merge-ReleaseBundle.ps1 -InputDirectory './artifacts/rc' -OutputDirectory './bundle/rc' -Version '${{ needs.version.outputs.rc_version }}'
+
+      - name: Upload RC bundle artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: native-rc-bundle
+          path: ./bundle/rc/*
+          retention-days: 90

--- a/.github/workflows/install-scripts.yml
+++ b/.github/workflows/install-scripts.yml
@@ -1,0 +1,117 @@
+name: Install Scripts
+
+on:
+  workflow_dispatch:
+
+jobs:
+  sign-install-script:
+    runs-on: windows-2022
+    environment: production
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Stage install script
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path ./artifacts/install-script -Force | Out-Null
+          Copy-Item ./scripts/install/install-copilotd.ps1 ./artifacts/install-script/install.ps1 -Force
+
+      - name: Azure login
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Sign install script
+        uses: azure/artifact-signing-action@b443cf8ea4124818d2ea9f043cba29fc3ec47b16
+        with:
+          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE }}
+          files-folder: ${{ github.workspace }}\artifacts\install-script
+          files-folder-filter: install.ps1
+          files-folder-recurse: false
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+          exclude-environment-credential: true
+          exclude-workload-identity-credential: true
+          exclude-managed-identity-credential: true
+          exclude-shared-token-cache-credential: true
+          exclude-visual-studio-credential: true
+          exclude-visual-studio-code-credential: true
+          exclude-azure-cli-credential: false
+          exclude-azure-powershell-credential: true
+          exclude-azure-developer-cli-credential: true
+          exclude-interactive-browser-credential: true
+
+      - name: Upload signed install script
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: signed-install-script
+          path: ./artifacts/install-script/install.ps1
+          retention-days: 7
+
+  publish-install-script:
+    runs-on: ubuntu-latest
+    needs: sign-install-script
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download signed install script
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: signed-install-script
+          path: ./artifacts/install-script
+
+      - name: Publish standing install release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          RELEASE_TAG='install-scripts'
+          RELEASE_TITLE='Install Scripts'
+          SCRIPT_PATH='./artifacts/install-script/install.ps1'
+          NOTES='Latest signed installer script for copilotd.'
+
+          if [ ! -f "$SCRIPT_PATH" ]; then
+            echo "::error::Signed installer script was not found at $SCRIPT_PATH."
+            exit 1
+          fi
+
+          if gh release view "$RELEASE_TAG" --repo "${{ github.repository }}" &>/dev/null; then
+            gh release edit "$RELEASE_TAG" \
+              --repo "${{ github.repository }}" \
+              --latest=false \
+              --title "$RELEASE_TITLE" \
+              --notes "$NOTES" \
+              --target "${{ github.sha }}"
+          else
+            gh release create "$RELEASE_TAG" \
+              --repo "${{ github.repository }}" \
+              --latest=false \
+              --target "${{ github.sha }}" \
+              --title "$RELEASE_TITLE" \
+              --notes "$NOTES"
+          fi
+
+          gh release upload "$RELEASE_TAG" \
+            --repo "${{ github.repository }}" \
+            "$SCRIPT_PATH" \
+            --clobber

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,60 @@
+name: PR
+
+on:
+  pull_request:
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+jobs:
+  validate-powershell-scripts:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Validate PowerShell script syntax
+        shell: pwsh
+        run: ./scripts/Verify-PowerShellSyntax.ps1
+
+  build:
+    needs: [validate-powershell-scripts]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Build
+        uses: ./.github/actions/build
+        with:
+          validate-native-aot: 'true'
+          aot-runtime-identifier: linux-x64
+
+  publish-aot:
+    needs: [build]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: windows-latest
+            rid: win-x64
+          - runner: ubuntu-22.04
+            rid: linux-x64
+          - runner: macos-latest
+            rid: osx-arm64
+
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Build and validate NativeAOT publish
+        uses: ./.github/actions/build
+        with:
+          validate-native-aot: 'true'
+          aot-runtime-identifier: ${{ matrix.rid }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,369 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      actions: read
+
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      ci_run_id: ${{ steps.version.outputs.ci_run_id }}
+      ci_head_sha: ${{ steps.version.outputs.ci_head_sha }}
+      state_json: ${{ steps.version.outputs.state_json }}
+      is_prerelease: ${{ steps.version.outputs.is_prerelease }}
+      phase: ${{ steps.version.outputs.phase }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Get version state and CI run
+        id: version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          DEV_RELEASE_BODY=$(gh release view dev --repo "${{ github.repository }}" --json body --jq '.body // empty' 2>/dev/null || echo "")
+
+          if [ -z "$DEV_RELEASE_BODY" ]; then
+            echo "::error::No dev release found. Run CI first to create a development build."
+            exit 1
+          fi
+
+          STATE_JSON=$(dotnet scripts/version.cs state --body "$DEV_RELEASE_BODY")
+          echo "Current state: $STATE_JSON"
+
+          CI_RUN_ID=$(echo "$DEV_RELEASE_BODY" | grep -o '<!-- CI_RUN_ID: [^>]* -->' | sed 's/<!-- CI_RUN_ID: \(.*\) -->/\1/' || echo "")
+          if [ -z "$CI_RUN_ID" ]; then
+            CI_RUN_ID=$(gh run list --repo "${{ github.repository }}" --workflow=ci.yml --branch=main --status=success --limit=1 --json databaseId --jq '.[0].databaseId // empty')
+          fi
+
+          if [ -z "$CI_RUN_ID" ]; then
+            echo "::error::No successful CI run found."
+            exit 1
+          fi
+
+          CI_HEAD_SHA=$(gh run view "${CI_RUN_ID}" --repo "${{ github.repository }}" --json headSha --jq '.headSha // empty')
+          if [ -z "$CI_HEAD_SHA" ]; then
+            echo "::error::Could not determine the commit SHA for CI run ${CI_RUN_ID}."
+            exit 1
+          fi
+
+          RC_VERSION=$(echo "$DEV_RELEASE_BODY" | grep -o '<!-- RC_VERSION: [^>]* -->' | sed 's/<!-- RC_VERSION: \(.*\) -->/\1/' || echo "")
+          if [ -z "$RC_VERSION" ]; then
+            VERSIONS_JSON=$(dotnet scripts/version.cs calculate --state "$STATE_JSON")
+            RC_VERSION=$(echo "$VERSIONS_JSON" | jq -r '.rcVersion')
+          fi
+
+          PHASE=$(echo "$STATE_JSON" | jq -r '.phase')
+          if [ "$PHASE" = "rtm" ]; then
+            IS_PRERELEASE=false
+          else
+            IS_PRERELEASE=true
+          fi
+
+          STATE_JSON_COMPACT=$(echo "$STATE_JSON" | jq -c '.')
+          echo "version=${RC_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "ci_run_id=${CI_RUN_ID}" >> "$GITHUB_OUTPUT"
+          echo "ci_head_sha=${CI_HEAD_SHA}" >> "$GITHUB_OUTPUT"
+          echo "state_json=${STATE_JSON_COMPACT}" >> "$GITHUB_OUTPUT"
+          echo "is_prerelease=${IS_PRERELEASE}" >> "$GITHUB_OUTPUT"
+          echo "phase=${PHASE}" >> "$GITHUB_OUTPUT"
+
+          echo "## Release" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Version:** ${RC_VERSION}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Phase:** ${PHASE}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **CI Run:** ${CI_RUN_ID}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **CI Commit:** ${CI_HEAD_SHA}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Validate CI run commit
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          WORKFLOW_SHA='${{ github.sha }}'
+          CI_HEAD_SHA='${{ steps.version.outputs.ci_head_sha }}'
+
+          if [ "$CI_HEAD_SHA" != "$WORKFLOW_SHA" ]; then
+            echo "::error::RC bundle came from CI run ${{ steps.version.outputs.ci_run_id }} at commit ${CI_HEAD_SHA}, but this release workflow is running for ${WORKFLOW_SHA}. Re-run the release workflow from the matching commit or rerun CI on the intended commit first."
+            exit 1
+          fi
+
+      - name: Download RC bundle from CI run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p ./artifacts
+          gh run download "${{ steps.version.outputs.ci_run_id }}" --repo "${{ github.repository }}" --name native-rc-bundle --dir ./artifacts
+
+      - name: Verify release metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          EXPECTED_VERSION='${{ steps.version.outputs.version }}'
+          METADATA_FILE='./artifacts/release-metadata.json'
+
+          if [ ! -f "$METADATA_FILE" ]; then
+            echo "::error::Missing release metadata file."
+            exit 1
+          fi
+
+          ACTUAL_VERSION=$(jq -r '.version' "$METADATA_FILE")
+          if [ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]; then
+            echo "::error::Release metadata version mismatch. Expected '$EXPECTED_VERSION' but found '$ACTUAL_VERSION'."
+            exit 1
+          fi
+
+      - name: Upload unsigned release bundle
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: release-unsigned-bundle
+          path: ./artifacts/*
+          retention-days: 7
+
+  sign-windows:
+    runs-on: windows-2022
+    needs: prepare-release
+    environment: production
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Download unsigned release bundle
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: release-unsigned-bundle
+          path: ./artifacts/bundle
+
+      - name: Expand Windows release assets
+        shell: pwsh
+        run: ./scripts/Expand-WindowsReleaseAssets.ps1 -BundleDirectory './artifacts/bundle' -WorkingDirectory './artifacts/windows-assets'
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Azure login
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Sign Windows executables
+        uses: azure/artifact-signing-action@b443cf8ea4124818d2ea9f043cba29fc3ec47b16
+        with:
+          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE }}
+          files-folder: ${{ github.workspace }}\artifacts\windows-assets
+          files-folder-filter: copilotd.exe
+          files-folder-recurse: true
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+          exclude-environment-credential: true
+          exclude-workload-identity-credential: true
+          exclude-managed-identity-credential: true
+          exclude-shared-token-cache-credential: true
+          exclude-visual-studio-credential: true
+          exclude-visual-studio-code-credential: true
+          exclude-azure-cli-credential: false
+          exclude-azure-powershell-credential: true
+          exclude-azure-developer-cli-credential: true
+          exclude-interactive-browser-credential: true
+
+      - name: Verify signed Windows issuer
+        shell: pwsh
+        run: |
+          $binaryPaths = @(Get-ChildItem -Path './artifacts/windows-assets' -Recurse -Filter 'copilotd.exe' -File)
+          if ($binaryPaths.Count -eq 0) {
+            throw "No signed copilotd.exe files were found under './artifacts/windows-assets'."
+          }
+
+          foreach ($binaryPath in $binaryPaths) {
+            ./scripts/Verify-WindowsBinaryIssuer.ps1 -BinaryPath $binaryPath.FullName -InstallerScriptPath './scripts/install/install-copilotd.ps1'
+          }
+
+      - name: Repack signed Windows assets
+        shell: pwsh
+        run: ./scripts/Compress-WindowsReleaseAssets.ps1 -WorkingDirectory './artifacts/windows-assets' -OutputDirectory './artifacts/signed-windows-assets'
+
+      - name: Upload signed Windows assets
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: release-signed-windows-assets
+          path: ./artifacts/signed-windows-assets/*
+          retention-days: 7
+
+  publish-release:
+    runs-on: ubuntu-latest
+    needs: [prepare-release, sign-windows]
+
+    permissions:
+      contents: write
+      actions: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Download unsigned release bundle
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: release-unsigned-bundle
+          path: ./artifacts/release
+
+      - name: Download signed Windows assets
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: release-signed-windows-assets
+          path: ./artifacts/signed-windows-assets
+
+      - name: Overlay signed Windows assets
+        shell: pwsh
+        run: Copy-Item './artifacts/signed-windows-assets/*' './artifacts/release' -Force
+
+      - name: Regenerate release metadata
+        shell: pwsh
+        run: ./scripts/Update-ReleaseBundleMetadata.ps1 -BundleDirectory './artifacts/release'
+
+      - name: Verify updated release metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          EXPECTED_VERSION='${{ needs.prepare-release.outputs.version }}'
+          METADATA_FILE='./artifacts/release/release-metadata.json'
+
+          if [ ! -f "$METADATA_FILE" ]; then
+            echo "::error::Missing release metadata file."
+            exit 1
+          fi
+
+          ACTUAL_VERSION=$(jq -r '.version' "$METADATA_FILE")
+          if [ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]; then
+            echo "::error::Release metadata version mismatch. Expected '$EXPECTED_VERSION' but found '$ACTUAL_VERSION'."
+            exit 1
+          fi
+
+      - name: Create GitHub release
+        id: create_release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          VERSION='${{ needs.prepare-release.outputs.version }}'
+          IS_PRERELEASE='${{ needs.prepare-release.outputs.is_prerelease }}'
+          PRERELEASE_FLAG=()
+
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            PRERELEASE_FLAG+=(--prerelease)
+          fi
+
+          if gh release view "v${VERSION}" --repo "${{ github.repository }}" &>/dev/null; then
+            echo "Release v${VERSION} already exists; skipping create."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+          gh release create "v${VERSION}" \
+            --repo "${{ github.repository }}" \
+            --target "${{ github.sha }}" \
+            "${PRERELEASE_FLAG[@]}" \
+            --title "v${VERSION}" \
+            --notes "## copilotd ${VERSION}
+
+          Native release assets for Windows, Linux, and macOS.
+
+          - checksums are included in \`checksums.txt\`.
+          - release metadata is included in \`release-metadata.json\`." \
+            ./artifacts/release/*
+
+      - name: Advance version state
+        if: steps.create_release.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          STATE_JSON: ${{ needs.prepare-release.outputs.state_json }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          VERSION='${{ needs.prepare-release.outputs.version }}'
+          NEW_STATE_JSON=$(dotnet scripts/version.cs advance --state "$STATE_JSON" --shipped-version "$VERSION")
+          VERSIONS_JSON=$(dotnet scripts/version.cs calculate --state "$NEW_STATE_JSON")
+          NEXT_DEV_VERSION=$(echo "$VERSIONS_JSON" | jq -r '.devVersion')
+          NEXT_RC_VERSION=$(echo "$VERSIONS_JSON" | jq -r '.rcVersion')
+          NEW_BASE=$(echo "$NEW_STATE_JSON" | jq -r '.base')
+          NEW_PHASE=$(echo "$NEW_STATE_JSON" | jq -r '.phase')
+          NEW_PHASE_NUMBER=$(echo "$NEW_STATE_JSON" | jq -r '.phaseNumber')
+          STATE_STRING="${NEW_BASE}|${NEW_PHASE}|${NEW_PHASE_NUMBER}|0|none"
+          NOTES=$(cat <<EOF
+          ## Development Build
+
+          **Last Published Release:** v${VERSION}
+          **Next Dev Version:** ${NEXT_DEV_VERSION}
+          **Next RC Version:** ${NEXT_RC_VERSION}
+          **Commit:** ${{ github.sha }}
+          **Build:** [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+          Release shipped successfully. The next push to main will publish fresh development assets.
+
+          <!-- VERSION_STATE: ${STATE_STRING} -->
+          EOF
+          )
+
+          if gh release view dev --repo "${{ github.repository }}" --json isDraft &>/dev/null; then
+            gh release edit dev \
+              --repo "${{ github.repository }}" \
+              --draft \
+              --prerelease \
+              --title "Development Build" \
+              --notes "$NOTES"
+          else
+            gh release create dev \
+              --repo "${{ github.repository }}" \
+              --target "${{ github.sha }}" \
+              --draft \
+              --prerelease \
+              --title "Development Build" \
+              --notes "$NOTES"
+          fi

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,12 @@
 <Project>
+
   <PropertyGroup>
-    <ArtifactsPath>$(MSBuildThisFileDirectory)artifacts</ArtifactsPath>
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+    <ContinuousIntegrationBuild Condition="'$(ContinuousIntegrationBuild)' == '' and '$(CI)' != ''">true</ContinuousIntegrationBuild>
+    <Version Condition="'$(Version)' == ''">0.0.1-pre.1.dev.1</Version>
+    <RepositoryUrl>https://github.com/DamianEdwards/copilotd</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
   </PropertyGroup>
+
 </Project>

--- a/scripts/Compress-WindowsReleaseAssets.ps1
+++ b/scripts/Compress-WindowsReleaseAssets.ps1
@@ -1,0 +1,57 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$WorkingDirectory,
+
+    [Parameter(Mandatory)]
+    [string]$OutputDirectory
+)
+
+$ErrorActionPreference = 'Stop'
+
+$workingDirectory = [System.IO.Path]::GetFullPath($WorkingDirectory)
+$outputDirectory = [System.IO.Path]::GetFullPath($OutputDirectory)
+$manifestPath = Join-Path $workingDirectory 'windows-assets-manifest.json'
+
+if (-not (Test-Path $manifestPath))
+{
+    throw "Windows asset manifest '$manifestPath' was not found."
+}
+
+$manifestEntries = @(Get-Content -Path $manifestPath -Raw | ConvertFrom-Json)
+if ($manifestEntries.Count -eq 0)
+{
+    throw "Windows asset manifest '$manifestPath' did not contain any entries."
+}
+
+New-Item -ItemType Directory -Path $outputDirectory -Force | Out-Null
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+foreach ($entry in $manifestEntries)
+{
+    $stagingDirectory = [System.IO.Path]::GetFullPath($entry.stagingDirectory)
+    if (-not (Test-Path $stagingDirectory))
+    {
+        throw "Staging directory '$stagingDirectory' was not found."
+    }
+
+    $binaryPath = Join-Path $stagingDirectory 'copilotd.exe'
+    if (-not (Test-Path $binaryPath))
+    {
+        throw "Staging directory '$stagingDirectory' does not contain 'copilotd.exe'."
+    }
+
+    $licensePath = Join-Path $stagingDirectory 'LICENSE'
+    if (-not (Test-Path $licensePath))
+    {
+        throw "Staging directory '$stagingDirectory' does not contain 'LICENSE'."
+    }
+
+    $archivePath = Join-Path $outputDirectory $entry.assetName
+    if (Test-Path $archivePath)
+    {
+        Remove-Item $archivePath -Force
+    }
+
+    [System.IO.Compression.ZipFile]::CreateFromDirectory($stagingDirectory, $archivePath)
+}

--- a/scripts/Expand-WindowsReleaseAssets.ps1
+++ b/scripts/Expand-WindowsReleaseAssets.ps1
@@ -1,0 +1,77 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$BundleDirectory,
+
+    [Parameter(Mandatory)]
+    [string]$WorkingDirectory
+)
+
+$ErrorActionPreference = 'Stop'
+
+$bundleDirectory = [System.IO.Path]::GetFullPath($BundleDirectory)
+$workingDirectory = [System.IO.Path]::GetFullPath($WorkingDirectory)
+$metadataPath = Join-Path $bundleDirectory 'release-metadata.json'
+
+if (-not (Test-Path $bundleDirectory))
+{
+    throw "Bundle directory '$bundleDirectory' was not found."
+}
+
+if (-not (Test-Path $metadataPath))
+{
+    throw "Release metadata file '$metadataPath' was not found."
+}
+
+$metadata = Get-Content -Path $metadataPath -Raw | ConvertFrom-Json
+$windowsAssets = @($metadata.windowsAssets)
+if ($windowsAssets.Count -eq 0)
+{
+    $windowsAssets = @($metadata.assets | Where-Object { $_.platform -eq 'win' })
+}
+
+if ($windowsAssets.Count -eq 0)
+{
+    throw "No Windows assets were found in '$metadataPath'."
+}
+
+New-Item -ItemType Directory -Path $workingDirectory -Force | Out-Null
+$manifestEntries = @()
+
+foreach ($asset in $windowsAssets)
+{
+    if ([string]::IsNullOrWhiteSpace($asset.runtimeIdentifier))
+    {
+        throw "Windows asset '$($asset.name)' is missing a runtimeIdentifier."
+    }
+
+    $archivePath = Join-Path $bundleDirectory $asset.name
+    if (-not (Test-Path $archivePath))
+    {
+        throw "Archive '$archivePath' referenced in release metadata was not found."
+    }
+
+    $assetDirectory = Join-Path $workingDirectory $asset.runtimeIdentifier
+    if (Test-Path $assetDirectory)
+    {
+        Remove-Item $assetDirectory -Recurse -Force
+    }
+
+    New-Item -ItemType Directory -Path $assetDirectory -Force | Out-Null
+    Expand-Archive -Path $archivePath -DestinationPath $assetDirectory -Force
+
+    $binaryPath = Join-Path $assetDirectory 'copilotd.exe'
+    if (-not (Test-Path $binaryPath))
+    {
+        throw "Expanded Windows asset '$($asset.name)' did not contain 'copilotd.exe'."
+    }
+
+    $manifestEntries += [ordered]@{
+        assetName = $asset.name
+        runtimeIdentifier = $asset.runtimeIdentifier
+        stagingDirectory = $assetDirectory
+    }
+}
+
+$manifestPath = Join-Path $workingDirectory 'windows-assets-manifest.json'
+$manifestEntries | ConvertTo-Json -Depth 5 | Set-Content -Path $manifestPath

--- a/scripts/Merge-ReleaseBundle.ps1
+++ b/scripts/Merge-ReleaseBundle.ps1
@@ -1,0 +1,73 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$InputDirectory,
+
+    [Parameter(Mandatory)]
+    [string]$OutputDirectory,
+
+    [Parameter(Mandatory)]
+    [string]$Version
+)
+
+$ErrorActionPreference = 'Stop'
+
+$inputDirectory = [System.IO.Path]::GetFullPath($InputDirectory)
+$outputDirectory = [System.IO.Path]::GetFullPath($OutputDirectory)
+
+if (-not (Test-Path $inputDirectory))
+{
+    throw "Input directory '$inputDirectory' was not found."
+}
+
+New-Item -ItemType Directory -Path $outputDirectory -Force | Out-Null
+
+$metadataFiles = Get-ChildItem -Path $inputDirectory -Recurse -Filter '*.json' |
+    Where-Object { $_.Name -ne 'release-metadata.json' }
+
+if ($metadataFiles.Count -eq 0)
+{
+    throw "No per-asset metadata files were found under '$inputDirectory'."
+}
+
+$assets = foreach ($metadataFile in $metadataFiles)
+{
+    $metadata = Get-Content -Path $metadataFile.FullName -Raw | ConvertFrom-Json
+    if ($metadata.version -ne $Version)
+    {
+        throw "Metadata file '$($metadataFile.FullName)' reported version '$($metadata.version)' instead of '$Version'."
+    }
+
+    $assetPath = Get-ChildItem -Path $inputDirectory -Recurse -File | Where-Object { $_.Name -eq $metadata.assetName } | Select-Object -First 1
+    if (-not $assetPath)
+    {
+        throw "Asset '$($metadata.assetName)' referenced by '$($metadataFile.FullName)' was not found."
+    }
+
+    $destinationPath = Join-Path $outputDirectory $assetPath.Name
+    Copy-Item $assetPath.FullName $destinationPath -Force
+
+    [ordered]@{
+        name = $metadata.assetName
+        runtimeIdentifier = $metadata.runtimeIdentifier
+        platform = $metadata.platform
+        architecture = $metadata.architecture
+        fileType = $metadata.fileType
+        commandName = $metadata.commandName
+        sha256 = $metadata.sha256
+    }
+}
+
+$sortedAssets = @($assets | Sort-Object name)
+$checksumsPath = Join-Path $outputDirectory 'checksums.txt'
+$checksums = $sortedAssets | ForEach-Object { "$($_.sha256)  $($_.name)" }
+$checksums | Set-Content -Path $checksumsPath
+
+$releaseMetadata = [ordered]@{
+    version = $Version
+    assets = $sortedAssets
+    windowsAssets = @($sortedAssets | Where-Object { $_.platform -eq 'win' })
+}
+
+$releaseMetadataPath = Join-Path $outputDirectory 'release-metadata.json'
+$releaseMetadata | ConvertTo-Json -Depth 5 | Set-Content -Path $releaseMetadataPath

--- a/scripts/Publish-NativeAsset.ps1
+++ b/scripts/Publish-NativeAsset.ps1
@@ -1,0 +1,217 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$RuntimeIdentifier,
+
+    [Parameter(Mandatory)]
+    [string]$Version,
+
+    [Parameter(Mandatory)]
+    [string]$ArtifactsDirectory,
+
+    [string]$ProjectPath = (Join-Path $PSScriptRoot '..\src\copilotd\copilotd.csproj'),
+
+    [ValidateSet('Release', 'Debug')]
+    [string]$Configuration = 'Release'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$projectPath = [System.IO.Path]::GetFullPath($ProjectPath)
+$artifactsDirectory = [System.IO.Path]::GetFullPath($ArtifactsDirectory)
+$repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
+$publishRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("copilotd-publish-" + [System.Guid]::NewGuid().ToString('N'))
+$publishDirectory = Join-Path $publishRoot $RuntimeIdentifier
+$stagingDirectory = Join-Path $publishRoot ("stage-" + $RuntimeIdentifier)
+
+function Quote-CmdArgument
+{
+    param([Parameter(Mandatory)][string]$Value)
+
+    if ([string]::IsNullOrEmpty($Value))
+    {
+        return '""'
+    }
+
+    if ($Value -notmatch '[\s"&()^<>|]')
+    {
+        return $Value
+    }
+
+    return '"' + $Value.Replace('"', '""') + '"'
+}
+
+function Get-VsDevCmdPath
+{
+    if (-not $IsWindows)
+    {
+        return $null
+    }
+
+    $vsWherePath = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+    if (-not (Test-Path $vsWherePath))
+    {
+        return $null
+    }
+
+    $installationPath = & $vsWherePath -latest -products * -property installationPath
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($installationPath))
+    {
+        return $null
+    }
+
+    $vsDevCmdPath = Join-Path $installationPath.Trim() 'Common7\Tools\VsDevCmd.bat'
+    if (-not (Test-Path $vsDevCmdPath))
+    {
+        return $null
+    }
+
+    return $vsDevCmdPath
+}
+
+function Get-WindowsTargetArchitecture
+{
+    param([Parameter(Mandatory)][string]$Rid)
+
+    $architecture = $Rid.Split('-', 2)[1]
+    switch ($architecture)
+    {
+        'x64' { 'amd64' }
+        'arm64' { 'arm64' }
+        default { throw "Unsupported Windows architecture '$Rid'." }
+    }
+}
+
+function Invoke-DotNetPublish
+{
+    param(
+        [Parameter(Mandatory)][string]$Rid,
+        [Parameter(Mandatory)][string[]]$Arguments
+    )
+
+    $platform = $Rid.Split('-', 2)[0]
+    if ($IsWindows -and $platform -eq 'win')
+    {
+        $vsDevCmdPath = Get-VsDevCmdPath
+        if (-not [string]::IsNullOrWhiteSpace($vsDevCmdPath))
+        {
+            $targetArchitecture = Get-WindowsTargetArchitecture -Rid $Rid
+            $commandSegments = @(
+                'call',
+                (Quote-CmdArgument -Value $vsDevCmdPath),
+                '-no_logo',
+                '-host_arch=amd64',
+                "-arch=$targetArchitecture",
+                '&&',
+                'dotnet'
+            ) + ($Arguments | ForEach-Object { Quote-CmdArgument -Value $_ })
+
+            & cmd.exe /d /c ($commandSegments -join ' ')
+            return
+        }
+    }
+
+    & dotnet @Arguments
+}
+
+New-Item -ItemType Directory -Path $artifactsDirectory -Force | Out-Null
+New-Item -ItemType Directory -Path $publishDirectory -Force | Out-Null
+
+try
+{
+    $publishArguments = @(
+        'publish',
+        $projectPath,
+        '--configuration', $Configuration,
+        '--runtime', $RuntimeIdentifier,
+        '--self-contained', 'true',
+        '--nologo',
+        '--tl:off',
+        "-p:Version=$Version",
+        '-p:ContinuousIntegrationBuild=true',
+        '-o', $publishDirectory
+    )
+
+    Invoke-DotNetPublish -Rid $RuntimeIdentifier -Arguments $publishArguments
+
+    if ($LASTEXITCODE -ne 0)
+    {
+        throw "dotnet publish failed for runtime '$RuntimeIdentifier'. Ensure the required NativeAOT toolchain is available for this platform."
+    }
+
+    $parts = $RuntimeIdentifier.Split('-', 2)
+    if ($parts.Length -ne 2)
+    {
+        throw "Unexpected runtime identifier format '$RuntimeIdentifier'."
+    }
+
+    $platform = $parts[0]
+    $architecture = $parts[1]
+    $binaryName = if ($platform -eq 'win') { 'copilotd.exe' } else { 'copilotd' }
+    $binaryPath = Join-Path $publishDirectory $binaryName
+
+    if (-not (Test-Path $binaryPath))
+    {
+        throw "Published binary '$binaryPath' was not found."
+    }
+
+    New-Item -ItemType Directory -Path $stagingDirectory -Force | Out-Null
+    Copy-Item $binaryPath (Join-Path $stagingDirectory $binaryName) -Force
+    Copy-Item (Join-Path $repoRoot 'LICENSE') (Join-Path $stagingDirectory 'LICENSE') -Force
+
+    $assetPath =
+        if ($platform -eq 'win')
+        {
+            $path = Join-Path $artifactsDirectory "copilotd-$RuntimeIdentifier.zip"
+            if (Test-Path $path)
+            {
+                Remove-Item $path -Force
+            }
+
+            Add-Type -AssemblyName System.IO.Compression.FileSystem
+            [System.IO.Compression.ZipFile]::CreateFromDirectory($stagingDirectory, $path)
+            $path
+        }
+        else
+        {
+            $path = Join-Path $artifactsDirectory "copilotd-$RuntimeIdentifier.tar.gz"
+            if (Test-Path $path)
+            {
+                Remove-Item $path -Force
+            }
+
+            tar -czf $path -C $stagingDirectory .
+            if ($LASTEXITCODE -ne 0)
+            {
+                throw "Failed to create archive '$path'."
+            }
+
+            $path
+        }
+
+    $hash = (Get-FileHash $assetPath -Algorithm SHA256).Hash.ToLowerInvariant()
+    $assetName = [System.IO.Path]::GetFileName($assetPath)
+    $hashPath = Join-Path $artifactsDirectory ($assetName + '.sha256')
+    "$hash  $assetName" | Set-Content -Path $hashPath -NoNewline
+
+    $metadata = [ordered]@{
+        version = $Version
+        runtimeIdentifier = $RuntimeIdentifier
+        platform = $platform
+        architecture = $architecture
+        assetName = $assetName
+        fileType = if ($platform -eq 'win') { 'zip' } else { 'tar.gz' }
+        commandName = 'copilotd'
+        sha256 = $hash
+    }
+
+    $metadataPath = Join-Path $artifactsDirectory ("copilotd-$RuntimeIdentifier.json")
+    $metadata | ConvertTo-Json -Depth 5 | Set-Content -Path $metadataPath
+}
+finally
+{
+    if (Test-Path $publishRoot)
+    {
+        Remove-Item $publishRoot -Recurse -Force
+    }
+}

--- a/scripts/Test-InstallerProvenance.ps1
+++ b/scripts/Test-InstallerProvenance.ps1
@@ -1,0 +1,297 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateSet('InstallerDefaults', 'GoodBinary', 'UnsignedBinary', 'TamperedBinary', 'WrongSubject', 'WrongIssuer', 'ChecksumMismatch', 'MetadataMismatch')]
+    [string]$Scenario,
+
+    [string]$BinaryPath,
+
+    [string]$ArchivePath,
+
+    [string]$ChecksumsPath,
+
+    [string]$ReleaseMetadataPath,
+
+    [string]$InstallerScriptPath = (Join-Path $PSScriptRoot 'install\install-copilotd.ps1'),
+
+    [switch]$KeepArtifacts
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Get-RequiredFullPath
+{
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][string]$Description
+    )
+
+    $resolvedPath = [System.IO.Path]::GetFullPath($Path)
+    if (-not (Test-Path $resolvedPath))
+    {
+        throw "$Description '$resolvedPath' was not found."
+    }
+
+    return $resolvedPath
+}
+
+function Invoke-ExpectedFailure
+{
+    param(
+        [Parameter(Mandatory)][string]$ScenarioName,
+        [Parameter(Mandatory)][scriptblock]$Action,
+        [Parameter(Mandatory)][string]$ExpectedMessageFragment
+    )
+
+    $failureMessage = $null
+    try
+    {
+        & $Action
+    }
+    catch
+    {
+        $failureMessage = $_.Exception.Message
+    }
+
+    if ($null -eq $failureMessage)
+    {
+        throw "Scenario '$ScenarioName' unexpectedly succeeded."
+    }
+
+    if ($failureMessage -notlike "*$ExpectedMessageFragment*")
+    {
+        throw "Scenario '$ScenarioName' failed, but with an unexpected message: $failureMessage"
+    }
+
+    Write-Host "Scenario '$ScenarioName' failed as expected: $failureMessage"
+}
+
+function New-TamperedBinaryCopy
+{
+    param(
+        [Parameter(Mandatory)][string]$SourcePath,
+        [Parameter(Mandatory)][string]$DestinationDirectory
+    )
+
+    $tamperedPath = Join-Path $DestinationDirectory (([System.IO.Path]::GetFileNameWithoutExtension($SourcePath)) + '-tampered' + [System.IO.Path]::GetExtension($SourcePath))
+    Copy-Item -Path $SourcePath -Destination $tamperedPath -Force
+
+    $bytes = [System.IO.File]::ReadAllBytes($tamperedPath)
+    if ($bytes.Length -eq 0)
+    {
+        throw "Cannot tamper with empty file '$tamperedPath'."
+    }
+
+    $bytes[$bytes.Length - 1] = ($bytes[$bytes.Length - 1] + 1) % 256
+    [System.IO.File]::WriteAllBytes($tamperedPath, $bytes)
+    Write-Verbose "Created tampered binary '$tamperedPath'."
+
+    return $tamperedPath
+}
+
+function Get-MutatedExpectedSubject
+{
+    param([Parameter(Mandatory)][string]$Subject)
+
+    $segments = @($Subject -split ',')
+    for ($index = 0; $index -lt $segments.Count; $index++)
+    {
+        $match = [regex]::Match($segments[$index], '^\s*([^=]+?)\s*=\s*(.+?)\s*$')
+        if (-not $match.Success)
+        {
+            continue
+        }
+
+        $key = Normalize-DistinguishedNameKey -Key $match.Groups[1].Value
+        if ($key -eq 'CN')
+        {
+            $segments[$index] = 'CN=Unexpected Signer'
+            return ($segments | ForEach-Object { $_.Trim() }) -join ', '
+        }
+    }
+
+    return "CN=Unexpected Signer, $Subject"
+}
+
+function Get-MutatedHexString
+{
+    param([Parameter(Mandatory)][string]$Value)
+
+    $replacement = if ($Value[0] -eq '0') { '1' } else { '0' }
+    return $replacement + $Value.Substring(1)
+}
+
+function New-ChecksumMismatchFile
+{
+    param(
+        [Parameter(Mandatory)][string]$ChecksumsPath,
+        [Parameter(Mandatory)][string]$AssetName,
+        [Parameter(Mandatory)][string]$DestinationDirectory
+    )
+
+    $destinationPath = Join-Path $DestinationDirectory 'checksums-mismatch.txt'
+    $lines = Get-Content -Path $ChecksumsPath
+    $updatedLines = foreach ($line in $lines)
+    {
+        if ($line -match "\s\*?$([regex]::Escape($AssetName))$")
+        {
+            $match = [regex]::Match($line, '^\s*([0-9a-fA-F]{64})(?<suffix>\s+\*?.+)$')
+            if (-not $match.Success)
+            {
+                throw "Invalid checksum line format for '$AssetName' in '$ChecksumsPath'."
+            }
+
+            $hash = $match.Groups[1].Value.ToLowerInvariant()
+            $replacement = if ($hash[0] -eq '0') { '1' } else { '0' }
+            $replacement + $hash.Substring(1) + $match.Groups['suffix'].Value
+        }
+        else
+        {
+            $line
+        }
+    }
+
+    $updatedLines | Set-Content -Path $destinationPath
+    Write-Verbose "Created checksum-mismatch fixture '$destinationPath'."
+    return $destinationPath
+}
+
+function New-MetadataMismatchFile
+{
+    param(
+        [Parameter(Mandatory)][string]$ReleaseMetadataPath,
+        [Parameter(Mandatory)][string]$AssetName,
+        [Parameter(Mandatory)][string]$DestinationDirectory
+    )
+
+    $destinationPath = Join-Path $DestinationDirectory 'release-metadata-mismatch.json'
+    $metadata = Get-Content -Path $ReleaseMetadataPath -Raw | ConvertFrom-Json
+    $metadataAsset = $metadata.assets | Where-Object { $_.name -eq $AssetName } | Select-Object -First 1
+    if ($null -eq $metadataAsset)
+    {
+        throw "release-metadata.json did not contain asset '$AssetName'."
+    }
+
+    $metadataAsset.sha256 = Get-MutatedHexString -Value $metadataAsset.sha256
+    $metadata | ConvertTo-Json -Depth 10 | Set-Content -Path $destinationPath
+    Write-Verbose "Created metadata-mismatch fixture '$destinationPath'."
+    return $destinationPath
+}
+
+$installerScriptPath = Get-RequiredFullPath -Path $InstallerScriptPath -Description 'Installer script'
+
+Write-Verbose "Loading installer helpers from '$installerScriptPath'."
+. $installerScriptPath -NoExecute
+
+$config = Get-CopilotdInstallerTrustConfiguration
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("copilotd-installer-verification-" + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
+
+try
+{
+    switch ($Scenario)
+    {
+        'InstallerDefaults'
+        {
+            $binaryPath = Get-RequiredFullPath -Path $BinaryPath -Description 'Signed binary'
+            $evidence = Assert-WindowsBinaryTrust -BinaryPath $binaryPath -ExpectedSubject $config.ExpectedSignerSubject -ExpectedIssuerSha512Thumbprints $config.ExpectedSignerIssuerSha512Thumbprints -ExpectedParentIssuerSha512Thumbprints $config.ExpectedSignerParentIssuerSha512Thumbprints
+            $matchDescription = if ($evidence.SignerIssuerTrustMatch.UsedFallback)
+            {
+                "using parent issuer fallback '$($evidence.SignerIssuerTrustMatch.Certificate.Subject)' ($($evidence.SignerIssuerTrustMatch.Sha512Thumbprint))"
+            }
+            else
+            {
+                "using immediate issuer '$($evidence.SignerIssuerTrustMatch.Certificate.Subject)' ($($evidence.SignerIssuerTrustMatch.Sha512Thumbprint))"
+            }
+
+            Write-Host "Scenario 'InstallerDefaults' succeeded for '$binaryPath' $matchDescription."
+        }
+
+        'GoodBinary'
+        {
+            $binaryPath = Get-RequiredFullPath -Path $BinaryPath -Description 'Signed binary'
+            $evidence = Get-WindowsBinaryTrustEvidence -BinaryPath $binaryPath
+            $null = Assert-WindowsBinaryTrust -BinaryPath $binaryPath -ExpectedSubject $evidence.SignerSubject -ExpectedIssuerSha512Thumbprints @($evidence.SignerIssuerSha512Thumbprint)
+            Write-Host "Scenario 'GoodBinary' succeeded for '$binaryPath': '$($evidence.SignerSubject)' issued by '$($evidence.SignerIssuerCertificate.Subject)'."
+        }
+
+        'UnsignedBinary'
+        {
+            $binaryPath = Get-RequiredFullPath -Path $BinaryPath -Description 'Unsigned binary'
+            Invoke-ExpectedFailure -ScenarioName $Scenario -ExpectedMessageFragment 'Authenticode signature validation failed' -Action {
+                $null = Get-WindowsBinaryTrustEvidence -BinaryPath $binaryPath
+            }
+        }
+
+        'TamperedBinary'
+        {
+            $binaryPath = Get-RequiredFullPath -Path $BinaryPath -Description 'Signed binary'
+            $tamperedPath = New-TamperedBinaryCopy -SourcePath $binaryPath -DestinationDirectory $tempRoot
+            Invoke-ExpectedFailure -ScenarioName $Scenario -ExpectedMessageFragment 'Authenticode signature validation failed' -Action {
+                $null = Get-WindowsBinaryTrustEvidence -BinaryPath $tamperedPath
+            }
+        }
+
+        'WrongSubject'
+        {
+            $binaryPath = Get-RequiredFullPath -Path $BinaryPath -Description 'Signed binary'
+            $evidence = Get-WindowsBinaryTrustEvidence -BinaryPath $binaryPath
+            $mutatedSubject = Get-MutatedExpectedSubject -Subject $evidence.SignerSubject
+            Invoke-ExpectedFailure -ScenarioName $Scenario -ExpectedMessageFragment 'expected' -Action {
+                $null = Assert-WindowsBinaryTrust -BinaryPath $binaryPath -ExpectedSubject $mutatedSubject -ExpectedIssuerSha512Thumbprints @($evidence.SignerIssuerSha512Thumbprint)
+            }
+        }
+
+        'WrongIssuer'
+        {
+            $binaryPath = Get-RequiredFullPath -Path $BinaryPath -Description 'Signed binary'
+            $evidence = Get-WindowsBinaryTrustEvidence -BinaryPath $binaryPath
+            $mutatedThumbprint = Get-MutatedHexString -Value $evidence.SignerIssuerSha512Thumbprint
+            $mutatedParentThumbprints = if ([string]::IsNullOrWhiteSpace($evidence.SignerParentIssuerSha512Thumbprint))
+            {
+                @()
+            }
+            else
+            {
+                @((Get-MutatedHexString -Value $evidence.SignerParentIssuerSha512Thumbprint))
+            }
+            Invoke-ExpectedFailure -ScenarioName $Scenario -ExpectedMessageFragment 'expected' -Action {
+                $null = Assert-WindowsBinaryTrust -BinaryPath $binaryPath -ExpectedSubject $evidence.SignerSubject -ExpectedIssuerSha512Thumbprints @($mutatedThumbprint) -ExpectedParentIssuerSha512Thumbprints $mutatedParentThumbprints
+            }
+        }
+
+        'ChecksumMismatch'
+        {
+            $archivePath = Get-RequiredFullPath -Path $ArchivePath -Description 'Archive'
+            $checksumsPath = Get-RequiredFullPath -Path $ChecksumsPath -Description 'checksums.txt'
+            $assetName = [System.IO.Path]::GetFileName($archivePath)
+            $mismatchChecksumsPath = New-ChecksumMismatchFile -ChecksumsPath $checksumsPath -AssetName $assetName -DestinationDirectory $tempRoot
+            Invoke-ExpectedFailure -ScenarioName $Scenario -ExpectedMessageFragment 'SHA256 mismatch' -Action {
+                $null = Assert-WindowsArchiveIntegrity -ArchivePath $archivePath -AssetName $assetName -ChecksumsPath $mismatchChecksumsPath
+            }
+        }
+
+        'MetadataMismatch'
+        {
+            $archivePath = Get-RequiredFullPath -Path $ArchivePath -Description 'Archive'
+            $checksumsPath = Get-RequiredFullPath -Path $ChecksumsPath -Description 'checksums.txt'
+            $releaseMetadataPath = Get-RequiredFullPath -Path $ReleaseMetadataPath -Description 'release-metadata.json'
+            $assetName = [System.IO.Path]::GetFileName($archivePath)
+            $mismatchMetadataPath = New-MetadataMismatchFile -ReleaseMetadataPath $releaseMetadataPath -AssetName $assetName -DestinationDirectory $tempRoot
+            Invoke-ExpectedFailure -ScenarioName $Scenario -ExpectedMessageFragment 'did not match checksums.txt' -Action {
+                $null = Assert-WindowsArchiveIntegrity -ArchivePath $archivePath -AssetName $assetName -ChecksumsPath $checksumsPath -ReleaseMetadataPath $mismatchMetadataPath
+            }
+        }
+    }
+}
+finally
+{
+    if ($KeepArtifacts)
+    {
+        Write-Host "Kept verification fixtures in '$tempRoot'."
+    }
+    elseif (Test-Path $tempRoot)
+    {
+        Remove-Item -Path $tempRoot -Recurse -Force
+    }
+}

--- a/scripts/Update-ReleaseBundleMetadata.ps1
+++ b/scripts/Update-ReleaseBundleMetadata.ps1
@@ -1,0 +1,59 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$BundleDirectory
+)
+
+$ErrorActionPreference = 'Stop'
+
+$bundleDirectory = [System.IO.Path]::GetFullPath($BundleDirectory)
+$metadataPath = Join-Path $bundleDirectory 'release-metadata.json'
+
+if (-not (Test-Path $bundleDirectory))
+{
+    throw "Bundle directory '$bundleDirectory' was not found."
+}
+
+if (-not (Test-Path $metadataPath))
+{
+    throw "Release metadata file '$metadataPath' was not found."
+}
+
+$metadata = Get-Content -Path $metadataPath -Raw | ConvertFrom-Json
+if ([string]::IsNullOrWhiteSpace($metadata.version))
+{
+    throw "Release metadata in '$metadataPath' did not contain a version."
+}
+
+$updatedAssets =
+    @($metadata.assets |
+        ForEach-Object {
+            $assetPath = Join-Path $bundleDirectory $_.name
+            if (-not (Test-Path $assetPath))
+            {
+                throw "Release asset '$assetPath' was not found."
+            }
+
+            [ordered]@{
+                name = $_.name
+                runtimeIdentifier = $_.runtimeIdentifier
+                platform = $_.platform
+                architecture = $_.architecture
+                fileType = $_.fileType
+                commandName = $_.commandName
+                sha256 = (Get-FileHash -Path $assetPath -Algorithm SHA256).Hash.ToLowerInvariant()
+            }
+        } |
+        Sort-Object name)
+
+$checksumsPath = Join-Path $bundleDirectory 'checksums.txt'
+$checksums = $updatedAssets | ForEach-Object { "$($_.sha256)  $($_.name)" }
+$checksums | Set-Content -Path $checksumsPath
+
+$updatedMetadata = [ordered]@{
+    version = $metadata.version
+    assets = $updatedAssets
+    windowsAssets = @($updatedAssets | Where-Object { $_.platform -eq 'win' })
+}
+
+$updatedMetadata | ConvertTo-Json -Depth 5 | Set-Content -Path $metadataPath

--- a/scripts/Verify-PowerShellSyntax.ps1
+++ b/scripts/Verify-PowerShellSyntax.ps1
@@ -1,0 +1,39 @@
+[CmdletBinding()]
+param(
+    [string]$RootPath = (Join-Path $PSScriptRoot '..')
+)
+
+$ErrorActionPreference = 'Stop'
+
+$resolvedRoot = [System.IO.Path]::GetFullPath($RootPath)
+$scriptFiles = @(Get-ChildItem -Path $resolvedRoot -Recurse -Filter '*.ps1' -File)
+if ($scriptFiles.Count -eq 0)
+{
+    throw "No PowerShell scripts were found under '$resolvedRoot'."
+}
+
+$syntaxErrors = @()
+foreach ($scriptFile in $scriptFiles)
+{
+    $tokens = $null
+    $errors = $null
+    [System.Management.Automation.Language.Parser]::ParseFile($scriptFile.FullName, [ref]$tokens, [ref]$errors) | Out-Null
+
+    foreach ($error in @($errors))
+    {
+        $syntaxErrors += [ordered]@{
+            Path = $scriptFile.FullName
+            Line = $error.Extent.StartLineNumber
+            Column = $error.Extent.StartColumnNumber
+            Message = $error.Message
+        }
+    }
+}
+
+if ($syntaxErrors.Count -gt 0)
+{
+    $details = $syntaxErrors | ForEach-Object { "$($_.Path):$($_.Line):$($_.Column) $($_.Message)" }
+    throw "PowerShell syntax validation failed:`n$($details -join [Environment]::NewLine)"
+}
+
+Write-Host "PowerShell syntax validation passed for $($scriptFiles.Count) script(s)."

--- a/scripts/Verify-WindowsBinaryIssuer.ps1
+++ b/scripts/Verify-WindowsBinaryIssuer.ps1
@@ -1,0 +1,48 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$BinaryPath,
+
+    [string]$InstallerScriptPath = (Join-Path $PSScriptRoot 'install\install-copilotd.ps1')
+)
+
+$ErrorActionPreference = 'Stop'
+
+$binaryPath = [System.IO.Path]::GetFullPath($BinaryPath)
+$installerScriptPath = [System.IO.Path]::GetFullPath($InstallerScriptPath)
+
+if (-not (Test-Path $binaryPath))
+{
+    throw "Signed binary '$binaryPath' was not found."
+}
+
+if (-not (Test-Path $installerScriptPath))
+{
+    throw "Installer script '$installerScriptPath' was not found."
+}
+
+Write-Verbose "Loading installer trust helpers from '$installerScriptPath'."
+. $installerScriptPath -NoExecute
+
+$config = Get-CopilotdInstallerTrustConfiguration
+$expectedThumbprints = @($config.ExpectedSignerIssuerSha512Thumbprints)
+$expectedParentThumbprints = @($config.ExpectedSignerParentIssuerSha512Thumbprints)
+$evidence = Get-WindowsBinaryTrustEvidence -BinaryPath $binaryPath
+
+$issuerTrustMatch = Assert-SignerIssuerTrust `
+    -Evidence $evidence `
+    -ExpectedIssuerThumbprints $expectedThumbprints `
+    -ExpectedParentIssuerThumbprints $expectedParentThumbprints
+
+$formattedExpectedThumbprints = ($expectedThumbprints | ForEach-Object { "'$_'" }) -join ', '
+$formattedExpectedParentThumbprints = ($expectedParentThumbprints | ForEach-Object { "'$_'" }) -join ', '
+$matchDescription = if ($issuerTrustMatch.UsedFallback)
+{
+    "using parent issuer fallback '$($issuerTrustMatch.Certificate.Subject)' ($($issuerTrustMatch.Sha512Thumbprint))"
+}
+else
+{
+    "using immediate issuer '$($issuerTrustMatch.Certificate.Subject)' ($($issuerTrustMatch.Sha512Thumbprint))"
+}
+
+Write-Host "Verified signer issuer chain for '$binaryPath' $matchDescription. Allowed immediate SHA512 thumbprints: $formattedExpectedThumbprints. Allowed parent SHA512 thumbprints: $formattedExpectedParentThumbprints."

--- a/scripts/install/install-copilotd.ps1
+++ b/scripts/install/install-copilotd.ps1
@@ -1,0 +1,1145 @@
+[CmdletBinding()]
+param(
+    [ValidateSet('Dev', 'PreRelease', 'Stable')]
+    [string]$Quality = 'Stable',
+
+    [switch]$Force,
+
+    [string]$TargetPath = (Join-Path $env:USERPROFILE '.copilotd\bin'),
+
+    [bool]$UpdatePath = $true,
+
+    [string]$Repository = 'DamianEdwards/copilotd',
+
+    [string]$ExpectedSignerSubject = 'CN=Damian Edwards, O=Damian Edwards, L=Issaquah, S=Washington, C=US',
+
+    [Parameter(DontShow = $true)]
+    [switch]$NoExecute
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Keep this single-sourced here; the release workflow reads these values from the installer script.
+$ExpectedSignerIssuerSha512Thumbprints = @(
+    '1c93dcf4e032b19949a67722d0c25e683309fbcd36110da84129f45d8175b709ebc6ef3439596ece9eb8f2dae1967b856adc49ba74535244a8a5db5fb48fa7b9'
+    '1770433e5d2c028e0bf8640a0345bdb86307e7cc2a99cfbe93acf9d960a996d1c63b2d5cf30d52e7741df4fd057ea778442f75c1b62ee2106c66333078a04e6d'
+)
+$ExpectedSignerParentIssuerSha512Thumbprints = @(
+    '46f16bb99340f8d728c83ff093af9d4cff87811d432f92a804741144f0f3fc0aa8011b1efe0c24e0480bd6c7cb7af699077f9b8fc7ec8a40f9f7a186725224c6'
+)
+
+$runningOnWindows = if (Get-Variable -Name IsWindows -ErrorAction SilentlyContinue)
+{
+    [bool]$IsWindows
+}
+else
+{
+    [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)
+}
+
+if (-not $runningOnWindows)
+{
+    $scriptName = if ($MyInvocation.MyCommand.Name) { $MyInvocation.MyCommand.Name } else { 'install-copilotd.ps1' }
+    Write-Error "$scriptName currently supports Windows only. Running on '$([System.Runtime.InteropServices.RuntimeInformation]::OSDescription)' is not yet supported."
+    exit 1
+}
+
+function Normalize-PathEntry
+{
+    param([Parameter(Mandatory)][string]$PathEntry)
+
+    return $PathEntry.Trim().TrimEnd('\').ToLowerInvariant()
+}
+
+function Ensure-PathContains
+{
+    param(
+        [Parameter(Mandatory)][string]$Entry,
+        [Parameter(Mandatory)][System.EnvironmentVariableTarget]$Target
+    )
+
+    $current = [System.Environment]::GetEnvironmentVariable('PATH', $Target)
+    $existingEntries = @()
+    if (-not [string]::IsNullOrWhiteSpace($current))
+    {
+        $existingEntries = @($current.Split(';', [System.StringSplitOptions]::RemoveEmptyEntries))
+    }
+
+    $normalizedTarget = Normalize-PathEntry -PathEntry $Entry
+    $alreadyPresent = $existingEntries | Where-Object { (Normalize-PathEntry -PathEntry $_) -eq $normalizedTarget } | Select-Object -First 1
+    if ($alreadyPresent)
+    {
+        return $false
+    }
+
+    $updated = if ([string]::IsNullOrWhiteSpace($current))
+    {
+        $Entry
+    }
+    else
+    {
+        $current.TrimEnd(';') + ';' + $Entry
+    }
+
+    [System.Environment]::SetEnvironmentVariable('PATH', $updated, $Target)
+    return $true
+}
+
+function Get-HttpStatusCode
+{
+    param([Parameter(Mandatory)][System.Exception]$Exception)
+
+    $responseProperty = $Exception.PSObject.Properties['Response']
+    if ($null -eq $responseProperty -or $null -eq $Exception.Response)
+    {
+        return $null
+    }
+
+    try
+    {
+        return [int]$Exception.Response.StatusCode
+    }
+    catch
+    {
+        return $null
+    }
+}
+
+function Invoke-GitHubApi
+{
+    param([Parameter(Mandatory)][string]$Uri)
+
+    $token = if (-not [string]::IsNullOrWhiteSpace($env:GH_TOKEN))
+    {
+        $env:GH_TOKEN
+    }
+    elseif (-not [string]::IsNullOrWhiteSpace($env:GITHUB_TOKEN))
+    {
+        $env:GITHUB_TOKEN
+    }
+    else
+    {
+        $null
+    }
+
+    $headers = @{
+        Accept       = 'application/vnd.github+json'
+        'User-Agent' = 'copilotd-install-script'
+    }
+    if ($token)
+    {
+        $headers.Authorization = "Bearer $token"
+    }
+
+    Invoke-RestMethod -Method Get -Uri $Uri -Headers $headers
+}
+
+function Invoke-GitHubAssetDownload
+{
+    param(
+        [Parameter(Mandatory)][string]$Uri,
+        [Parameter(Mandatory)][string]$OutFile
+    )
+
+    $token = if (-not [string]::IsNullOrWhiteSpace($env:GH_TOKEN))
+    {
+        $env:GH_TOKEN
+    }
+    elseif (-not [string]::IsNullOrWhiteSpace($env:GITHUB_TOKEN))
+    {
+        $env:GITHUB_TOKEN
+    }
+    else
+    {
+        $null
+    }
+
+    $headers = @{
+        'User-Agent' = 'copilotd-install-script'
+    }
+    if ($token)
+    {
+        $headers.Authorization = "Bearer $token"
+    }
+
+    Invoke-WebRequest -Uri $Uri -Headers $headers -OutFile $OutFile
+}
+
+function Get-ReleaseByTag
+{
+    param(
+        [Parameter(Mandatory)][string]$Repo,
+        [Parameter(Mandatory)][string]$Tag
+    )
+
+    $tagUri = "https://api.github.com/repos/$Repo/releases/tags/$Tag"
+    try
+    {
+        return Invoke-GitHubApi -Uri $tagUri
+    }
+    catch
+    {
+        if ((Get-HttpStatusCode -Exception $_.Exception) -eq 404)
+        {
+            return $null
+        }
+
+        throw
+    }
+}
+
+function Get-ReleaseAsset
+{
+    param(
+        [Parameter(Mandatory)]$Release,
+        [Parameter(Mandatory)][string]$AssetName
+    )
+
+    return $Release.assets | Where-Object { $_.name -eq $AssetName } | Select-Object -First 1
+}
+
+function Get-WindowsArchitecture
+{
+    $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+    switch ($arch)
+    {
+        ([System.Runtime.InteropServices.Architecture]::X64) { return 'x64' }
+        ([System.Runtime.InteropServices.Architecture]::Arm64) { return 'arm64' }
+        default { throw "Unsupported Windows architecture '$arch'. Only x64 and arm64 are supported." }
+    }
+}
+
+function Get-ReleaseForQuality
+{
+    param(
+        [Parameter(Mandatory)][string]$Repo,
+        [Parameter(Mandatory)][string]$SelectedQuality,
+        [Parameter(Mandatory)][string]$AssetName
+    )
+
+    if ($SelectedQuality -eq 'Dev')
+    {
+        $devRelease = Get-ReleaseByTag -Repo $Repo -Tag 'dev'
+        if ($null -eq $devRelease)
+        {
+            $releases = @(Invoke-GitHubApi -Uri "https://api.github.com/repos/$Repo/releases?per_page=100" | ForEach-Object { $_ })
+            $devRelease = $releases | Where-Object { $_.name -eq 'Development Build' } | Select-Object -First 1
+        }
+
+        if ($null -eq $devRelease)
+        {
+            throw "Could not locate the standing Development Build release (tag 'dev' or title 'Development Build')."
+        }
+
+        $devAsset = Get-ReleaseAsset -Release $devRelease -AssetName $AssetName
+        if ($null -eq $devAsset)
+        {
+            throw "Development Build release '$($devRelease.name)' does not contain asset '$AssetName'."
+        }
+
+        return $devRelease
+    }
+
+    $allReleases = @(Invoke-GitHubApi -Uri "https://api.github.com/repos/$Repo/releases?per_page=100" | ForEach-Object { $_ })
+    foreach ($release in $allReleases)
+    {
+        if ($release.draft)
+        {
+            continue
+        }
+
+        if ($release.tag_name -in @('dev', 'install-scripts'))
+        {
+            continue
+        }
+
+        if ($SelectedQuality -eq 'Stable' -and $release.prerelease)
+        {
+            continue
+        }
+
+        $asset = Get-ReleaseAsset -Release $release -AssetName $AssetName
+        if ($null -eq $asset)
+        {
+            continue
+        }
+
+        return $release
+    }
+
+    throw "No '$SelectedQuality' release containing '$AssetName' was found in '$Repo'."
+}
+
+function Get-ExpectedSha256
+{
+    param(
+        [Parameter(Mandatory)][string]$ChecksumsPath,
+        [Parameter(Mandatory)][string]$AssetName
+    )
+
+    $line = @(Get-Content -Path $ChecksumsPath | Where-Object { $_ -match "\s\*?$([regex]::Escape($AssetName))$" } | Select-Object -First 1)
+    if ($line.Count -eq 0)
+    {
+        throw "checksums.txt did not contain an entry for '$AssetName'."
+    }
+
+    $match = [regex]::Match($line[0], '^\s*([0-9a-fA-F]{64})\s+\*?.+$')
+    if (-not $match.Success)
+    {
+        throw "Invalid checksum line format for '$AssetName' in checksums.txt."
+    }
+
+    return $match.Groups[1].Value.ToLowerInvariant()
+}
+
+function Get-CopilotdInstallerTrustConfiguration
+{
+    return [pscustomobject]@{
+        ExpectedSignerSubject = $ExpectedSignerSubject
+        ExpectedSignerIssuerSha512Thumbprints = @($ExpectedSignerIssuerSha512Thumbprints)
+        ExpectedSignerParentIssuerSha512Thumbprints = @($ExpectedSignerParentIssuerSha512Thumbprints)
+    }
+}
+
+function Get-CertificateSha512Thumbprint
+{
+    param([Parameter(Mandatory)][System.Security.Cryptography.X509Certificates.X509Certificate2]$Certificate)
+
+    $sha512 = [System.Security.Cryptography.SHA512]::Create()
+    try
+    {
+        $hashBytes = $sha512.ComputeHash($Certificate.RawData)
+        return ([System.BitConverter]::ToString($hashBytes)).Replace('-', '').ToLowerInvariant()
+    }
+    finally
+    {
+        $sha512.Dispose()
+    }
+}
+
+function Get-ChainStatusMessages
+{
+    param([Parameter(Mandatory)][System.Security.Cryptography.X509Certificates.X509Chain]$Chain)
+
+    return @($Chain.ChainStatus |
+            Where-Object { $_.Status -ne [System.Security.Cryptography.X509Certificates.X509ChainStatusFlags]::NoError } |
+            ForEach-Object {
+                $statusText = $_.Status.ToString()
+                $infoText = $_.StatusInformation.Trim()
+                if ([string]::IsNullOrWhiteSpace($infoText))
+                {
+                    $statusText
+                }
+                else
+                {
+                    "$statusText ($infoText)"
+                }
+            })
+}
+
+function Write-CertificateDetailsVerbose
+{
+    param(
+        [Parameter(Mandatory)][string]$Description,
+        [System.Security.Cryptography.X509Certificates.X509Certificate2]$Certificate
+    )
+
+    if ($null -eq $Certificate)
+    {
+        Write-Verbose "$Description certificate: <null>"
+        return
+    }
+
+    Write-Verbose ("{0} certificate: Subject='{1}', Issuer='{2}', Thumbprint='{3}', NotBefore='{4:O}', NotAfter='{5:O}'" -f `
+            $Description, `
+            $Certificate.Subject, `
+            $Certificate.Issuer, `
+            $Certificate.Thumbprint, `
+            $Certificate.NotBefore, `
+            $Certificate.NotAfter)
+}
+
+function Write-CertificateChainVerbose
+{
+    param(
+        [Parameter(Mandatory)][System.Security.Cryptography.X509Certificates.X509Chain]$Chain,
+        [Parameter(Mandatory)][string]$Description
+    )
+
+    Write-Verbose "$Description certificate chain contains $($Chain.ChainElements.Count) element(s)."
+
+    for ($index = 0; $index -lt $Chain.ChainElements.Count; $index++)
+    {
+        Write-CertificateDetailsVerbose -Description "$Description chain[$index]" -Certificate $Chain.ChainElements[$index].Certificate
+    }
+
+    $statuses = Get-ChainStatusMessages -Chain $Chain
+    if ($statuses.Count -eq 0)
+    {
+        Write-Verbose "$Description certificate chain status: NoError."
+        return
+    }
+
+    foreach ($status in $statuses)
+    {
+        Write-Verbose "$Description certificate chain status: $status"
+    }
+}
+
+function Assert-WindowsArchiveIntegrity
+{
+    param(
+        [Parameter(Mandatory)][string]$ArchivePath,
+        [Parameter(Mandatory)][string]$AssetName,
+        [Parameter(Mandatory)][string]$ChecksumsPath,
+        [string]$ReleaseMetadataPath
+    )
+
+    Write-Verbose "Validating archive SHA256 for '$AssetName' using '$ChecksumsPath'."
+    $expectedSha = Get-ExpectedSha256 -ChecksumsPath $ChecksumsPath -AssetName $AssetName
+    $actualSha = (Get-FileHash -Path $ArchivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+    Write-Verbose "checksums.txt expected SHA256 for '$AssetName': '$expectedSha'."
+    Write-Verbose "Actual SHA256 for '$ArchivePath': '$actualSha'."
+
+    if ($expectedSha -ne $actualSha)
+    {
+        throw "SHA256 mismatch for '$AssetName'. Expected '$expectedSha' but got '$actualSha'."
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($ReleaseMetadataPath))
+    {
+        Write-Verbose "Validating release metadata for '$AssetName' using '$ReleaseMetadataPath'."
+        $metadata = Get-Content -Path $ReleaseMetadataPath -Raw | ConvertFrom-Json
+        $metadataAsset = $metadata.assets | Where-Object { $_.name -eq $AssetName } | Select-Object -First 1
+        if ($null -eq $metadataAsset)
+        {
+            throw "release-metadata.json did not contain asset '$AssetName'."
+        }
+
+        $metadataSha = $metadataAsset.sha256.ToLowerInvariant()
+        Write-Verbose "release-metadata.json SHA256 for '$AssetName': '$metadataSha'."
+        if ($metadataSha -ne $expectedSha)
+        {
+            throw "release-metadata.json SHA256 for '$AssetName' did not match checksums.txt."
+        }
+    }
+
+    return $actualSha
+}
+
+function Expand-WindowsReleaseArchive
+{
+    param(
+        [Parameter(Mandatory)][string]$ArchivePath,
+        [Parameter(Mandatory)][string]$DestinationPath
+    )
+
+    Write-Verbose "Expanding '$ArchivePath' to '$DestinationPath'."
+    Expand-Archive -Path $ArchivePath -DestinationPath $DestinationPath -Force
+
+    $binaryPath = Join-Path $DestinationPath 'copilotd.exe'
+    if (-not (Test-Path $binaryPath))
+    {
+        throw "Downloaded archive '$([System.IO.Path]::GetFileName($ArchivePath))' did not contain 'copilotd.exe'."
+    }
+
+    Write-Verbose "Found extracted Windows binary '$binaryPath'."
+    return $binaryPath
+}
+
+function Invoke-StatusStep
+{
+    param(
+        [Parameter(Mandatory)][string]$Message,
+        [Parameter(Mandatory)][scriptblock]$Action
+    )
+
+    Write-Host "$Message... " -NoNewline
+    & $Action
+    Write-Host 'done'
+}
+
+function Get-ReleaseStatusLabel
+{
+    param(
+        [Parameter(Mandatory)][string]$SelectedQuality,
+        [Parameter(Mandatory)]$Release
+    )
+
+    $releaseLabel =
+        switch ($SelectedQuality)
+        {
+            'Stable' { 'latest stable release' }
+            'PreRelease' { 'latest prerelease' }
+            'Dev' { 'latest development build' }
+            default { 'release' }
+        }
+
+    $releaseVersion = if (-not [string]::IsNullOrWhiteSpace($Release.tag_name))
+    {
+        $Release.tag_name
+    }
+    elseif (-not [string]::IsNullOrWhiteSpace($Release.name))
+    {
+        $Release.name
+    }
+    else
+    {
+        'unknown version'
+    }
+
+    return "$releaseLabel ($releaseVersion)"
+}
+
+function Get-ValidatedCertificateChain
+{
+    param(
+        [Parameter(Mandatory)][System.Security.Cryptography.X509Certificates.X509Certificate2]$Certificate,
+        [Parameter(Mandatory)][string]$Description,
+        [switch]$IgnoreTimeValidity
+    )
+
+    Write-CertificateDetailsVerbose -Description $Description -Certificate $Certificate
+    Write-Verbose "Building $Description certificate chain. IgnoreTimeValidity=$IgnoreTimeValidity."
+
+    $chain = [System.Security.Cryptography.X509Certificates.X509Chain]::new()
+    $chain.ChainPolicy.RevocationMode = [System.Security.Cryptography.X509Certificates.X509RevocationMode]::Online
+    $chain.ChainPolicy.RevocationFlag = [System.Security.Cryptography.X509Certificates.X509RevocationFlag]::EntireChain
+    $chain.ChainPolicy.UrlRetrievalTimeout = [TimeSpan]::FromSeconds(15)
+    $chain.ChainPolicy.VerificationFlags = if ($IgnoreTimeValidity)
+    {
+        [System.Security.Cryptography.X509Certificates.X509VerificationFlags]::IgnoreNotTimeValid
+    }
+    else
+    {
+        [System.Security.Cryptography.X509Certificates.X509VerificationFlags]::NoFlag
+    }
+
+    $ok = $chain.Build($Certificate)
+    if ($ok)
+    {
+        Write-CertificateChainVerbose -Chain $chain -Description $Description
+        return $chain
+    }
+
+    $statuses = Get-ChainStatusMessages -Chain $chain
+    Write-CertificateChainVerbose -Chain $chain -Description $Description
+    $statusMessage = if ($statuses.Count -gt 0)
+    {
+        $statuses -join '; '
+    }
+    else
+    {
+        'unknown chain validation failure'
+    }
+
+    throw "$Description certificate chain validation failed: $statusMessage"
+}
+
+function Get-ImmediateIssuerCertificate
+{
+    param(
+        [Parameter(Mandatory)][System.Security.Cryptography.X509Certificates.X509Chain]$Chain,
+        [Parameter(Mandatory)][string]$Description
+    )
+
+    if ($Chain.ChainElements.Count -lt 2)
+    {
+        throw "$Description certificate chain did not include an issuing certificate."
+    }
+
+    $issuerCertificate = $Chain.ChainElements[1].Certificate
+    if ($null -eq $issuerCertificate)
+    {
+        throw "$Description certificate chain did not provide an issuing certificate."
+    }
+
+    Write-CertificateDetailsVerbose -Description "$Description issuer" -Certificate $issuerCertificate
+    return $issuerCertificate
+}
+
+function Get-ParentIntermediateIssuerCertificate
+{
+    param(
+        [Parameter(Mandatory)][System.Security.Cryptography.X509Certificates.X509Chain]$Chain,
+        [Parameter(Mandatory)][string]$Description
+    )
+
+    if ($Chain.ChainElements.Count -lt 3)
+    {
+        Write-Verbose "$Description certificate chain did not include a parent issuer fallback candidate."
+        return $null
+    }
+
+    $parentIndex = 2
+    $parentCertificate = $Chain.ChainElements[$parentIndex].Certificate
+    if ($null -eq $parentCertificate)
+    {
+        Write-Verbose "$Description certificate chain did not provide a parent issuer fallback candidate."
+        return $null
+    }
+
+    $isRootCandidate = ($parentIndex -eq ($Chain.ChainElements.Count - 1)) -or
+        [string]::Equals($parentCertificate.Subject, $parentCertificate.Issuer, [System.StringComparison]::OrdinalIgnoreCase)
+    if ($isRootCandidate)
+    {
+        Write-Verbose "$Description parent issuer fallback candidate resolved to a root certificate. Root certificates are never used for issuer fallback."
+        return $null
+    }
+
+    Write-CertificateDetailsVerbose -Description "$Description parent issuer" -Certificate $parentCertificate
+    return $parentCertificate
+}
+
+function Normalize-DistinguishedNameKey
+{
+    param([Parameter(Mandatory)][string]$Key)
+
+    $normalized = $Key.Trim().ToUpperInvariant()
+    if ($normalized -eq 'ST')
+    {
+        return 'S'
+    }
+
+    return $normalized
+}
+
+function Parse-DistinguishedName
+{
+    param([Parameter(Mandatory)][string]$DistinguishedName)
+
+    $result = @{}
+    foreach ($segment in $DistinguishedName -split ',')
+    {
+        $match = [regex]::Match($segment, '^\s*([^=]+?)\s*=\s*(.+?)\s*$')
+        if (-not $match.Success)
+        {
+            throw "Could not parse distinguished name segment '$segment' from '$DistinguishedName'."
+        }
+
+        $key = Normalize-DistinguishedNameKey -Key $match.Groups[1].Value
+        $value = $match.Groups[2].Value.Trim()
+        if ([string]::IsNullOrWhiteSpace($value))
+        {
+            throw "Distinguished name key '$key' in '$DistinguishedName' has an empty value."
+        }
+
+        if ($result.ContainsKey($key))
+        {
+            throw "Distinguished name '$DistinguishedName' contains duplicate key '$key', which is not supported."
+        }
+
+        $result[$key] = $value
+    }
+
+    return $result
+}
+
+function Get-WindowsBinaryTrustEvidence
+{
+    param(
+        [Parameter(Mandatory)][string]$BinaryPath
+    )
+
+    $resolvedBinaryPath = [System.IO.Path]::GetFullPath($BinaryPath)
+    Write-Verbose "Inspecting Authenticode signature for '$resolvedBinaryPath'."
+
+    $signature = Get-AuthenticodeSignature -FilePath $resolvedBinaryPath
+    $statusMessage = if ([string]::IsNullOrWhiteSpace($signature.StatusMessage)) { 'No additional details were provided.' } else { $signature.StatusMessage }
+    Write-Verbose "Authenticode signature status for '$resolvedBinaryPath': $($signature.Status) - $statusMessage"
+
+    if ($signature.Status -ne [System.Management.Automation.SignatureStatus]::Valid)
+    {
+        throw "Authenticode signature validation failed for '$resolvedBinaryPath': $($signature.Status) - $statusMessage"
+    }
+
+    if ($null -eq $signature.SignerCertificate)
+    {
+        throw "Authenticode signature on '$resolvedBinaryPath' did not include a signer certificate."
+    }
+
+    $signerChain = Get-ValidatedCertificateChain -Certificate $signature.SignerCertificate -Description 'Signer' -IgnoreTimeValidity
+    $issuerCertificate = Get-ImmediateIssuerCertificate -Chain $signerChain -Description 'Signer'
+    $issuerThumbprint = Get-CertificateSha512Thumbprint -Certificate $issuerCertificate
+    Write-Verbose "Signer issuer SHA512 thumbprint for '$resolvedBinaryPath': '$issuerThumbprint'."
+    $parentIssuerCertificate = Get-ParentIntermediateIssuerCertificate -Chain $signerChain -Description 'Signer'
+    $parentIssuerThumbprint = $null
+    if ($null -ne $parentIssuerCertificate)
+    {
+        $parentIssuerThumbprint = Get-CertificateSha512Thumbprint -Certificate $parentIssuerCertificate
+        Write-Verbose "Signer parent issuer SHA512 thumbprint for '$resolvedBinaryPath': '$parentIssuerThumbprint'."
+    }
+
+    if ($null -eq $signature.TimeStamperCertificate)
+    {
+        throw "Expected a timestamped signature for '$resolvedBinaryPath', but no timestamp certificate was present."
+    }
+
+    $timestampChain = Get-ValidatedCertificateChain -Certificate $signature.TimeStamperCertificate -Description 'Timestamp'
+
+    return [pscustomobject]@{
+        BinaryPath = $resolvedBinaryPath
+        Signature = $signature
+        SignerCertificate = $signature.SignerCertificate
+        SignerSubject = $signature.SignerCertificate.Subject
+        SignerChain = $signerChain
+        SignerIssuerCertificate = $issuerCertificate
+        SignerIssuerSha512Thumbprint = $issuerThumbprint
+        SignerParentIssuerCertificate = $parentIssuerCertificate
+        SignerParentIssuerSha512Thumbprint = $parentIssuerThumbprint
+        TimeStamperCertificate = $signature.TimeStamperCertificate
+        TimeStamperChain = $timestampChain
+    }
+}
+
+function Get-NormalizedSha512ThumbprintSet
+{
+    param(
+        [Parameter(Mandatory)][string[]]$Thumbprints,
+        [Parameter(Mandatory)][string]$Description
+    )
+
+    $normalizedThumbprintSet = @($Thumbprints |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+        ForEach-Object { $_.Trim().ToLowerInvariant() })
+    if ($normalizedThumbprintSet.Count -eq 0)
+    {
+        throw "At least one expected $Description SHA512 thumbprint is required."
+    }
+
+    return $normalizedThumbprintSet
+}
+
+function Format-Sha512ThumbprintSet
+{
+    param([Parameter(Mandatory)][string[]]$Thumbprints)
+
+    return ($Thumbprints | ForEach-Object { "'$_'" }) -join ', '
+}
+
+function Test-Sha512ThumbprintMatch
+{
+    param(
+        [Parameter(Mandatory)][string]$ActualThumbprint,
+        [Parameter(Mandatory)][string[]]$ExpectedThumbprints
+    )
+
+    $match = $ExpectedThumbprints |
+        Where-Object { [string]::Equals($_, $ActualThumbprint, [System.StringComparison]::OrdinalIgnoreCase) } |
+        Select-Object -First 1
+    return ($null -ne $match)
+}
+
+function Assert-SignerIssuerTrust
+{
+    param(
+        [Parameter(Mandatory)]$Evidence,
+        [Parameter(Mandatory)][string[]]$ExpectedIssuerThumbprints,
+        [string[]]$ExpectedParentIssuerThumbprints = @()
+    )
+
+    $expectedIssuerThumbprintSet = Get-NormalizedSha512ThumbprintSet -Thumbprints $ExpectedIssuerThumbprints -Description 'signer issuer'
+    $formattedExpectedIssuerThumbprints = Format-Sha512ThumbprintSet -Thumbprints $expectedIssuerThumbprintSet
+    Write-Verbose "Validating signer immediate issuer SHA512 thumbprint for '$($Evidence.BinaryPath)'. Expected one of $formattedExpectedIssuerThumbprints, actual '$($Evidence.SignerIssuerSha512Thumbprint)'."
+
+    if (Test-Sha512ThumbprintMatch -ActualThumbprint $Evidence.SignerIssuerSha512Thumbprint -ExpectedThumbprints $expectedIssuerThumbprintSet)
+    {
+        Write-Verbose "Signer immediate issuer matched configured issuer SHA512 thumbprints for '$($Evidence.BinaryPath)'."
+        return [pscustomobject]@{
+            MatchSource = 'ImmediateIssuer'
+            Certificate = $Evidence.SignerIssuerCertificate
+            Sha512Thumbprint = $Evidence.SignerIssuerSha512Thumbprint
+            UsedFallback = $false
+        }
+    }
+
+    Write-Verbose "Signer immediate issuer thumbprint for '$($Evidence.BinaryPath)' did not match configured issuer SHA512 thumbprints. Evaluating parent issuer fallback."
+    $expectedParentIssuerThumbprintSet = @($ExpectedParentIssuerThumbprints |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+        ForEach-Object { $_.Trim().ToLowerInvariant() })
+    if ($expectedParentIssuerThumbprintSet.Count -eq 0)
+    {
+        throw "Signer issuer certificate '$($Evidence.SignerIssuerCertificate.Subject)' has SHA512 thumbprint '$($Evidence.SignerIssuerSha512Thumbprint)', expected one of: $formattedExpectedIssuerThumbprints. Parent issuer fallback is not configured."
+    }
+
+    $formattedExpectedParentIssuerThumbprints = Format-Sha512ThumbprintSet -Thumbprints $expectedParentIssuerThumbprintSet
+
+    if ($null -eq $Evidence.SignerParentIssuerCertificate -or [string]::IsNullOrWhiteSpace($Evidence.SignerParentIssuerSha512Thumbprint))
+    {
+        throw "Signer issuer certificate '$($Evidence.SignerIssuerCertificate.Subject)' has SHA512 thumbprint '$($Evidence.SignerIssuerSha512Thumbprint)', expected one of: $formattedExpectedIssuerThumbprints. Parent issuer fallback expected one of: $formattedExpectedParentIssuerThumbprints, but no parent intermediate issuer was available."
+    }
+
+    Write-Verbose "Falling back to signer parent issuer SHA512 thumbprint for '$($Evidence.BinaryPath)'. Expected one of $formattedExpectedParentIssuerThumbprints, actual '$($Evidence.SignerParentIssuerSha512Thumbprint)'."
+    if (Test-Sha512ThumbprintMatch -ActualThumbprint $Evidence.SignerParentIssuerSha512Thumbprint -ExpectedThumbprints $expectedParentIssuerThumbprintSet)
+    {
+        Write-Verbose "Signer parent issuer fallback matched configured parent issuer SHA512 thumbprints for '$($Evidence.BinaryPath)'."
+        return [pscustomobject]@{
+            MatchSource = 'ParentIssuer'
+            Certificate = $Evidence.SignerParentIssuerCertificate
+            Sha512Thumbprint = $Evidence.SignerParentIssuerSha512Thumbprint
+            UsedFallback = $true
+        }
+    }
+
+    throw "Signer issuer certificate '$($Evidence.SignerIssuerCertificate.Subject)' has SHA512 thumbprint '$($Evidence.SignerIssuerSha512Thumbprint)', expected one of: $formattedExpectedIssuerThumbprints. Fallback parent issuer certificate '$($Evidence.SignerParentIssuerCertificate.Subject)' has SHA512 thumbprint '$($Evidence.SignerParentIssuerSha512Thumbprint)', expected one of: $formattedExpectedParentIssuerThumbprints."
+}
+
+function Assert-WindowsBinaryTrust
+{
+    param(
+        [Parameter(Mandatory)][string]$BinaryPath,
+        [Parameter(Mandatory)][string]$ExpectedSubject,
+        [Parameter(Mandatory)][string[]]$ExpectedIssuerSha512Thumbprints,
+        [string[]]$ExpectedParentIssuerSha512Thumbprints = @()
+    )
+
+    $evidence = Get-WindowsBinaryTrustEvidence -BinaryPath $BinaryPath
+    Write-Verbose "Validating signer subject for '$($evidence.BinaryPath)'."
+
+    $actualSubject = $evidence.SignerSubject
+    $expectedSubjectParts = Parse-DistinguishedName -DistinguishedName $ExpectedSubject
+    $actualSubjectParts = Parse-DistinguishedName -DistinguishedName $actualSubject
+    foreach ($key in $expectedSubjectParts.Keys)
+    {
+        if (-not $actualSubjectParts.ContainsKey($key))
+        {
+            throw "Signer subject '$actualSubject' is missing required field '$key' from expected subject '$ExpectedSubject'."
+        }
+
+        $actualValue = $actualSubjectParts[$key]
+        $expectedValue = $expectedSubjectParts[$key]
+        if (-not [string]::Equals($actualValue, $expectedValue, [System.StringComparison]::OrdinalIgnoreCase))
+        {
+            throw "Signer subject '$actualSubject' has '$key=$actualValue', expected '$key=$expectedValue'."
+        }
+    }
+
+    $issuerTrustMatch = Assert-SignerIssuerTrust `
+        -Evidence $evidence `
+        -ExpectedIssuerThumbprints $ExpectedIssuerSha512Thumbprints `
+        -ExpectedParentIssuerThumbprints $ExpectedParentIssuerSha512Thumbprints
+
+    Add-Member -InputObject $evidence -NotePropertyName SignerIssuerTrustMatch -NotePropertyValue $issuerTrustMatch -Force
+    Write-Verbose "Windows binary trust verification succeeded for '$($evidence.BinaryPath)'."
+    return $evidence
+}
+
+function Get-CopilotdVersionString
+{
+    param([Parameter(Mandatory)][string]$BinaryPath)
+
+    try
+    {
+        $output = & $BinaryPath --version 2>$null
+        if ($LASTEXITCODE -eq 0 -and $output)
+        {
+            $firstLine = @($output | Select-Object -First 1)[0]
+            $match = [regex]::Match($firstLine, '\d+\.\d+\.\d+(?:\.\d+)?(?:-[0-9A-Za-z\.-]+)?')
+            if ($match.Success)
+            {
+                return $match.Value
+            }
+        }
+    }
+    catch
+    {
+    }
+
+    $versionInfo = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($BinaryPath)
+    $candidate = if (-not [string]::IsNullOrWhiteSpace($versionInfo.ProductVersion))
+    {
+        $versionInfo.ProductVersion
+    }
+    else
+    {
+        $versionInfo.FileVersion
+    }
+
+    if ([string]::IsNullOrWhiteSpace($candidate))
+    {
+        throw "Could not determine version for '$BinaryPath'."
+    }
+
+    $metadataMatch = [regex]::Match($candidate, '\d+\.\d+\.\d+(?:\.\d+)?(?:-[0-9A-Za-z\.-]+)?')
+    if (-not $metadataMatch.Success)
+    {
+        throw "Version '$candidate' for '$BinaryPath' was not in an expected format."
+    }
+
+    return $metadataMatch.Value
+}
+
+function Parse-SemanticVersion
+{
+    param([Parameter(Mandatory)][string]$Value)
+
+    $match = [regex]::Match($Value, '^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?:\.\d+)?(?:-(?<prerelease>[0-9A-Za-z\.-]+))?$')
+    if (-not $match.Success)
+    {
+        throw "Version '$Value' is not a supported semantic version format."
+    }
+
+    return [ordered]@{
+        Major = [int]$match.Groups['major'].Value
+        Minor = [int]$match.Groups['minor'].Value
+        Patch = [int]$match.Groups['patch'].Value
+        PreRelease = $match.Groups['prerelease'].Value
+    }
+}
+
+function Compare-SemanticVersion
+{
+    param(
+        [Parameter(Mandatory)][string]$Left,
+        [Parameter(Mandatory)][string]$Right
+    )
+
+    $leftVersion = Parse-SemanticVersion -Value $Left
+    $rightVersion = Parse-SemanticVersion -Value $Right
+
+    foreach ($part in @('Major', 'Minor', 'Patch'))
+    {
+        if ($leftVersion[$part] -gt $rightVersion[$part])
+        {
+            return 1
+        }
+
+        if ($leftVersion[$part] -lt $rightVersion[$part])
+        {
+            return -1
+        }
+    }
+
+    $leftPre = $leftVersion.PreRelease
+    $rightPre = $rightVersion.PreRelease
+    if ([string]::IsNullOrWhiteSpace($leftPre) -and [string]::IsNullOrWhiteSpace($rightPre))
+    {
+        return 0
+    }
+
+    if ([string]::IsNullOrWhiteSpace($leftPre))
+    {
+        return 1
+    }
+
+    if ([string]::IsNullOrWhiteSpace($rightPre))
+    {
+        return -1
+    }
+
+    $leftIdentifiers = $leftPre.Split('.', [System.StringSplitOptions]::RemoveEmptyEntries)
+    $rightIdentifiers = $rightPre.Split('.', [System.StringSplitOptions]::RemoveEmptyEntries)
+    $maxLength = [Math]::Max($leftIdentifiers.Length, $rightIdentifiers.Length)
+
+    for ($index = 0; $index -lt $maxLength; $index++)
+    {
+        if ($index -ge $leftIdentifiers.Length)
+        {
+            return -1
+        }
+
+        if ($index -ge $rightIdentifiers.Length)
+        {
+            return 1
+        }
+
+        $leftIdentifier = $leftIdentifiers[$index]
+        $rightIdentifier = $rightIdentifiers[$index]
+        $leftIsNumeric = $leftIdentifier -match '^\d+$'
+        $rightIsNumeric = $rightIdentifier -match '^\d+$'
+
+        if ($leftIsNumeric -and $rightIsNumeric)
+        {
+            $leftNumeric = [System.Numerics.BigInteger]::Parse($leftIdentifier)
+            $rightNumeric = [System.Numerics.BigInteger]::Parse($rightIdentifier)
+            if ($leftNumeric -gt $rightNumeric)
+            {
+                return 1
+            }
+
+            if ($leftNumeric -lt $rightNumeric)
+            {
+                return -1
+            }
+
+            continue
+        }
+
+        if ($leftIsNumeric -and -not $rightIsNumeric)
+        {
+            return -1
+        }
+
+        if (-not $leftIsNumeric -and $rightIsNumeric)
+        {
+            return 1
+        }
+
+        $identifierComparison = [string]::CompareOrdinal($leftIdentifier, $rightIdentifier)
+        if ($identifierComparison -gt 0)
+        {
+            return 1
+        }
+
+        if ($identifierComparison -lt 0)
+        {
+            return -1
+        }
+    }
+
+    return 0
+}
+
+function Invoke-CopilotdInstall
+{
+    $architecture = Get-WindowsArchitecture
+    $assetName = "copilotd-win-$architecture.zip"
+    Write-Verbose "Selecting release asset '$assetName' for quality '$Quality' from '$Repository'."
+
+    $release = Get-ReleaseForQuality -Repo $Repository -SelectedQuality $Quality -AssetName $assetName
+    Write-Verbose "Selected release '$($release.name)' ($($release.tag_name))."
+    $releaseStatusLabel = Get-ReleaseStatusLabel -SelectedQuality $Quality -Release $release
+
+    $asset = Get-ReleaseAsset -Release $release -AssetName $assetName
+    if ($null -eq $asset)
+    {
+        throw "Release '$($release.name)' does not contain expected asset '$assetName'."
+    }
+
+    if ($Quality -eq 'Dev' -and -not $Force)
+    {
+        $confirmation = Read-Host "Dev quality disables checksum/signature verification. Type YES to continue"
+        if ($confirmation -cne 'YES')
+        {
+            throw 'Installation canceled by user.'
+        }
+    }
+
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("copilotd-install-" + [guid]::NewGuid().ToString('N'))
+    $downloadPath = Join-Path $tempRoot $assetName
+    $extractPath = Join-Path $tempRoot 'extract'
+
+    Write-Verbose "Using temporary workspace '$tempRoot'."
+
+    try
+    {
+        New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
+
+        Invoke-StatusStep -Message "Downloading $releaseStatusLabel" -Action {
+            Write-Verbose "Downloading release asset from '$($asset.browser_download_url)' to '$downloadPath'."
+            Invoke-GitHubAssetDownload -Uri $asset.browser_download_url -OutFile $downloadPath
+        }
+
+        if ($Quality -ne 'Dev')
+        {
+            $checksumsAsset = Get-ReleaseAsset -Release $release -AssetName 'checksums.txt'
+            if ($null -eq $checksumsAsset)
+            {
+                throw "Release '$($release.name)' did not include checksums.txt."
+            }
+
+            $checksumsPath = Join-Path $tempRoot 'checksums.txt'
+            Write-Verbose "Downloading checksums from '$($checksumsAsset.browser_download_url)' to '$checksumsPath'."
+            Invoke-GitHubAssetDownload -Uri $checksumsAsset.browser_download_url -OutFile $checksumsPath
+
+            $releaseMetadataPath = $null
+            $releaseMetadataAsset = Get-ReleaseAsset -Release $release -AssetName 'release-metadata.json'
+            if ($null -ne $releaseMetadataAsset)
+            {
+                $releaseMetadataPath = Join-Path $tempRoot 'release-metadata.json'
+                Write-Verbose "Downloading release metadata from '$($releaseMetadataAsset.browser_download_url)' to '$releaseMetadataPath'."
+                Invoke-GitHubAssetDownload -Uri $releaseMetadataAsset.browser_download_url -OutFile $releaseMetadataPath
+            }
+
+            Invoke-StatusStep -Message 'Verifying asset checksums' -Action {
+                $null = Assert-WindowsArchiveIntegrity -ArchivePath $downloadPath -AssetName $assetName -ChecksumsPath $checksumsPath -ReleaseMetadataPath $releaseMetadataPath
+            }
+        }
+
+        $downloadedBinaryPath = Expand-WindowsReleaseArchive -ArchivePath $downloadPath -DestinationPath $extractPath
+
+        if ($Quality -ne 'Dev')
+        {
+            Invoke-StatusStep -Message 'Verifying asset provenance' -Action {
+                $null = Assert-WindowsBinaryTrust -BinaryPath $downloadedBinaryPath -ExpectedSubject $ExpectedSignerSubject -ExpectedIssuerSha512Thumbprints $ExpectedSignerIssuerSha512Thumbprints -ExpectedParentIssuerSha512Thumbprints $ExpectedSignerParentIssuerSha512Thumbprints
+            }
+        }
+        else
+        {
+            Write-Host 'Skipping checksum and provenance verification for development build.'
+        }
+
+        $installDirectory = [System.IO.Path]::GetFullPath($TargetPath)
+        Write-Verbose "Installing to '$installDirectory'."
+        New-Item -ItemType Directory -Path $installDirectory -Force | Out-Null
+
+        $destinationPath = Join-Path $installDirectory 'copilotd.exe'
+        $downloadedVersion = Get-CopilotdVersionString -BinaryPath $downloadedBinaryPath
+        $installedVersion = $downloadedVersion
+        Write-Verbose "Downloaded copilotd.exe version: '$downloadedVersion'."
+
+        $shouldInstall = $true
+        if (Test-Path $destinationPath)
+        {
+            $existingVersion = Get-CopilotdVersionString -BinaryPath $destinationPath
+            $comparison = Compare-SemanticVersion -Left $downloadedVersion -Right $existingVersion
+            Write-Verbose "Existing copilotd.exe version at '$destinationPath': '$existingVersion'. Comparison result: $comparison."
+            if ($comparison -le 0)
+            {
+                $shouldInstall = $false
+                $installedVersion = $existingVersion
+                Write-Host "Existing copilotd.exe version '$existingVersion' is newer than or equal to downloaded version '$downloadedVersion'; skipping overwrite."
+            }
+        }
+
+        if ($shouldInstall)
+        {
+            Invoke-StatusStep -Message "Installing $downloadedVersion to '$installDirectory'" -Action {
+                Copy-Item -Path $downloadedBinaryPath -Destination $destinationPath -Force
+            }
+        }
+
+        if ($UpdatePath)
+        {
+            $sessionPathUpdated = Ensure-PathContains -Entry $installDirectory -Target Process
+            $userPathUpdated = Ensure-PathContains -Entry $installDirectory -Target User
+
+            if ($sessionPathUpdated)
+            {
+                Write-Host "Added '$installDirectory' to current session PATH."
+            }
+            else
+            {
+                Write-Host "Current session PATH already contains '$installDirectory'."
+            }
+
+            if ($userPathUpdated)
+            {
+                Write-Host "Added '$installDirectory' to user PATH (will take effect in new terminal sessions)."
+            }
+            else
+            {
+                Write-Host "User PATH already contains '$installDirectory'."
+            }
+        }
+        else
+        {
+            Write-Host "Skipped PATH updates because -UpdatePath was set to false."
+        }
+
+        Write-Host "copilotd $installedVersion is ready to use from '$installDirectory'." -ForegroundColor Green
+    }
+    finally
+    {
+        if (Test-Path $tempRoot)
+        {
+            Write-Verbose "Cleaning up temporary workspace '$tempRoot'."
+            Remove-Item -Path $tempRoot -Recurse -Force
+        }
+    }
+}
+
+if (-not $NoExecute)
+{
+    Invoke-CopilotdInstall
+}

--- a/scripts/version.cs
+++ b/scripts/version.cs
@@ -1,0 +1,368 @@
+#!/usr/bin/env dotnet
+#:package NuGet.Versioning@6.13.1
+#:package System.CommandLine@2.0.3
+#:property PublishAot=false
+
+using System.CommandLine;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using NuGet.Versioning;
+
+var jsonOptions = new JsonSerializerOptions
+{
+    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    WriteIndented = true
+};
+
+var rootCommand = new RootCommand("Version management tool for copilotd release workflows.");
+
+var stateCommand = new Command("state", "Read version state from the dev draft release.");
+var bodyOption = new Option<string?>("--body") { Description = "Release body content to parse." };
+var releasesJsonOption = new Option<string?>("--releases-json") { Description = "JSON array of releases for initialization." };
+stateCommand.Options.Add(bodyOption);
+stateCommand.Options.Add(releasesJsonOption);
+stateCommand.SetAction(parseResult => ExecuteHandled(() =>
+{
+    var body = parseResult.GetValue(bodyOption);
+    var releasesJson = parseResult.GetValue(releasesJsonOption);
+    VersionState state;
+
+    if (!string.IsNullOrEmpty(body))
+    {
+        state = ParseStateFromBody(body);
+    }
+    else if (!string.IsNullOrEmpty(releasesJson))
+    {
+        state = InitializeFromReleases(releasesJson);
+    }
+    else
+    {
+        state = new VersionState("0.0.1", "pre", 1, 0, "none");
+    }
+
+    Console.WriteLine(JsonSerializer.Serialize(state, jsonOptions));
+}));
+rootCommand.Subcommands.Add(stateCommand);
+
+var calculateCommand = new Command("calculate", "Calculate dev and RC versions from state.");
+var stateJsonOption = new Option<string>("--state") { Description = "Version state as JSON.", Required = true };
+calculateCommand.Options.Add(stateJsonOption);
+calculateCommand.SetAction(parseResult => ExecuteHandled(() =>
+{
+    var stateJson = parseResult.GetValue(stateJsonOption)!;
+    var state = JsonSerializer.Deserialize<VersionState>(stateJson, jsonOptions)
+        ?? throw new ArgumentException("Invalid state JSON.");
+
+    var versions = CalculateVersions(state);
+    Console.WriteLine(JsonSerializer.Serialize(versions, jsonOptions));
+}));
+rootCommand.Subcommands.Add(calculateCommand);
+
+var advanceCommand = new Command("advance", "Calculate the next state after a release is shipped.");
+var advanceStateOption = new Option<string>("--state") { Description = "Current version state as JSON.", Required = true };
+var shippedVersionOption = new Option<string>("--shipped-version") { Description = "The version that was just shipped.", Required = true };
+advanceCommand.Options.Add(advanceStateOption);
+advanceCommand.Options.Add(shippedVersionOption);
+advanceCommand.SetAction(parseResult => ExecuteHandled(() =>
+{
+    var stateJson = parseResult.GetValue(advanceStateOption)!;
+    var shippedVersion = parseResult.GetValue(shippedVersionOption)!;
+    var state = JsonSerializer.Deserialize<VersionState>(stateJson, jsonOptions)
+        ?? throw new ArgumentException("Invalid state JSON.");
+
+    var newState = AdvanceState(state);
+    Console.WriteLine(JsonSerializer.Serialize(newState, jsonOptions));
+}));
+rootCommand.Subcommands.Add(advanceCommand);
+
+var bumpCommand = new Command("bump", "Apply a version bump and/or phase change.");
+var bumpStateOption = new Option<string>("--state") { Description = "Current version state as JSON.", Required = true };
+var versionBumpOption = new Option<string>("--version-bump") { Description = "Version bump type: auto, patch, minor, major.", Required = true };
+var phaseOption = new Option<string>("--phase") { Description = "Target phase: pre, rc, rtm.", Required = true };
+var bumpReleasesJsonOption = new Option<string?>("--releases-json") { Description = "JSON array of shipped releases for validation." };
+bumpCommand.Options.Add(bumpStateOption);
+bumpCommand.Options.Add(versionBumpOption);
+bumpCommand.Options.Add(phaseOption);
+bumpCommand.Options.Add(bumpReleasesJsonOption);
+bumpCommand.SetAction(parseResult => ExecuteHandled(() =>
+{
+    var stateJson = parseResult.GetValue(bumpStateOption)!;
+    var versionBump = parseResult.GetValue(versionBumpOption)!;
+    var phase = parseResult.GetValue(phaseOption)!;
+    var releasesJson = parseResult.GetValue(bumpReleasesJsonOption);
+    var state = JsonSerializer.Deserialize<VersionState>(stateJson, jsonOptions)
+        ?? throw new ArgumentException("Invalid state JSON.");
+
+    var result = BumpVersion(state, versionBump, phase, releasesJson);
+    if (!result.Valid)
+    {
+        Fail(result.Reason ?? "Version bump validation failed.");
+    }
+
+    Console.WriteLine(JsonSerializer.Serialize(result.NewState, jsonOptions));
+}));
+rootCommand.Subcommands.Add(bumpCommand);
+
+var validateCommand = new Command("validate", "Check whether a version is valid compared to shipped releases.");
+var versionOption = new Option<string>("--version") { Description = "Version to validate.", Required = true };
+var validateReleasesJsonOption = new Option<string?>("--releases-json") { Description = "JSON array of shipped releases." };
+validateCommand.Options.Add(versionOption);
+validateCommand.Options.Add(validateReleasesJsonOption);
+validateCommand.SetAction(parseResult => ExecuteHandled(() =>
+{
+    var version = parseResult.GetValue(versionOption)!;
+    var releasesJson = parseResult.GetValue(validateReleasesJsonOption);
+    var result = ValidateVersion(version, releasesJson);
+    Console.WriteLine(JsonSerializer.Serialize(result, jsonOptions));
+
+    if (!result.Valid)
+    {
+        Environment.Exit(1);
+    }
+}));
+rootCommand.Subcommands.Add(validateCommand);
+
+return rootCommand.Parse(args).Invoke();
+
+static VersionState ParseStateFromBody(string body)
+{
+    var match = Regex.Match(body, @"<!--\s*VERSION_STATE:\s*([^|]+)\|([^|]+)\|([^|]+)\|([^|]+)\|([^>\s]+)\s*-->");
+    if (!match.Success)
+    {
+        throw new ArgumentException("Could not parse VERSION_STATE from the dev release body. Ensure it still contains a comment like <!-- VERSION_STATE: <base>|<phase>|<phaseNumber>|<devNumber>|<pending> -->.");
+    }
+
+    if (!int.TryParse(match.Groups[3].Value.Trim(), out var phaseNumber))
+    {
+        throw new ArgumentException("VERSION_STATE contains an invalid phase number.");
+    }
+
+    if (!int.TryParse(match.Groups[4].Value.Trim(), out var devNumber))
+    {
+        throw new ArgumentException("VERSION_STATE contains an invalid dev number.");
+    }
+
+    return new VersionState(
+        match.Groups[1].Value.Trim(),
+        match.Groups[2].Value.Trim(),
+        phaseNumber,
+        devNumber,
+        match.Groups[5].Value.Trim());
+}
+
+static void ExecuteHandled(Action action)
+{
+    try
+    {
+        action();
+    }
+    catch (ArgumentException ex)
+    {
+        Fail(ex.Message);
+    }
+    catch (FormatException ex)
+    {
+        Fail(ex.Message);
+    }
+    catch (JsonException ex)
+    {
+        Fail($"Invalid JSON input: {ex.Message}");
+    }
+}
+
+static void Fail(string message)
+{
+    Console.Error.WriteLine($"Error: {message}");
+    Environment.Exit(1);
+}
+
+static VersionState InitializeFromReleases(string releasesJson)
+{
+    var releases = JsonSerializer.Deserialize<List<ReleaseInfo>>(releasesJson, new JsonSerializerOptions
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    }) ?? [];
+
+    var latestStable = releases
+        .Where(r => !r.IsDraft && !r.IsPrerelease)
+        .Select(r => r.TagName.TrimStart('v'))
+        .Where(v => NuGetVersion.TryParse(v, out _))
+        .Select(NuGetVersion.Parse)
+        .OrderByDescending(v => v)
+        .FirstOrDefault();
+
+    if (latestStable is null)
+    {
+        return new VersionState("0.0.1", "pre", 1, 0, "none");
+    }
+
+    var nextVersion = latestStable.Major == 0
+        ? new NuGetVersion(latestStable.Major, latestStable.Minor, latestStable.Patch + 1)
+        : new NuGetVersion(latestStable.Major, latestStable.Minor + 1, 0);
+
+    return new VersionState(nextVersion.ToNormalizedString(), "pre", 1, 0, "none");
+}
+
+static CalculatedVersions CalculateVersions(VersionState state)
+{
+    var devNumber = state.DevNumber + 1;
+    var devVersion = state.Phase switch
+    {
+        "pre" => $"{state.Base}-pre.{state.PhaseNumber}.dev.{devNumber}",
+        "rc" => $"{state.Base}-rc.{state.PhaseNumber}.dev.{devNumber}",
+        "rtm" => $"{state.Base}-rtm.dev.{devNumber}",
+        _ => throw new ArgumentException($"Unknown phase: {state.Phase}")
+    };
+
+    var rcVersion = state.Phase switch
+    {
+        "pre" => $"{state.Base}-pre.{state.PhaseNumber}.rel",
+        "rc" => $"{state.Base}-rc.{state.PhaseNumber}.rel",
+        "rtm" => state.Base,
+        _ => throw new ArgumentException($"Unknown phase: {state.Phase}")
+    };
+
+    var nextState = $"{state.Base}|{state.Phase}|{state.PhaseNumber}|{devNumber}|none";
+    return new CalculatedVersions(devVersion, rcVersion, nextState);
+}
+
+static VersionState AdvanceState(VersionState state)
+{
+    return state.Phase switch
+    {
+        "pre" or "rc" => new VersionState(state.Base, state.Phase, state.PhaseNumber + 1, 0, "none"),
+        "rtm" => new VersionState(BumpBaseVersion(state.Base), "pre", 1, 0, "none"),
+        _ => throw new ArgumentException($"Unknown phase: {state.Phase}")
+    };
+}
+
+static BumpResult BumpVersion(VersionState state, string versionBump, string targetPhase, string? releasesJson)
+{
+    if (targetPhase is not ("pre" or "rc" or "rtm"))
+    {
+        return new BumpResult(false, $"Unknown phase: {targetPhase}.", null);
+    }
+
+    var currentOrder = PhaseOrder(state.Phase);
+    var targetOrder = PhaseOrder(targetPhase);
+    var newBase = state.Base;
+
+    switch (versionBump.ToLowerInvariant())
+    {
+        case "auto":
+            if (targetOrder <= currentOrder)
+            {
+                newBase = BumpBaseVersion(state.Base);
+            }
+            break;
+        case "patch":
+        case "minor":
+        case "major":
+            newBase = BumpBaseVersion(state.Base, versionBump.ToLowerInvariant());
+            break;
+        default:
+            return new BumpResult(false, $"Unknown version bump type: {versionBump}.", null);
+    }
+
+    if (newBase == state.Base && targetPhase == state.Phase)
+    {
+        return new BumpResult(false, "No effective change was requested.", null);
+    }
+
+    var newState = new VersionState(newBase, targetPhase, targetPhase == "rtm" ? 0 : 1, 0, "none");
+    var proposedReleaseVersion = targetPhase == "rtm"
+        ? newBase
+        : $"{newBase}-{targetPhase}.1.rel";
+
+    var validation = ValidateVersion(proposedReleaseVersion, releasesJson);
+    if (!validation.Valid)
+    {
+        return new BumpResult(false, validation.Reason, null);
+    }
+
+    return new BumpResult(true, null, newState);
+}
+
+static ValidationResult ValidateVersion(string version, string? releasesJson)
+{
+    if (!NuGetVersion.TryParse(version, out var proposedVersion))
+    {
+        return new ValidationResult(false, $"Invalid version format: {version}");
+    }
+
+    if (string.IsNullOrEmpty(releasesJson))
+    {
+        return new ValidationResult(true, null);
+    }
+
+    var releases = JsonSerializer.Deserialize<List<ReleaseInfo>>(releasesJson, new JsonSerializerOptions
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    }) ?? [];
+
+    var shippedVersions = releases
+        .Where(r => !r.IsDraft)
+        .Select(r => r.TagName.TrimStart('v'))
+        .Where(v => NuGetVersion.TryParse(v, out _))
+        .Select(NuGetVersion.Parse)
+        .ToList();
+
+    foreach (var shipped in shippedVersions)
+    {
+        if (proposedVersion <= shipped)
+        {
+            return new ValidationResult(false, $"Version {version} is not greater than existing release {shipped}.");
+        }
+    }
+
+    return new ValidationResult(true, null);
+}
+
+static int PhaseOrder(string phase) => phase switch
+{
+    "pre" => 0,
+    "rc" => 1,
+    "rtm" => 2,
+    _ => throw new ArgumentException($"Unknown phase: {phase}")
+};
+
+static string BumpBaseVersion(string version, string bump = "auto")
+{
+    var parsed = NuGetVersion.Parse(version);
+    return bump switch
+    {
+        "major" => new NuGetVersion(parsed.Major + 1, 0, 0).ToNormalizedString(),
+        "minor" => new NuGetVersion(parsed.Major, parsed.Minor + 1, 0).ToNormalizedString(),
+        "patch" => new NuGetVersion(parsed.Major, parsed.Minor, parsed.Patch + 1).ToNormalizedString(),
+        _ => parsed.Major == 0
+            ? new NuGetVersion(parsed.Major, parsed.Minor, parsed.Patch + 1).ToNormalizedString()
+            : new NuGetVersion(parsed.Major, parsed.Minor + 1, 0).ToNormalizedString()
+    };
+}
+
+internal sealed record VersionState(
+    [property: JsonPropertyName("base")] string Base,
+    [property: JsonPropertyName("phase")] string Phase,
+    [property: JsonPropertyName("phaseNumber")] int PhaseNumber,
+    [property: JsonPropertyName("devNumber")] int DevNumber,
+    [property: JsonPropertyName("pending")] string Pending);
+
+internal sealed record CalculatedVersions(
+    [property: JsonPropertyName("devVersion")] string DevVersion,
+    [property: JsonPropertyName("rcVersion")] string RcVersion,
+    [property: JsonPropertyName("nextState")] string NextState);
+
+internal sealed record BumpResult(
+    [property: JsonPropertyName("valid")] bool Valid,
+    [property: JsonPropertyName("reason")] string? Reason,
+    [property: JsonPropertyName("newState")] VersionState? NewState);
+
+internal sealed record ValidationResult(
+    [property: JsonPropertyName("valid")] bool Valid,
+    [property: JsonPropertyName("reason")] string? Reason);
+
+internal sealed record ReleaseInfo(
+    [property: JsonPropertyName("tagName")] string TagName,
+    [property: JsonPropertyName("isDraft")] bool IsDraft,
+    [property: JsonPropertyName("isPrerelease")] bool IsPrerelease);


### PR DESCRIPTION
- CI workflow (ci.yml): version calculation, build, NativeAOT publish for 6 RIDs, dev/RC bundling, draft release management
- PR workflow (pr.yml): PowerShell syntax validation, build, NativeAOT publish validation on 3 platforms
- Release workflow (release.yml): RC bundle download, Windows code signing via Azure, GitHub release creation, version state advancement
- Install scripts workflow (install-scripts.yml): sign and publish the public install script to a standing release
- Bump version workflow (bump-version.yml): manual version bump with phase transitions (pre/rc/rtm)
- Build composite action (.github/actions/build): restore, build, and optional NativeAOT publish validation
- Version management tool (scripts/version.cs): state tracking, calculation, bump, advance, and validation
- Native publish and bundling scripts for cross-platform release assets
- Windows code signing support scripts (expand, compress, verify issuer)
- PowerShell installer script with checksum and provenance verification
- Updated Directory.Build.props with Version, RepositoryUrl, and CI build properties