### PR TITLE
Add concurrency group to CI workflow to prevent release race conditions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
     paths-ignore:
       - '**/*.md'
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   DOTNET_NOLOGO: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true


### PR DESCRIPTION
## Problem

CI runs #3 and #4 triggered within 29 seconds of each other when two PRs merged to main in quick succession. Both runs reached the bundle-dev job simultaneously and raced on the shared dev draft release:

1. Both runs called gh release edit dev
2. Run #4 deleted asset copilotd-linux-arm64.tar.gz first
3. Run #3 tried to delete the same asset — asset not found — failed due to set -e

## Fix

Add a workflow-level concurrency group (ci-github.ref) so pushes to the same branch are serialized. cancel-in-progress: false ensures no in-flight build is lost — the next run simply queues behind the current one.

Closes #13