### PR TITLE
Normalize path separators for worktree paths on Windows

### DIFF
--- a/src/copilotd/Commands/SessionCommand.cs
+++ b/src/copilotd/Commands/SessionCommand.cs
@@ -122,7 +122,7 @@ public static class SessionCommand
                 }
 
                 // Use worktree path if available, otherwise fall back to main repo
-                var workingDir = session.WorktreePath ?? Path.Combine(config.RepoHome ?? ".", session.Repo);
+                var workingDir = session.WorktreePath ?? config.GetRepoPath(session.Repo);
                 if (!Directory.Exists(workingDir))
                 {
                     ConsoleOutput.Error($"Working directory not found: {workingDir}");
@@ -149,7 +149,7 @@ public static class SessionCommand
 
                 ConsoleOutput.Success($"Joining session {session.CopilotSessionId} for {issueKey}");
                 if (session.WorktreePath is not null)
-                    ConsoleOutput.Info($"Working directory: {session.WorktreePath}");
+                    ConsoleOutput.Info($"Working directory: {session.WorktreePath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar)}");
                 ConsoleOutput.Info("Press Ctrl+C to exit the interactive session.");
                 Console.WriteLine();
 
@@ -434,7 +434,9 @@ public static class SessionCommand
             var sessionId = string.IsNullOrEmpty(s.CopilotSessionId)
                 ? "-"
                 : s.CopilotSessionId;
-            var worktree = string.IsNullOrEmpty(s.WorktreePath) ? "-" : s.WorktreePath;
+            var worktree = string.IsNullOrEmpty(s.WorktreePath)
+                ? "-"
+                : s.WorktreePath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
 
             table.AddRow(
                 Markup.Escape(s.IssueKey),

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -30,7 +30,7 @@ public sealed partial class ProcessManager
     public DispatchSession? LaunchCopilot(DispatchSession session, CopilotdConfig config, GitHubIssue issue)
     {
         // Use worktree path if available, otherwise fall back to main repo path
-        var repoPath = session.WorktreePath ?? Path.Combine(config.RepoHome ?? ".", issue.Repo);
+        var repoPath = session.WorktreePath ?? config.GetRepoPath(issue.Repo);
         if (!Directory.Exists(repoPath))
         {
             _logger.LogWarning("Working directory not found: {Path}", repoPath);
@@ -426,7 +426,7 @@ public sealed partial class ProcessManager
     /// </summary>
     public bool PrepareWorktree(DispatchSession session, CopilotdConfig config)
     {
-        var mainRepoPath = Path.Combine(config.RepoHome ?? ".", session.Repo);
+        var mainRepoPath = config.GetRepoPath(session.Repo);
         if (!Directory.Exists(mainRepoPath))
         {
             _logger.LogWarning("Main repo directory not found: {Path}", mainRepoPath);
@@ -488,7 +488,7 @@ public sealed partial class ProcessManager
         if (string.IsNullOrEmpty(session.WorktreePath))
             return;
 
-        var mainRepoPath = Path.Combine(config.RepoHome ?? ".", session.Repo);
+        var mainRepoPath = config.GetRepoPath(session.Repo);
         var branchName = $"copilotd/issue-{session.IssueNumber}";
 
         _logger.LogDebug("Cleaning up worktree for {Key} at {Path}", session.IssueKey, session.WorktreePath);

--- a/src/copilotd/Models/CopilotdConfig.cs
+++ b/src/copilotd/Models/CopilotdConfig.cs
@@ -13,6 +13,13 @@ public sealed class CopilotdConfig
     public string? RepoHome { get; set; }
 
     /// <summary>
+    /// Returns the normalized local filesystem path for a given repo slug (e.g., "org/repo").
+    /// Ensures consistent path separators for the current platform.
+    /// </summary>
+    public string GetRepoPath(string repo)
+        => Path.GetFullPath(Path.Combine(RepoHome ?? ".", repo));
+
+    /// <summary>
     /// Base prompt template for dispatched copilot sessions.
     /// Supports tokens: $(issue.repo), $(issue.id), $(issue.type), $(issue.milestone).
     /// </summary>


### PR DESCRIPTION
## Summary

Fixes #7 — mixed path separators in the Worktree column (e.g., `D:\src\GitHub\DamianEdwards/kusto-cli_sessions\issue-42`) when running `copilotd status` on Windows.

## Root Cause

`session.Repo` is `org/repo` (GitHub format with forward slash). When passed to `Path.Combine(config.RepoHome, session.Repo)`, the forward slash is preserved, producing mixed separators when combined with the Windows backslash from `RepoHome`.

## Changes

- **`CopilotdConfig.GetRepoPath()`** — new helper that combines `RepoHome` with a repo slug and normalizes via `Path.GetFullPath()`, ensuring consistent platform-native separators.
- **4 call sites updated** in `ProcessManager` (`LaunchCopilot`, `PrepareWorktree`, `CleanupWorktree`) and `SessionCommand` (`session join`) to use the new helper.
- **Display normalization** — `RenderSessionTable` and `session join` output now defensively normalize `WorktreePath` separators for any existing persisted state that may have mixed separators.