### PR TITLE
Fix init repo home prompt: platform-specific example and no empty default

### DIFF
--- a/src/copilotd/Commands/InitCommand.cs
+++ b/src/copilotd/Commands/InitCommand.cs
@@ -60,9 +60,11 @@ public static class InitCommand
                 config.CurrentUser = username;
 
                 // Prompt for repo home directory
-                var repoHome = AnsiConsole.Ask(
-                    "Enter the directory where repos are cloned (e.g., ~/repos):",
-                    config.RepoHome ?? "");
+                var examplePath = OperatingSystem.IsWindows() ? @"C:\source" : "~/repos";
+                var prompt = $"Enter the directory where repos are cloned (e.g., {examplePath}):";
+                var repoHome = config.RepoHome is not null
+                    ? AnsiConsole.Ask(prompt, config.RepoHome)
+                    : AnsiConsole.Ask<string>(prompt);
 
                 if (string.IsNullOrWhiteSpace(repoHome))
                 {


### PR DESCRIPTION
Fixes two UX issues with the repo home directory prompt during \copilotd init\:

1. **Platform-specific example path**: Shows \C:\source\ on Windows instead of \~/repos\ (which is Unix-specific and confusing on Windows)
2. **No empty default display**: When no existing \epo_home\ is configured, avoids passing an empty string as the default value to \AnsiConsole.Ask\, which was causing Spectre.Console to render empty green parentheses \()\. Now uses the no-default overload so the user simply sees the prompt without a misleading suffix.

When re-running init with an existing value, the current value is still shown as the default.

Fixes #29