### PR TITLE
Fix worktree creation failure from stale branches

### DIFF
--- a/src/copilotd/Commands/SessionCommand.cs
+++ b/src/copilotd/Commands/SessionCommand.cs
@@ -369,7 +369,6 @@ public static class SessionCommand
                 session.CopilotSessionId = Guid.NewGuid().ToString();
                 session.ProcessId = null;
                 session.ProcessStartTime = null;
-                session.WorktreePath = null;
                 session.RetryCount = 0;
                 session.LastFailureAt = null;
                 session.UpdatedAt = DateTimeOffset.UtcNow;

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -436,15 +436,28 @@ public sealed partial class ProcessManager
         // Session dir: <repo_home>/org/repo_sessions/issue-N/
         var sessionsDir = mainRepoPath + "_sessions";
         var worktreePath = Path.Combine(sessionsDir, $"issue-{session.IssueNumber}");
-        var branchName = $"copilotd/issue-{session.IssueNumber}";
 
-        // If the worktree already exists from a prior run, remove it first
+        // If the worktree directory already exists from a prior run, remove it
         if (Directory.Exists(worktreePath))
         {
             _logger.LogDebug("Removing existing worktree at {Path}", worktreePath);
             RunGit(mainRepoPath, $"worktree remove \"{worktreePath}\" --force");
-            // Also delete the branch if it exists from a prior run
-            RunGit(mainRepoPath, $"branch -D {branchName}");
+        }
+
+        // Prune stale worktree tracking entries (handles crash scenarios where
+        // the directory was deleted but git still tracks the worktree internally)
+        RunGit(mainRepoPath, "worktree prune");
+
+        // Clean up stale branch from a previous failed attempt (tracked in state).
+        // Done AFTER worktree remove + prune so the branch is no longer checked
+        // out in any worktree (git refuses to delete checked-out branches).
+        if (!string.IsNullOrEmpty(session.BranchName))
+        {
+            _logger.LogDebug("Cleaning up stale branch {Branch} from previous attempt", session.BranchName);
+            if (RunGit(mainRepoPath, $"branch -D {session.BranchName}"))
+            {
+                session.BranchName = null;
+            }
         }
 
         Directory.CreateDirectory(sessionsDir);
@@ -465,9 +478,18 @@ public sealed partial class ProcessManager
             return false;
         }
 
+        // Generate a unique branch name with random suffix to avoid conflicts
+        // with user branches and stale branches from non-atomic git worktree add
+        var suffix = Guid.NewGuid().ToString("N")[..4];
+        var branchName = $"copilotd/issue-{session.IssueNumber}-{suffix}";
+
+        // Track branch name BEFORE the git command so it's persisted even if
+        // worktree add fails partway (git creates the branch before the worktree)
+        session.BranchName = branchName;
+
         // Create worktree on a new branch from origin's default branch
-        _logger.LogInformation("Creating worktree for {Key} at {Path} from {Branch}",
-            session.IssueKey, worktreePath, defaultBranch);
+        _logger.LogInformation("Creating worktree for {Key} at {Path} from {Branch} (branch: {BranchName})",
+            session.IssueKey, worktreePath, defaultBranch, branchName);
 
         if (!RunGit(mainRepoPath, $"worktree add \"{worktreePath}\" -b {branchName} {defaultBranch}"))
         {
@@ -482,29 +504,36 @@ public sealed partial class ProcessManager
 
     /// <summary>
     /// Removes the git worktree and branch associated with a session.
+    /// Safe to call even when WorktreePath is null (e.g., after a failed PrepareWorktree).
     /// </summary>
     public void CleanupWorktree(DispatchSession session, CopilotdConfig config)
     {
-        if (string.IsNullOrEmpty(session.WorktreePath))
-            return;
-
         var mainRepoPath = config.GetRepoPath(session.Repo);
-        var branchName = $"copilotd/issue-{session.IssueNumber}";
 
-        _logger.LogDebug("Cleaning up worktree for {Key} at {Path}", session.IssueKey, session.WorktreePath);
-
-        if (Directory.Exists(session.WorktreePath))
+        // Remove the worktree directory if it exists
+        if (!string.IsNullOrEmpty(session.WorktreePath))
         {
-            RunGit(mainRepoPath, $"worktree remove \"{session.WorktreePath}\" --force");
+            _logger.LogDebug("Cleaning up worktree for {Key} at {Path}", session.IssueKey, session.WorktreePath);
+
+            if (Directory.Exists(session.WorktreePath))
+            {
+                RunGit(mainRepoPath, $"worktree remove \"{session.WorktreePath}\" --force");
+            }
+
+            session.WorktreePath = null;
         }
 
-        // Delete the local branch (it was only used for this session)
-        RunGit(mainRepoPath, $"branch -D {branchName}");
-
-        session.WorktreePath = null;
+        // Delete the branch — use the stored name, falling back to the legacy
+        // naming scheme for sessions created before BranchName tracking was added.
+        // Only clear BranchName on success so a future cleanup can retry.
+        var branchName = session.BranchName ?? $"copilotd/issue-{session.IssueNumber}";
+        if (RunGit(mainRepoPath, $"branch -D {branchName}"))
+        {
+            session.BranchName = null;
+        }
     }
 
-    private static string? GetDefaultBranch(string repoPath)
+    private string? GetDefaultBranch(string repoPath)
     {
         try
         {
@@ -529,8 +558,8 @@ public sealed partial class ProcessManager
                 return output;
 
             // Fallback: try origin/main then origin/master
-            return RunGitCheck(repoPath, "rev-parse --verify origin/main") ? "origin/main"
-                : RunGitCheck(repoPath, "rev-parse --verify origin/master") ? "origin/master"
+            return RunGit(repoPath, "rev-parse --verify origin/main") ? "origin/main"
+                : RunGit(repoPath, "rev-parse --verify origin/master") ? "origin/master"
                 : null;
         }
         catch
@@ -539,10 +568,12 @@ public sealed partial class ProcessManager
         }
     }
 
-    private static bool RunGit(string workingDir, string arguments)
+    private bool RunGit(string workingDir, string arguments)
     {
         try
         {
+            _logger.LogDebug("Running: git {Arguments} (in {Dir})", arguments, workingDir);
+
             var psi = new ProcessStartInfo
             {
                 FileName = "git",
@@ -555,20 +586,39 @@ public sealed partial class ProcessManager
             };
 
             using var process = Process.Start(psi);
-            if (process is null) return false;
+            if (process is null)
+            {
+                _logger.LogWarning("Failed to start git process for: git {Arguments}", arguments);
+                return false;
+            }
 
-            process.StandardOutput.ReadToEnd();
-            process.StandardError.ReadToEnd();
+            // Read stderr asynchronously to avoid deadlock when stdout/stderr
+            // buffers fill in different orders
+            var stderrTask = process.StandardError.ReadToEndAsync();
+            var stdout = process.StandardOutput.ReadToEnd();
+            var stderr = stderrTask.GetAwaiter().GetResult();
             process.WaitForExit(TimeSpan.FromSeconds(30));
-            return process.ExitCode == 0;
+
+            if (process.ExitCode != 0)
+            {
+                _logger.LogWarning("git {Arguments} failed (exit {ExitCode}): {StdErr}",
+                    arguments, process.ExitCode, stderr.Trim());
+                return false;
+            }
+
+            if (!string.IsNullOrWhiteSpace(stderr))
+                _logger.LogDebug("git {Arguments} stderr: {StdErr}", arguments, stderr.Trim());
+
+            return true;
         }
-        catch
+        catch (Exception ex)
         {
+            _logger.LogWarning(ex, "Exception running: git {Arguments}", arguments);
             return false;
         }
     }
 
-    private static bool RunGitCheck(string workingDir, string arguments)
+    private bool RunGitCheck(string workingDir, string arguments)
     {
         return RunGit(workingDir, arguments);
     }

--- a/src/copilotd/Models/SessionState.cs
+++ b/src/copilotd/Models/SessionState.cs
@@ -112,6 +112,12 @@ public sealed class DispatchSession
     /// </summary>
     public string? WorktreePath { get; set; }
 
+    /// <summary>
+    /// Name of the git branch created for this session's worktree (e.g., "copilotd/issue-42-a3f7").
+    /// Tracked so cleanup can delete the correct branch even if worktree creation failed partway.
+    /// </summary>
+    public string? BranchName { get; set; }
+
     /// <summary>Maximum retries before giving up (0 = unlimited).</summary>
     public const int MaxRetries = 3;
 

--- a/src/copilotd/Services/ReconciliationEngine.cs
+++ b/src/copilotd/Services/ReconciliationEngine.cs
@@ -80,8 +80,8 @@ public sealed class ReconciliationEngine
         foreach (var key in toRemove)
         {
             var session = state.Sessions[key];
-            // Clean up any lingering worktree
-            if (!string.IsNullOrEmpty(session.WorktreePath))
+            // Clean up any lingering worktree or branch
+            if (!string.IsNullOrEmpty(session.WorktreePath) || !string.IsNullOrEmpty(session.BranchName))
             {
                 var config = _stateStore.LoadConfig();
                 _processManager.CleanupWorktree(session, config);
@@ -327,7 +327,6 @@ public sealed class ReconciliationEngine
                         existing.CopilotSessionId = Guid.NewGuid().ToString();
                         existing.ProcessId = null;
                         existing.ProcessStartTime = null;
-                        existing.WorktreePath = null;
                         existing.UpdatedAt = DateTimeOffset.UtcNow;
                         existing.LastFailureAt = DateTimeOffset.UtcNow;
                         continue;
@@ -357,7 +356,6 @@ public sealed class ReconciliationEngine
                         existing.CopilotSessionId = Guid.NewGuid().ToString();
                         existing.ProcessId = null;
                         existing.ProcessStartTime = null;
-                        existing.WorktreePath = null;
                         existing.UpdatedAt = DateTimeOffset.UtcNow;
                         continue;
                 }


### PR DESCRIPTION
## Problem

`git worktree add -b` is non-atomic: it creates the branch **before** the worktree directory, and does **not** roll back the branch on failure. Once a stale branch was left behind, all subsequent dispatch attempts for that issue failed permanently with `fatal: a branch named 'copilotd/issue-N' already exists` — and the error was silently swallowed by `RunGit`, making it invisible in logs.

## Root Cause

Reproduced end-to-end: a single transient failure during `git worktree add -b` leaves a stale branch that creates a **permanent failure loop** because:
1. `PrepareWorktree` only cleaned up branches inside the `Directory.Exists` guard — skipped when the directory was never created
2. `CleanupWorktree` early-returned when `WorktreePath` was null (which it always was after a failed prepare)
3. `RunGit` discarded all stdout/stderr, making the `fatal:` message invisible

## Fix

- **Random-suffixed branch names** (e.g., `copilotd/issue-42-a3f7`) — avoids conflicts with user branches and eliminates the permanent failure loop (each retry gets a unique name)
- **`BranchName` tracked in `DispatchSession` state** — enables reliable cleanup even after partial failures
- **`PrepareWorktree`** — cleans up stored `BranchName` from prior failed attempts; reordered to: worktree remove, prune, then branch delete (so branch is not checked out when we try to delete it)
- **`CleanupWorktree`** — no longer early-returns on null `WorktreePath`; uses stored `BranchName` with legacy fallback; only clears `BranchName` on successful deletion (preserves for retry)
- **`RunGit`** — now captures and logs stdout/stderr (reads stderr async to avoid deadlock); logs the command at Debug level, stderr at Warning on failure
- **Callers** — `CleanupWorktree` owns `WorktreePath`/`BranchName` lifecycle; callers no longer override them

## Verification

- Reproduced the original failure with a test repo (stale branch -> 49ms `fatal:` error)
- Built successfully with 0 warnings
- E2E tested: ran the daemon, created a real issue, verified worktree creation succeeded with the random suffix and `BranchName` persisted in state, then cleaned up

Closes #28
