### PR TITLE
Add git worktree isolation and prompt.md file support

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -66,6 +66,16 @@ Reflection-based serialization is disabled. Adding a new persisted model require
 - State is saved immediately after each process launch to prevent ghost processes on crash
 - Corrupt/missing files are treated as empty (self-healing) with a logged warning
 - Single-instance guard via exclusive `FileStream` on `~/.copilotd/.lock`
+- Prompt template loaded from `~/.copilotd/prompt.md` (falls back to `config.Prompt`)
+
+### Worktree Isolation
+
+Each dispatched session works in its own git worktree:
+- Layout: `<repo_home>/org/repo_sessions/issue-N/` (sibling to main checkout)
+- Created via `git -C <main-repo> worktree add <path> -b copilotd/issue-N origin/<default-branch>`
+- Cleaned up via `git worktree remove` on completion, reset, or pruning
+- `WorktreePath` is tracked on `DispatchSession` and used as working directory + `--add-dir` target
+- `PrepareWorktree` fetches origin first to ensure latest default branch HEAD
 
 ### Console Output
 

--- a/README.md
+++ b/README.md
@@ -210,8 +210,34 @@ Log files are written to `$TEMP/copilotd/logs/` with daily rollover.
 - **Spectre.Console** for interactive prompts and formatted output
 - **Native AOT** compatible (source-generated JSON serialization)
 - Dispatched `copilot` processes are fully independent (not child processes)
+- Each session gets its own **git worktree** for isolation — multiple sessions on the same repo work in parallel without conflicts
 - State reconciliation uses three truth sources: persisted state → live process status → current GitHub issue matches
 - Graceful process shutdown via platform-specific signals (Ctrl+Break/Ctrl+C on Windows via helper process, SIGINT/SIGKILL on Unix)
+
+### Worktree isolation
+
+Each dispatched session works in its own git worktree on a new branch, ensuring:
+- **No conflicts** between concurrent sessions on the same repo
+- **Clean starting state** from the latest default branch HEAD
+- **Isolated branches** — each session creates `copilotd/issue-<N>`
+
+Directory layout:
+
+```
+<repo_home>/org/repo/                    ← main checkout (fetch-only base)
+<repo_home>/org/repo_sessions/issue-1/   ← worktree for issue #1
+<repo_home>/org/repo_sessions/issue-5/   ← worktree for issue #5
+```
+
+Worktrees are created before dispatch (`git fetch` + `git worktree add`) and cleaned up
+when sessions complete, are reset, or are pruned.
+
+### Prompt customization
+
+The prompt template is stored at `~/.copilotd/prompt.md` (created during `copilotd init`).
+Edit this file to customize the instructions given to dispatched copilot sessions. Token
+replacement is applied at dispatch time. Per-rule extra prompts are appended after the base
+prompt.
 
 ## License
 

--- a/src/copilotd/Commands/InitCommand.cs
+++ b/src/copilotd/Commands/InitCommand.cs
@@ -128,6 +128,7 @@ public static class InitCommand
                 }
 
                 stateStore.SaveConfig(config);
+                stateStore.EnsurePromptFile();
                 ConsoleOutput.Success("Configuration saved successfully!");
                 ConsoleOutput.Info($"Config stored in: {stateStore.ConfigDir}");
 

--- a/src/copilotd/Commands/SessionCommand.cs
+++ b/src/copilotd/Commands/SessionCommand.cs
@@ -121,10 +121,11 @@ public static class SessionCommand
                     return 1;
                 }
 
-                var repoPath = Path.Combine(config.RepoHome ?? ".", session.Repo);
-                if (!Directory.Exists(repoPath))
+                // Use worktree path if available, otherwise fall back to main repo
+                var workingDir = session.WorktreePath ?? Path.Combine(config.RepoHome ?? ".", session.Repo);
+                if (!Directory.Exists(workingDir))
                 {
-                    ConsoleOutput.Error($"Repo directory not found: {repoPath}");
+                    ConsoleOutput.Error($"Working directory not found: {workingDir}");
                     return 1;
                 }
 
@@ -147,6 +148,8 @@ public static class SessionCommand
                 stateStore.SaveState(state);
 
                 ConsoleOutput.Success($"Joining session {session.CopilotSessionId} for {issueKey}");
+                if (session.WorktreePath is not null)
+                    ConsoleOutput.Info($"Working directory: {session.WorktreePath}");
                 ConsoleOutput.Info("Press Ctrl+C to exit the interactive session.");
                 Console.WriteLine();
 
@@ -155,7 +158,7 @@ public static class SessionCommand
                 {
                     FileName = "copilot",
                     Arguments = $"--resume={session.CopilotSessionId}",
-                    WorkingDirectory = repoPath,
+                    WorkingDirectory = workingDir,
                     UseShellExecute = false,
                     RedirectStandardInput = false,
                     RedirectStandardOutput = false,
@@ -273,7 +276,9 @@ public static class SessionCommand
             return await ConsoleOutput.RunWithErrorHandling(async () =>
             {
                 var stateStore = services.GetRequiredService<StateStore>();
+                var processManager = services.GetRequiredService<ProcessManager>();
                 var state = stateStore.LoadState();
+                var config = stateStore.LoadConfig();
 
                 var issueKey = parseResult.GetValue(issueArg)!;
 
@@ -289,11 +294,15 @@ public static class SessionCommand
                     return 0;
                 }
 
+                // Clean up old worktree before resetting
+                processManager.CleanupWorktree(session, config);
+
                 session.Status = SessionStatus.Pending;
                 session.CompletedBySession = false;
                 session.CopilotSessionId = Guid.NewGuid().ToString();
                 session.ProcessId = null;
                 session.ProcessStartTime = null;
+                session.WorktreePath = null;
                 session.RetryCount = 0;
                 session.LastFailureAt = null;
                 session.UpdatedAt = DateTimeOffset.UtcNow;
@@ -405,6 +414,7 @@ public static class SessionCommand
         table.AddColumn("Status");
         table.AddColumn("PID");
         table.AddColumn("Session ID");
+        table.AddColumn("Worktree");
         table.AddColumn("Created");
         table.AddColumn("Updated");
 
@@ -424,6 +434,7 @@ public static class SessionCommand
             var sessionId = string.IsNullOrEmpty(s.CopilotSessionId)
                 ? "-"
                 : s.CopilotSessionId;
+            var worktree = string.IsNullOrEmpty(s.WorktreePath) ? "-" : s.WorktreePath;
 
             table.AddRow(
                 Markup.Escape(s.IssueKey),
@@ -431,6 +442,7 @@ public static class SessionCommand
                 statusMarkup,
                 Markup.Escape(pid),
                 Markup.Escape(sessionId),
+                Markup.Escape(worktree),
                 FormatTime(s.CreatedAt),
                 FormatTime(s.UpdatedAt)
             );

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -14,10 +14,12 @@ public sealed partial class ProcessManager
     private static readonly TimeSpan SignalDelay = TimeSpan.FromSeconds(2);
     private static readonly TimeSpan GracefulTimeout = TimeSpan.FromSeconds(10);
 
+    private readonly StateStore _stateStore;
     private readonly ILogger<ProcessManager> _logger;
 
-    public ProcessManager(ILogger<ProcessManager> logger)
+    public ProcessManager(StateStore stateStore, ILogger<ProcessManager> logger)
     {
+        _stateStore = stateStore;
         _logger = logger;
     }
 
@@ -27,14 +29,16 @@ public sealed partial class ProcessManager
     /// </summary>
     public DispatchSession? LaunchCopilot(DispatchSession session, CopilotdConfig config, GitHubIssue issue)
     {
-        var repoPath = Path.Combine(config.RepoHome ?? ".", issue.Repo);
+        // Use worktree path if available, otherwise fall back to main repo path
+        var repoPath = session.WorktreePath ?? Path.Combine(config.RepoHome ?? ".", issue.Repo);
         if (!Directory.Exists(repoPath))
         {
-            _logger.LogWarning("Repo directory not found: {Path}", repoPath);
+            _logger.LogWarning("Working directory not found: {Path}", repoPath);
             return null;
         }
 
-        var prompt = BuildPrompt(config, issue, session);
+        var promptTemplate = _stateStore.LoadPromptTemplate(config);
+        var prompt = BuildPrompt(promptTemplate, issue, session, config);
         var args = BuildArguments(session, prompt, config.Rules.GetValueOrDefault(session.RuleName), repoPath);
 
         _logger.LogInformation("Launching copilot for {IssueKey} with session {SessionId}", session.IssueKey, session.CopilotSessionId);
@@ -348,9 +352,9 @@ public sealed partial class ProcessManager
         return true;
     }
 
-    private static string BuildPrompt(CopilotdConfig config, GitHubIssue issue, DispatchSession session)
+    private static string BuildPrompt(string template, GitHubIssue issue, DispatchSession session, CopilotdConfig config)
     {
-        var prompt = config.Prompt
+        var prompt = template
             .Replace("$(issue.repo)", issue.Repo)
             .Replace("$(issue.id)", issue.Number.ToString())
             .Replace("$(issue.type)", issue.Type ?? "issue")
@@ -359,7 +363,7 @@ public sealed partial class ProcessManager
         var rule = config.Rules.GetValueOrDefault(session.RuleName);
         if (!string.IsNullOrWhiteSpace(rule?.ExtraPrompt))
         {
-            prompt += " " + rule.ExtraPrompt;
+            prompt += "\n\n" + rule.ExtraPrompt;
         }
 
         return prompt;
@@ -412,6 +416,161 @@ public sealed partial class ProcessManager
         {
             return null;
         }
+    }
+
+    // ---- Worktree lifecycle ----
+
+    /// <summary>
+    /// Creates a git worktree for the session on a new branch from the latest default branch.
+    /// Layout: &lt;repo_home&gt;/org/repo_sessions/issue-N/
+    /// </summary>
+    public bool PrepareWorktree(DispatchSession session, CopilotdConfig config)
+    {
+        var mainRepoPath = Path.Combine(config.RepoHome ?? ".", session.Repo);
+        if (!Directory.Exists(mainRepoPath))
+        {
+            _logger.LogWarning("Main repo directory not found: {Path}", mainRepoPath);
+            return false;
+        }
+
+        // Session dir: <repo_home>/org/repo_sessions/issue-N/
+        var sessionsDir = mainRepoPath + "_sessions";
+        var worktreePath = Path.Combine(sessionsDir, $"issue-{session.IssueNumber}");
+        var branchName = $"copilotd/issue-{session.IssueNumber}";
+
+        // If the worktree already exists from a prior run, remove it first
+        if (Directory.Exists(worktreePath))
+        {
+            _logger.LogDebug("Removing existing worktree at {Path}", worktreePath);
+            RunGit(mainRepoPath, $"worktree remove \"{worktreePath}\" --force");
+            // Also delete the branch if it exists from a prior run
+            RunGit(mainRepoPath, $"branch -D {branchName}");
+        }
+
+        Directory.CreateDirectory(sessionsDir);
+
+        // Fetch latest from origin
+        _logger.LogDebug("Fetching latest from origin for {Repo}", session.Repo);
+        if (!RunGit(mainRepoPath, "fetch origin"))
+        {
+            _logger.LogWarning("Failed to fetch origin for {Repo}", session.Repo);
+            return false;
+        }
+
+        // Determine default branch (origin/HEAD → origin/main or origin/master)
+        var defaultBranch = GetDefaultBranch(mainRepoPath);
+        if (defaultBranch is null)
+        {
+            _logger.LogWarning("Could not determine default branch for {Repo}", session.Repo);
+            return false;
+        }
+
+        // Create worktree on a new branch from origin's default branch
+        _logger.LogInformation("Creating worktree for {Key} at {Path} from {Branch}",
+            session.IssueKey, worktreePath, defaultBranch);
+
+        if (!RunGit(mainRepoPath, $"worktree add \"{worktreePath}\" -b {branchName} {defaultBranch}"))
+        {
+            _logger.LogWarning("Failed to create worktree for {Key}", session.IssueKey);
+            return false;
+        }
+
+        session.WorktreePath = worktreePath;
+        _logger.LogInformation("Worktree ready for {Key} at {Path}", session.IssueKey, worktreePath);
+        return true;
+    }
+
+    /// <summary>
+    /// Removes the git worktree and branch associated with a session.
+    /// </summary>
+    public void CleanupWorktree(DispatchSession session, CopilotdConfig config)
+    {
+        if (string.IsNullOrEmpty(session.WorktreePath))
+            return;
+
+        var mainRepoPath = Path.Combine(config.RepoHome ?? ".", session.Repo);
+        var branchName = $"copilotd/issue-{session.IssueNumber}";
+
+        _logger.LogDebug("Cleaning up worktree for {Key} at {Path}", session.IssueKey, session.WorktreePath);
+
+        if (Directory.Exists(session.WorktreePath))
+        {
+            RunGit(mainRepoPath, $"worktree remove \"{session.WorktreePath}\" --force");
+        }
+
+        // Delete the local branch (it was only used for this session)
+        RunGit(mainRepoPath, $"branch -D {branchName}");
+
+        session.WorktreePath = null;
+    }
+
+    private static string? GetDefaultBranch(string repoPath)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "git",
+                Arguments = "rev-parse --abbrev-ref origin/HEAD",
+                WorkingDirectory = repoPath,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+            };
+
+            using var process = Process.Start(psi);
+            if (process is null) return null;
+
+            var output = process.StandardOutput.ReadToEnd().Trim();
+            process.WaitForExit(TimeSpan.FromSeconds(10));
+
+            if (process.ExitCode == 0 && !string.IsNullOrEmpty(output) && output != "origin/HEAD")
+                return output;
+
+            // Fallback: try origin/main then origin/master
+            return RunGitCheck(repoPath, "rev-parse --verify origin/main") ? "origin/main"
+                : RunGitCheck(repoPath, "rev-parse --verify origin/master") ? "origin/master"
+                : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static bool RunGit(string workingDir, string arguments)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "git",
+                Arguments = arguments,
+                WorkingDirectory = workingDir,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+            };
+
+            using var process = Process.Start(psi);
+            if (process is null) return false;
+
+            process.StandardOutput.ReadToEnd();
+            process.StandardError.ReadToEnd();
+            process.WaitForExit(TimeSpan.FromSeconds(30));
+            return process.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool RunGitCheck(string workingDir, string arguments)
+    {
+        return RunGit(workingDir, arguments);
     }
 
     #region Platform Interop

--- a/src/copilotd/Infrastructure/StateStore.cs
+++ b/src/copilotd/Infrastructure/StateStore.cs
@@ -19,6 +19,8 @@ public sealed class StateStore
 
     public string ConfigDir => _configDir;
 
+    private string PromptPath => Path.Combine(_configDir, "prompt.md");
+
     public StateStore(ILogger<StateStore> logger)
     {
         _logger = logger;
@@ -90,6 +92,53 @@ public sealed class StateStore
         var json = JsonSerializer.Serialize(state, CopilotdJsonContext.Default.DaemonState);
         AtomicWrite(_statePath, json);
         _logger.LogDebug("State saved to {Path}", _statePath);
+    }
+
+    // --- Prompt ---
+
+    /// <summary>
+    /// Loads the prompt template from ~/.copilotd/prompt.md if it exists,
+    /// falling back to the config's inline Prompt property.
+    /// </summary>
+    public string LoadPromptTemplate(CopilotdConfig config)
+    {
+        if (File.Exists(PromptPath))
+        {
+            try
+            {
+                var content = File.ReadAllText(PromptPath).Trim();
+                if (!string.IsNullOrEmpty(content))
+                {
+                    _logger.LogDebug("Loaded prompt template from {Path}", PromptPath);
+                    return content;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to read prompt.md, falling back to config prompt");
+            }
+        }
+
+        return config.Prompt;
+    }
+
+    /// <summary>
+    /// Writes the default prompt template to ~/.copilotd/prompt.md if it doesn't exist.
+    /// </summary>
+    public void EnsurePromptFile()
+    {
+        if (File.Exists(PromptPath))
+            return;
+
+        try
+        {
+            File.WriteAllText(PromptPath, CopilotdConfig.DefaultPrompt);
+            _logger.LogDebug("Created default prompt file at {Path}", PromptPath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to create prompt.md");
+        }
     }
 
     // --- Single-instance guard ---

--- a/src/copilotd/Models/CopilotdConfig.cs
+++ b/src/copilotd/Models/CopilotdConfig.cs
@@ -37,11 +37,16 @@ public sealed class CopilotdConfig
     public const string DefaultRuleName = "Default";
 
     public const string DefaultPrompt =
-        "You are working on issue #$(issue.id) in the $(issue.repo) repository. " +
-        "Read the issue details carefully and implement the requested changes. " +
-        "Follow the project's coding conventions and ensure all tests pass. " +
-        "When you have completed all the work for this issue, run " +
-        "`copilotd session complete $(issue.repo)#$(issue.id)` to mark the session as done.";
+        """
+        You are working on issue #$(issue.id) in the $(issue.repo) repository.
+        Read the issue details carefully and implement the requested changes.
+        Follow the project's coding conventions and ensure all tests pass.
+
+        Git workflow:
+        - You are already on a new branch created for this issue. Commit your changes here.
+        - When your work is complete, push the branch and create a pull request that references the issue (e.g., "Closes #$(issue.id)").
+        - After the pull request is created, run `copilotd session complete $(issue.repo)#$(issue.id)` to mark this session as done.
+        """;
 }
 
 /// <summary>

--- a/src/copilotd/Models/SessionState.cs
+++ b/src/copilotd/Models/SessionState.cs
@@ -95,6 +95,11 @@ public sealed class DispatchSession
     /// </summary>
     public bool CompletedBySession { get; set; }
 
+    /// <summary>
+    /// Path to the git worktree directory for this session. Null if using the main repo checkout.
+    /// </summary>
+    public string? WorktreePath { get; set; }
+
     /// <summary>Maximum retries before giving up (0 = unlimited).</summary>
     public const int MaxRetries = 3;
 

--- a/src/copilotd/Services/ReconciliationEngine.cs
+++ b/src/copilotd/Services/ReconciliationEngine.cs
@@ -78,6 +78,13 @@ public sealed class ReconciliationEngine
 
         foreach (var key in toRemove)
         {
+            var session = state.Sessions[key];
+            // Clean up any lingering worktree
+            if (!string.IsNullOrEmpty(session.WorktreePath))
+            {
+                var config = _stateStore.LoadConfig();
+                _processManager.CleanupWorktree(session, config);
+            }
             state.Sessions.Remove(key);
             _logger.LogDebug("Pruned terminal session {Key}", key);
         }
@@ -258,6 +265,7 @@ public sealed class ReconciliationEngine
             {
                 session.Status = SessionStatus.Completed;
                 session.UpdatedAt = DateTimeOffset.UtcNow;
+                _processManager.CleanupWorktree(session, config);
             }
         }
 
@@ -278,11 +286,13 @@ public sealed class ReconciliationEngine
                     case SessionStatus.Orphaned when existing.CanRetry:
                         _logger.LogInformation("Re-dispatching orphaned session {Key} (retry {N}/{Max})",
                             issueKey, existing.RetryCount + 1, DispatchSession.MaxRetries);
+                        _processManager.CleanupWorktree(existing, config);
                         existing.Status = SessionStatus.Pending;
                         existing.RetryCount++;
                         existing.CopilotSessionId = Guid.NewGuid().ToString();
                         existing.ProcessId = null;
                         existing.ProcessStartTime = null;
+                        existing.WorktreePath = null;
                         existing.UpdatedAt = DateTimeOffset.UtcNow;
                         existing.LastFailureAt = DateTimeOffset.UtcNow;
                         continue;
@@ -307,10 +317,12 @@ public sealed class ReconciliationEngine
                         }
                         // Issue re-appeared after completion — re-dispatch with a fresh session
                         _logger.LogInformation("Issue {Key} re-matched after completion, re-dispatching", issueKey);
+                        _processManager.CleanupWorktree(existing, config);
                         existing.Status = SessionStatus.Pending;
                         existing.CopilotSessionId = Guid.NewGuid().ToString();
                         existing.ProcessId = null;
                         existing.ProcessStartTime = null;
+                        existing.WorktreePath = null;
                         existing.UpdatedAt = DateTimeOffset.UtcNow;
                         continue;
                 }
@@ -363,6 +375,18 @@ public sealed class ReconciliationEngine
             session.Status = SessionStatus.Dispatching;
             session.UpdatedAt = DateTimeOffset.UtcNow;
 
+            // Create worktree for isolated working directory
+            if (!_processManager.PrepareWorktree(session, config))
+            {
+                _logger.LogWarning("Failed to prepare worktree for {Key}", session.IssueKey);
+                session.Status = SessionStatus.Failed;
+                session.RetryCount++;
+                session.LastFailureAt = DateTimeOffset.UtcNow;
+                session.UpdatedAt = DateTimeOffset.UtcNow;
+                _stateStore.SaveState(state);
+                continue;
+            }
+
             // We need the issue data for prompt building
             var issue = new GitHubIssue
             {
@@ -378,6 +402,8 @@ public sealed class ReconciliationEngine
                 session.RetryCount++;
                 session.LastFailureAt = DateTimeOffset.UtcNow;
                 session.UpdatedAt = DateTimeOffset.UtcNow;
+                // Clean up the worktree we just created
+                _processManager.CleanupWorktree(session, config);
             }
             // else: session was updated in-place by LaunchCopilot
 


### PR DESCRIPTION
## Summary

Each dispatched copilot session now gets its own git worktree for complete isolation — no more shared working directories between concurrent sessions.

### Worktree isolation

- Before dispatch: \git fetch origin\ + \git worktree add <session-dir> -b copilotd/issue-N origin/<default-branch>\
- Layout: \<repo_home>/org/repo_sessions/issue-N/\ (sibling to main checkout, avoids .gitignore concerns)
- Each session starts from the latest default branch HEAD on a fresh branch
- Worktrees cleaned up on: completion, reset, orphan re-dispatch, terminal pruning
- \session join\ uses the worktree directory as the working directory
- \session reset\ cleans up the old worktree before re-queuing
- New \WorktreePath\ field on \DispatchSession\ tracks the worktree location

### Prompt file (\prompt.md\)

- Prompt template moved to \~/.copilotd/prompt.md\ (created during \copilotd init\)
- Users can edit the file directly to customize session instructions
- Falls back to \config.Prompt\ if the file doesn't exist
- Updated default prompt with git workflow instructions:
  - Already on a new branch (created by worktree)
  - Push and create a PR referencing the issue
  - Call \copilotd session complete\ after PR is created

### Other changes

- Session table now shows Worktree column
- \ProcessManager\ accepts \StateStore\ for prompt loading
- Added \PrepareWorktree\, \CleanupWorktree\, \GetDefaultBranch\ helper methods
- Updated copilot-instructions.md and README.md with worktree docs