### PR TITLE
Enable console logging by default for 'copilotd run'

### DIFF
--- a/src/copilotd/Commands/RunCommand.cs
+++ b/src/copilotd/Commands/RunCommand.cs
@@ -13,7 +13,7 @@ public static class RunCommand
     {
         var command = new Command("run", "Start the copilotd daemon");
         var intervalOption = new Option<int>("--interval") { Description = "Polling interval in seconds", DefaultValueFactory = _ => 60 };
-        var logLevelOption = new Option<string?>("--log-level") { Description = "Enable console logging at the specified level (debug, info, warning, error)" };
+        var logLevelOption = new Option<string?>("--log-level") { Description = "Set console logging level (default: info). Use 'debug' for more detail or 'error' for less." };
 
         command.Options.Add(intervalOption);
         command.Options.Add(logLevelOption);

--- a/src/copilotd/Program.cs
+++ b/src/copilotd/Program.cs
@@ -57,21 +57,38 @@ public class Program
 
     private static LogLevel? ParseLogLevel(string[] args)
     {
-        for (var i = 0; i < args.Length - 1; i++)
+        for (var i = 0; i < args.Length; i++)
         {
-            if (string.Equals(args[i], "--log-level", StringComparison.OrdinalIgnoreCase))
+            // Handle --log-level value
+            if (string.Equals(args[i], "--log-level", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length)
             {
-                return args[i + 1].ToLowerInvariant() switch
-                {
-                    "debug" or "trace" => LogLevel.Debug,
-                    "info" or "information" => LogLevel.Information,
-                    "warn" or "warning" => LogLevel.Warning,
-                    "error" => LogLevel.Error,
-                    _ => LogLevel.Information,
-                };
+                return ParseLogLevelValue(args[i + 1]);
             }
+
+            // Handle --log-level=value
+            if (args[i].StartsWith("--log-level=", StringComparison.OrdinalIgnoreCase))
+            {
+                return ParseLogLevelValue(args[i]["--log-level=".Length..]);
+            }
+        }
+
+        // Default to Information level for the 'run' command so users can see
+        // poll cycle activity and session status changes without needing --log-level
+        var command = args.FirstOrDefault(a => !a.StartsWith('-'));
+        if (string.Equals(command, "run", StringComparison.OrdinalIgnoreCase))
+        {
+            return LogLevel.Information;
         }
 
         return null;
     }
+
+    private static LogLevel ParseLogLevelValue(string value) => value.ToLowerInvariant() switch
+    {
+        "debug" or "trace" => LogLevel.Debug,
+        "info" or "information" => LogLevel.Information,
+        "warn" or "warning" => LogLevel.Warning,
+        "error" => LogLevel.Error,
+        _ => LogLevel.Information,
+    };
 }


### PR DESCRIPTION
Fixes #8

The ReconciliationEngine already has extensive LogInformation calls for cycle start/end, session counts, status transitions, dispatches, and queue status. However, the StderrLoggerProvider was only added when --log-level was explicitly specified, so none of this was visible by default.

Changes:
- Default console logging for run: when the run command is used without --log-level, console logging is enabled at Information level
- --log-level=value format: now supports both --log-level info and --log-level=info syntax
- --log-level still overrides: use --log-level debug for more detail, --log-level error for less
- Updated option description in the run command help text