### PR TITLE
Fix install script to fall back to prerelease when no stable release exists

### DIFF
--- a/scripts/install/install-copilotd.ps1
+++ b/scripts/install/install-copilotd.ps1
@@ -241,6 +241,7 @@ function Get-ReleaseForQuality
     }
 
     $allReleases = @(Invoke-GitHubApi -Uri "https://api.github.com/repos/$Repo/releases?per_page=100" | ForEach-Object { $_ })
+    $candidateReleases = @()
     foreach ($release in $allReleases)
     {
         if ($release.draft)
@@ -253,18 +254,27 @@ function Get-ReleaseForQuality
             continue
         }
 
-        if ($SelectedQuality -eq 'Stable' -and $release.prerelease)
-        {
-            continue
-        }
-
         $asset = Get-ReleaseAsset -Release $release -AssetName $AssetName
         if ($null -eq $asset)
         {
             continue
         }
 
+        if ($SelectedQuality -eq 'Stable' -and $release.prerelease)
+        {
+            # Track as fallback candidate but keep looking for a stable release
+            $candidateReleases += $release
+            continue
+        }
+
         return $release
+    }
+
+    # When looking for Stable and none found, fall back to the latest prerelease
+    if ($SelectedQuality -eq 'Stable' -and $candidateReleases.Count -gt 0)
+    {
+        Write-Warning "No stable release containing '$AssetName' was found. Falling back to latest prerelease."
+        return $candidateReleases[0]
     }
 
     throw "No '$SelectedQuality' release containing '$AssetName' was found in '$Repo'."
@@ -469,7 +479,10 @@ function Get-ReleaseStatusLabel
     $releaseLabel =
         switch ($SelectedQuality)
         {
-            'Stable' { 'latest stable release' }
+            'Stable' {
+                if ($Release.prerelease) { 'latest prerelease (no stable release available)' }
+                else { 'latest stable release' }
+            }
             'PreRelease' { 'latest prerelease' }
             'Dev' { 'latest development build' }
             default { 'release' }


### PR DESCRIPTION
When the user runs the install script with the default \Stable\ quality and no stable releases exist, the script now falls back to the latest prerelease instead of throwing an error.

**Changes:**
- \Get-ReleaseForQuality\: Collects prerelease candidates while searching for a stable release, and returns the first candidate if no stable release is found
- \Get-ReleaseStatusLabel\: Shows \latest prerelease (no stable release available)\ when a fallback occurred
- A \Write-Warning\ informs the user that a fallback happened

Fixes #19