### PR TITLE
Support investigation issues with WaitingForFeedback state

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,7 +27,7 @@ State converges through this loop — every inconsistency (crashed process, stal
 
 **Three truth sources** are reconciled each cycle: persisted state (`~/.copilotd/state.json`) → live OS process status → current GitHub issue matches.
 
-**Session lifecycle states:** Pending → Dispatching → Running → Completed/Failed/Orphaned, plus Joined (user-controlled interactive takeover). `CompletedBySession` flag distinguishes explicit copilot completion from automatic (issue unmatched) completion.
+**Session lifecycle states:** Pending → Dispatching → Running → Completed/Failed/Orphaned, plus Joined (user-controlled interactive takeover) and WaitingForFeedback (session paused, waiting for new issue comments). `CompletedBySession` flag distinguishes explicit copilot completion from automatic (issue unmatched) completion.
 
 ## Key Conventions
 
@@ -52,6 +52,8 @@ JsonSerializer.Deserialize(json, CopilotdJsonContext.Default.TypeName);
 ```
 
 Reflection-based serialization is disabled. Adding a new persisted model requires adding a `[JsonSerializable]` attribute to `CopilotdJsonContext`.
+
+`SessionStatus` uses a custom `TolerantSessionStatusConverter` (not `JsonStringEnumConverter`) that falls back to `Pending` for unknown enum values. This ensures version resilience — older binaries won't lose all state when encountering new status values. New enum values on persisted types should follow this pattern.
 
 ### Process Management (Platform-Specific)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An orchestration daemon that watches configured GitHub repositories for issues m
 - **Issue watching** — polls GitHub repos for issues matching configurable rules (assigned user, labels, milestone, issue type)
 - **Automatic dispatch** — launches `copilot --remote` sessions with templated prompts derived from issue metadata
 - **Named dispatch rules** — flexible, composable rules with per-rule launch options (`--yolo`, `--allow-all-tools`, `--allow-all-urls`, extra prompts, repo assignments)
-- **Session lifecycle** — full state machine with retry, backoff, orphan recovery, and explicit completion signaling
+- **Session lifecycle** — full state machine with retry, backoff, orphan recovery, investigation feedback loops, and explicit completion signaling
 - **Self-healing state** — reconciles persisted state, live process status, and GitHub issue matches on every poll cycle and at startup
 - **Crash-resilient** — dispatched `copilot` sessions run as independent processes that survive daemon restarts; state is persisted atomically
 - **Interactive takeover** — join any orchestrated session interactively with `copilotd session join`, then hand it back automatically
@@ -60,6 +60,7 @@ Convenience scripts `copilotd.sh` and `copilotd.cmd` in the repo root run the pr
 | `copilotd session` | List dispatched sessions (alias for `session list`) |
 | `copilotd session list` | List dispatched sessions with optional filtering |
 | `copilotd session join <issue>` | Take over a session interactively |
+| `copilotd session comment <issue>` | Post a comment on the issue and wait for feedback (callable from within a copilot session) |
 | `copilotd session complete <issue>` | Mark a session as completed (callable from within a copilot session) |
 | `copilotd session reset <issue>` | Reset a completed/failed session to pending for re-dispatch |
 | `copilotd config` | Display current configuration |
@@ -79,7 +80,7 @@ Convenience scripts `copilotd.sh` and `copilotd.cmd` in the repo root run the pr
 ### Status & session options
 
 ```
---filter <status>   Filter by status (pending, running, joined, completed, failed, orphaned)
+--filter <status>   Filter by status (pending, running, joined, waitingforfeedback, completed, failed, orphaned)
 --all               Include ended (completed/failed) sessions
 ```
 
@@ -135,6 +136,15 @@ Each dispatched copilot session follows a state machine:
                  │◄──── Completed ◄────────┴─────────────────────┘
                  │      (auto)                   (explicit)
                  │
+                 │                   copilot calls
+                 │                   session comment
+                 │◄── WaitingForFeedback ◄───────────────────────┘
+                      │          ▲
+          new comment │          │ no new comments
+          detected    │          │ (keeps waiting)
+                      ▼          │
+                    Pending ─────┘
+                 │
           re-opened / re-matched
           (only if not explicitly completed)
 ```
@@ -148,12 +158,15 @@ Each dispatched copilot session follows a state machine:
 | **Dispatching** | **Running** | Process successfully started, PID tracked |
 | **Dispatching** | **Failed** | Process launch failed (increments retry count) |
 | **Running** | **Completed** | Issue no longer matches rules (closed, relabeled, etc.) — process gracefully terminated |
+| **Running** | **WaitingForFeedback** | Copilot calls `copilotd session comment` — process exits, session waits for new issue comments |
 | **Running** | **Orphaned** | Process died unexpectedly (PID gone or reused) |
 | **Running** | **Joined** | User runs `copilotd session join` — process terminated, user takes over |
 | **Orphaned** | **Pending** | Retry eligible (retry count < 3) — exponential backoff: 2^n minutes, capped at 30m |
 | **Orphaned** | **Failed** | Max retries (3) exceeded |
 | **Failed** | **Pending** | Issue still matches and retry count < 3 |
 | **Joined** | **Pending** | User exits interactive session — automatically re-queued for dispatch |
+| **WaitingForFeedback** | **Pending** | New comment detected on the issue (not posted by copilotd) — re-dispatched with same session ID for `--resume` context continuity |
+| **WaitingForFeedback** | **Completed** | Issue no longer matches rules while waiting |
 | **Completed** | **Pending** | Issue re-matches rules (e.g., reopened) — only if not explicitly completed by copilot |
 | Any non-terminal | **Completed** | Copilot calls `copilotd session complete` — sets `CompletedBySession` flag, prevents re-dispatch |
 
@@ -167,7 +180,18 @@ Sessions can reach the **Completed** state in two ways:
 
 3. **Manual reset** — use `copilotd session reset <issue>` to force a completed or failed session back to pending with a fresh session ID, regardless of the `CompletedBySession` flag.
 
-The default prompt instructs copilot sessions to call `copilotd session complete` when they finish their work.
+### Investigation & clarification
+
+When a copilot session encounters an issue that needs more information before work can begin, it can post a comment and pause:
+
+1. The session calls `copilotd session comment <issue> --message "question or findings"`
+2. The comment is posted to the GitHub issue (with a hidden `<!-- posted by copilotd -->` marker)
+3. The session transitions to **WaitingForFeedback** — the copilot process exits, no instance slot is consumed
+4. On each poll cycle, the reconciler checks for new comments on the issue (ignoring copilotd-posted comments)
+5. When a new comment is detected, the session is re-dispatched with `--resume` to preserve the full conversation context
+6. The model can then decide to start coding or ask further questions (multiple rounds supported)
+
+The default prompt instructs copilot sessions to use this flow when they need clarification.
 
 ### Interactive takeover
 
@@ -181,6 +205,7 @@ Use `copilotd session join <issue>` to take over any tracked session:
 ### Terminal states and pruning
 
 - **Completed** and **Failed** are terminal states
+- **WaitingForFeedback** is *not* terminal — the session is paused, not finished
 - Terminal sessions are automatically pruned from state after 7 days
 - All running sessions are gracefully terminated when the daemon shuts down
 

--- a/src/copilotd/Commands/SessionCommand.cs
+++ b/src/copilotd/Commands/SessionCommand.cs
@@ -3,6 +3,7 @@ using System.CommandLine.Parsing;
 using System.Diagnostics;
 using Copilotd.Infrastructure;
 using Copilotd.Models;
+using Copilotd.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
@@ -17,6 +18,7 @@ public static class SessionCommand
 
         command.Subcommands.Add(CreateListCommand(services));
         command.Subcommands.Add(CreateJoinCommand(services));
+        command.Subcommands.Add(CreateCommentCommand(services));
         command.Subcommands.Add(CreateCompleteCommand(services));
         command.Subcommands.Add(CreateResetCommand(services));
 
@@ -208,6 +210,71 @@ public static class SessionCommand
                     RequeueSession(stateStore, issueKey);
                 }
 
+                return 0;
+            }, logger);
+        });
+
+        return command;
+    }
+
+    // ---- comment subcommand ----
+
+    private static Command CreateCommentCommand(IServiceProvider services)
+    {
+        var command = new Command("comment", "Post a comment on the issue and wait for feedback (can be called from within a copilot session)");
+
+        var issueArg = new Argument<string>("issue") { Description = "Issue key (e.g., owner/repo#123)" };
+        command.Arguments.Add(issueArg);
+
+        var messageOption = new Option<string>("--message")
+        {
+            Description = "The comment message to post on the issue",
+            Required = true,
+        };
+        command.Options.Add(messageOption);
+
+        command.SetAction(async (ParseResult parseResult, CancellationToken ct) =>
+        {
+            var logger = services.GetRequiredService<ILogger<Program>>();
+            return await ConsoleOutput.RunWithErrorHandling(async () =>
+            {
+                var stateStore = services.GetRequiredService<StateStore>();
+                var ghCli = services.GetRequiredService<GhCliService>();
+                var state = stateStore.LoadState();
+
+                var issueKey = parseResult.GetValue(issueArg)!;
+                var message = parseResult.GetValue(messageOption)!;
+
+                if (!state.Sessions.TryGetValue(issueKey, out var session))
+                {
+                    ConsoleOutput.Error($"No session found for '{issueKey}'.");
+                    return 1;
+                }
+
+                if (session.IsTerminal)
+                {
+                    ConsoleOutput.Error($"Session for '{issueKey}' is already {session.Status.ToString().ToLowerInvariant()}.");
+                    return 1;
+                }
+
+                // Post the comment to the issue
+                if (!ghCli.PostIssueComment(session.Repo, session.IssueNumber, message))
+                {
+                    ConsoleOutput.Error($"Failed to post comment on {issueKey}.");
+                    return 1;
+                }
+
+                // Transition to WaitingForFeedback. The calling copilot process is
+                // expected to exit on its own after this command returns. We clear the
+                // PID so the reconciler doesn't try to verify a dead process.
+                session.Status = SessionStatus.WaitingForFeedback;
+                session.WaitingSince = DateTimeOffset.UtcNow;
+                session.ProcessId = null;
+                session.ProcessStartTime = null;
+                session.UpdatedAt = DateTimeOffset.UtcNow;
+                stateStore.SaveState(state);
+
+                ConsoleOutput.Success($"Comment posted on {issueKey}. Session is now waiting for feedback.");
                 return 0;
             }, logger);
         });
@@ -424,6 +491,7 @@ public static class SessionCommand
             {
                 SessionStatus.Running => $"[green]{s.Status}[/]",
                 SessionStatus.Joined => $"[blue]{s.Status}[/]",
+                SessionStatus.WaitingForFeedback => $"[cyan]{s.Status}[/]",
                 SessionStatus.Pending or SessionStatus.Dispatching => $"[yellow]{s.Status}[/]",
                 SessionStatus.Failed or SessionStatus.Orphaned => $"[red]{s.Status}[/]",
                 SessionStatus.Completed => $"[grey]{s.Status}[/]",

--- a/src/copilotd/Models/CopilotdConfig.cs
+++ b/src/copilotd/Models/CopilotdConfig.cs
@@ -46,13 +46,17 @@ public sealed class CopilotdConfig
     public const string DefaultPrompt =
         """
         You are working on issue #$(issue.id) in the $(issue.repo) repository.
-        Read the issue details carefully and implement the requested changes.
+        Read the issue details carefully and decide on the best course of action.
         Follow the project's coding conventions and ensure all tests pass.
 
-        Git workflow:
+        If you have enough information to implement the requested changes:
         - You are already on a new branch created for this issue. Commit your changes here.
         - When your work is complete, push the branch and create a pull request that references the issue (e.g., "Closes #$(issue.id)").
         - After the pull request is created, run `copilotd session complete $(issue.repo)#$(issue.id)` to mark this session as done.
+
+        If you need more information or clarification before proceeding:
+        - Run `copilotd session comment $(issue.repo)#$(issue.id) --message "Your question or findings here"` to post a comment on the issue.
+        - This will pause your session until a response is posted on the issue, at which point your session will automatically resume.
         """;
 }
 

--- a/src/copilotd/Models/JsonContext.cs
+++ b/src/copilotd/Models/JsonContext.cs
@@ -4,13 +4,55 @@ using System.Text.Json.Serialization;
 namespace Copilotd.Models;
 
 /// <summary>
+/// AOT-compatible JSON converter for <see cref="SessionStatus"/> that gracefully handles
+/// unknown enum values by falling back to <see cref="SessionStatus.Pending"/>.
+/// This prevents older binaries from losing all persisted state when encountering
+/// new enum values added in later versions.
+/// </summary>
+public sealed class TolerantSessionStatusConverter : JsonConverter<SessionStatus>
+{
+    public override SessionStatus Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            var value = reader.GetString();
+            if (Enum.TryParse<SessionStatus>(value, ignoreCase: true, out var status))
+                return status;
+
+            // Unknown enum value from a newer version. Falling back to Pending means
+            // the reconciliation engine may re-dispatch the session prematurely, but
+            // that is recoverable. The alternatives (Completed = session lost, throwing
+            // = entire state file rejected) are worse. The newer binary will correct the
+            // status on its next run.
+            return SessionStatus.Pending;
+        }
+
+        if (reader.TokenType == JsonTokenType.Number)
+        {
+            var intValue = reader.GetInt32();
+            if (Enum.IsDefined(typeof(SessionStatus), intValue))
+                return (SessionStatus)intValue;
+
+            return SessionStatus.Pending;
+        }
+
+        return SessionStatus.Pending;
+    }
+
+    public override void Write(Utf8JsonWriter writer, SessionStatus value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToString());
+    }
+}
+
+/// <summary>
 /// AOT-safe JSON serialization metadata for all persisted models.
 /// </summary>
 [JsonSourceGenerationOptions(
     WriteIndented = true,
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-    Converters = [typeof(JsonStringEnumConverter<SessionStatus>)])]
+    Converters = [typeof(TolerantSessionStatusConverter)])]
 [JsonSerializable(typeof(CopilotdConfig))]
 [JsonSerializable(typeof(DaemonState))]
 [JsonSerializable(typeof(DispatchRule))]

--- a/src/copilotd/Models/SessionState.cs
+++ b/src/copilotd/Models/SessionState.cs
@@ -41,7 +41,13 @@ public enum SessionStatus
     Orphaned,
 
     /// <summary>User has taken over this session interactively via 'copilotd join'.</summary>
-    Joined
+    Joined,
+
+    /// <summary>
+    /// Session posted a comment on the issue and is waiting for a response.
+    /// No process is running; the reconciler monitors for new comments.
+    /// </summary>
+    WaitingForFeedback
 }
 
 /// <summary>
@@ -94,6 +100,12 @@ public sealed class DispatchSession
     /// still matches rules.
     /// </summary>
     public bool CompletedBySession { get; set; }
+
+    /// <summary>
+    /// When the session entered <see cref="SessionStatus.WaitingForFeedback"/> state.
+    /// Used to detect new comments on the issue since the session started waiting.
+    /// </summary>
+    public DateTimeOffset? WaitingSince { get; set; }
 
     /// <summary>
     /// Path to the git worktree directory for this session. Null if using the main repo checkout.

--- a/src/copilotd/Services/GhCliService.cs
+++ b/src/copilotd/Services/GhCliService.cs
@@ -196,6 +196,119 @@ public sealed class GhCliService
         return issues;
     }
 
+    /// <summary>
+    /// Marker appended to comments posted by copilotd, used to distinguish
+    /// bot-posted comments from human replies when checking for new feedback.
+    /// Invisible on GitHub (HTML comment).
+    /// </summary>
+    internal const string CommentMarker = "<!-- posted by copilotd -->";
+
+    /// <summary>
+    /// Posts a comment on a GitHub issue. Appends a hidden marker so copilotd
+    /// can distinguish its own comments from human replies.
+    /// </summary>
+    public bool PostIssueComment(string repo, int issueNumber, string message)
+    {
+        var body = message + "\n\n" + CommentMarker;
+
+        // Use --body-file - to pipe via stdin, avoiding all shell escaping issues
+        var args = $"issue comment {issueNumber} --repo {repo} --body-file -";
+
+        _logger.LogDebug("Running: gh {Args}", args);
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "gh",
+            Arguments = args,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        using var process = Process.Start(psi)!;
+        process.StandardInput.Write(body);
+        process.StandardInput.Close();
+
+        var stderrTask = process.StandardError.ReadToEndAsync();
+        var stdout = process.StandardOutput.ReadToEnd();
+
+        if (!process.WaitForExit(GhTimeout))
+        {
+            _logger.LogWarning("gh command timed out posting comment on {Repo}#{Issue}", repo, issueNumber);
+            process.Kill();
+            return false;
+        }
+
+        if (process.ExitCode != 0)
+        {
+            var stderr = stderrTask.Result;
+            var output = string.IsNullOrEmpty(stdout) ? stderr : stdout;
+            _logger.LogWarning("Failed to post comment on {Repo}#{Issue}: {Output}", repo, issueNumber, output);
+            return false;
+        }
+
+        _logger.LogInformation("Posted comment on {Repo}#{Issue}", repo, issueNumber);
+        return true;
+    }
+
+    /// <summary>
+    /// Checks whether there are new comments on an issue since the given timestamp,
+    /// excluding comments posted by copilotd itself (identified by <see cref="CommentMarker"/>).
+    /// </summary>
+    public bool HasNewCommentsSince(string repo, int issueNumber, DateTimeOffset since)
+    {
+        var args = $"issue view {issueNumber} --repo {repo} --json comments";
+        var (exitCode, output) = RunGh(args);
+        if (exitCode != 0)
+        {
+            _logger.LogWarning("Failed to query comments on {Repo}#{Issue}: {Output}", repo, issueNumber, output);
+            return false;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(output);
+            if (!doc.RootElement.TryGetProperty("comments", out var comments))
+                return false;
+
+            foreach (var comment in comments.EnumerateArray())
+            {
+                if (!comment.TryGetProperty("createdAt", out var createdAtEl))
+                    continue;
+
+                var createdAtStr = createdAtEl.GetString();
+                if (createdAtStr is null || !DateTimeOffset.TryParse(createdAtStr, out var createdAt))
+                    continue;
+
+                if (createdAt <= since)
+                    continue;
+
+                // Skip comments posted by copilotd (identified by hidden marker)
+                if (comment.TryGetProperty("body", out var bodyEl))
+                {
+                    var body = bodyEl.GetString();
+                    if (body is not null && body.Contains(CommentMarker, StringComparison.Ordinal))
+                        continue;
+                }
+
+                // Found at least one new comment not posted by copilotd
+                _logger.LogDebug("Found new comment on {Repo}#{Issue} from {Author}",
+                    repo, issueNumber,
+                    comment.TryGetProperty("author", out var a) && a.TryGetProperty("login", out var l) ? l.GetString() : "unknown");
+                return true;
+            }
+
+            return false;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse comments JSON for {Repo}#{Issue}", repo, issueNumber);
+            return false;
+        }
+    }
+
     private static readonly TimeSpan GhTimeout = TimeSpan.FromSeconds(30);
 
     private (int ExitCode, string Output) RunGh(string arguments)

--- a/src/copilotd/Services/ReconciliationEngine.cs
+++ b/src/copilotd/Services/ReconciliationEngine.cs
@@ -59,9 +59,10 @@ public sealed class ReconciliationEngine
         state.LastPollTime = DateTimeOffset.UtcNow;
         _stateStore.SaveState(state);
 
-        _logger.LogInformation("Reconciliation complete: {Active} active, {Pending} pending, {Terminal} terminal sessions",
+        _logger.LogInformation("Reconciliation complete: {Active} active, {Pending} pending, {Waiting} waiting, {Terminal} terminal sessions",
             state.Sessions.Values.Count(s => s.Status == SessionStatus.Running),
             state.Sessions.Values.Count(s => s.Status == SessionStatus.Pending),
+            state.Sessions.Values.Count(s => s.Status == SessionStatus.WaitingForFeedback),
             state.Sessions.Values.Count(s => s.IsTerminal));
     }
 
@@ -104,6 +105,10 @@ public sealed class ReconciliationEngine
                 continue;
 
             if (session.Status is SessionStatus.Pending)
+                continue;
+
+            // WaitingForFeedback sessions have no running process — skip liveness check
+            if (session.Status is SessionStatus.WaitingForFeedback)
                 continue;
 
             // For Joined sessions, check if the interactive process is still alive.
@@ -240,11 +245,22 @@ public sealed class ReconciliationEngine
 
             if (!desired.ContainsKey(key))
             {
-                // Only terminate if the session's repo was successfully queried.
+                // Only act if the session's repo was successfully queried.
                 // If the repo query failed, we don't know if the issue still matches.
                 if (!queriedRepos.Contains(session.Repo))
                 {
                     _logger.LogDebug("Repo {Repo} query failed, preserving session {Key}", session.Repo, key);
+                    continue;
+                }
+
+                // WaitingForFeedback sessions have no process to terminate
+                if (session.Status is SessionStatus.WaitingForFeedback)
+                {
+                    _logger.LogInformation("Issue {Key} no longer matches rules, completing waiting session", key);
+                    session.Status = SessionStatus.Completed;
+                    session.WaitingSince = null;
+                    session.UpdatedAt = DateTimeOffset.UtcNow;
+                    _processManager.CleanupWorktree(session, config);
                     continue;
                 }
 
@@ -281,6 +297,25 @@ public sealed class ReconciliationEngine
                     case SessionStatus.Pending:
                     case SessionStatus.Joined:
                         // Already active or user-controlled, nothing to do
+                        continue;
+
+                    case SessionStatus.WaitingForFeedback:
+                        // Check for new comments since the session started waiting
+                        if (existing.WaitingSince is not null
+                            && _ghCli.HasNewCommentsSince(existing.Repo, existing.IssueNumber, existing.WaitingSince.Value))
+                        {
+                            _logger.LogInformation("New comment detected on {Key}, re-dispatching waiting session", issueKey);
+                            // Keep same CopilotSessionId so --resume preserves context
+                            existing.Status = SessionStatus.Pending;
+                            existing.WaitingSince = null;
+                            existing.ProcessId = null;
+                            existing.ProcessStartTime = null;
+                            existing.UpdatedAt = DateTimeOffset.UtcNow;
+                        }
+                        else
+                        {
+                            _logger.LogDebug("Session {Key} still waiting for feedback", issueKey);
+                        }
                         continue;
 
                     case SessionStatus.Orphaned when existing.CanRetry:


### PR DESCRIPTION
## Summary

Adds support for issues that require investigation or clarification before code work begins. The model decides at runtime whether to code or ask questions — no configuration flags needed.

## Changes

### New `WaitingForFeedback` session status
Sessions can now pause to wait for human feedback on an issue, then auto-resume when a new comment is posted. The flow:

\\\
Issue matches rule → dispatch session
    ↓
Model reads issue
    ├─ Has enough info → code → PR → session complete (existing)
    └─ Needs clarification → session comment → WaitingForFeedback
                                                      ↓
                                            New comment detected by reconciler
                                                      ↓
                                              Re-dispatch with --resume
                                              (preserves Copilot context)
\\\

### New `copilotd session comment` subcommand
Posts a comment on the issue and transitions the session to `WaitingForFeedback`. Called by the model from within a Copilot session when it needs more information.

### Reconciliation engine updates
- Monitors `WaitingForFeedback` sessions for new issue comments each poll cycle
- Re-dispatches with the same `CopilotSessionId` so `--resume` preserves context
- Waiting sessions don't count against `MaxInstances`
- Properly handles waiting sessions when issues no longer match rules

### Updated default prompt
Explains both completion paths — the model decides which to use based on the issue content.

### Version resilience
- **Tolerant JSON converter**: Unknown `SessionStatus` enum values (from newer versions) fall back to `Pending` instead of corrupting the entire state file
- **Nullable properties**: `WaitingSince` is safely ignored by older binaries (`DefaultIgnoreCondition.WhenWritingNull`)

### Self-comment detection
Uses an invisible HTML comment marker (`<!-- posted by copilotd -->`) to identify bot-posted comments, so replies from the same GitHub account are correctly detected as new feedback.

## Files changed
- `SessionState.cs` — New enum value + `WaitingSince` property
- `JsonContext.cs` — Tolerant `SessionStatus` converter
- `SessionCommand.cs` — New `comment` subcommand + UI color
- `GhCliService.cs` — `PostIssueComment()` (stdin piping) + `HasNewCommentsSince()`
- `ReconciliationEngine.cs` — WaitingForFeedback handling in all code paths
- `CopilotdConfig.cs` — Updated default prompt

Closes #21