### PR TITLE
Add start/stop commands for background daemon operation

### DIFF
--- a/src/copilotd/Commands/PreflightChecks.cs
+++ b/src/copilotd/Commands/PreflightChecks.cs
@@ -1,0 +1,44 @@
+using Copilotd.Infrastructure;
+using Copilotd.Services;
+
+namespace Copilotd.Commands;
+
+/// <summary>
+/// Shared pre-flight validation used by both the run and start commands.
+/// </summary>
+internal static class PreflightChecks
+{
+    /// <summary>
+    /// Verifies that gh CLI, copilot CLI, and authentication are available, and config exists.
+    /// Returns 0 on success, or a non-zero exit code with error messages written to console.
+    /// </summary>
+    public static int Run(GhCliService ghCli, CopilotCliService copilotCli, StateStore stateStore)
+    {
+        if (!ghCli.IsAvailable())
+        {
+            ConsoleOutput.Error("gh CLI is not available. Install from: https://cli.github.com/");
+            return 1;
+        }
+
+        if (!copilotCli.IsAvailable())
+        {
+            ConsoleOutput.Error("copilot CLI is not available. Install from: https://docs.github.com/copilot/how-tos/copilot-cli");
+            return 1;
+        }
+
+        var authResult = ghCli.CheckAuth();
+        if (!authResult.IsLoggedIn)
+        {
+            ConsoleOutput.Error("gh CLI is not authenticated. Run 'gh auth login' first.");
+            return 1;
+        }
+
+        if (!stateStore.ConfigExists())
+        {
+            ConsoleOutput.Error("copilotd is not configured. Run 'copilotd init' first.");
+            return 1;
+        }
+
+        return 0;
+    }
+}

--- a/src/copilotd/Commands/RunCommand.cs
+++ b/src/copilotd/Commands/RunCommand.cs
@@ -32,30 +32,9 @@ public static class RunCommand
                 var interval = parseResult.GetValue(intervalOption);
 
                 // Pre-flight checks
-                if (!ghCli.IsAvailable())
-                {
-                    ConsoleOutput.Error("gh CLI is not available. Install from: https://cli.github.com/");
-                    return 1;
-                }
-
-                if (!copilotCli.IsAvailable())
-                {
-                    ConsoleOutput.Error("copilot CLI is not available. Install from: https://docs.github.com/copilot/how-tos/copilot-cli");
-                    return 1;
-                }
-
-                var authResult = ghCli.CheckAuth();
-                if (!authResult.IsLoggedIn)
-                {
-                    ConsoleOutput.Error("gh CLI is not authenticated. Run 'gh auth login' first.");
-                    return 1;
-                }
-
-                if (!stateStore.ConfigExists())
-                {
-                    ConsoleOutput.Error("copilotd is not configured. Run 'copilotd init' first.");
-                    return 1;
-                }
+                var preflightResult = PreflightChecks.Run(ghCli, copilotCli, stateStore);
+                if (preflightResult != 0)
+                    return preflightResult;
 
                 // Single-instance guard
                 if (!stateStore.TryAcquireLock())

--- a/src/copilotd/Commands/StartCommand.cs
+++ b/src/copilotd/Commands/StartCommand.cs
@@ -1,0 +1,231 @@
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Copilotd.Infrastructure;
+using Copilotd.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using static Copilotd.Infrastructure.NativeInterop;
+
+namespace Copilotd.Commands;
+
+public static class StartCommand
+{
+    private static readonly TimeSpan StartupTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan StartupPollInterval = TimeSpan.FromMilliseconds(500);
+
+    public static Command Create(IServiceProvider services)
+    {
+        var command = new Command("start", "Start the copilotd daemon in the background");
+        var intervalOption = new Option<int>("--interval") { Description = "Polling interval in seconds", DefaultValueFactory = _ => 60 };
+        var logLevelOption = new Option<string?>("--log-level") { Description = "Set logging level (default: info). Use 'debug' for more detail or 'error' for less." };
+
+        command.Options.Add(intervalOption);
+        command.Options.Add(logLevelOption);
+
+        command.SetAction(async (ParseResult parseResult, CancellationToken ct) =>
+        {
+            var logger = services.GetRequiredService<ILogger<Program>>();
+            return await ConsoleOutput.RunWithErrorHandling(async () =>
+            {
+                var ghCli = services.GetRequiredService<GhCliService>();
+                var copilotCli = services.GetRequiredService<CopilotCliService>();
+                var stateStore = services.GetRequiredService<StateStore>();
+
+                var interval = parseResult.GetValue(intervalOption);
+                var logLevel = parseResult.GetValue(logLevelOption);
+
+                // Pre-flight checks
+                var preflightResult = PreflightChecks.Run(ghCli, copilotCli, stateStore);
+                if (preflightResult != 0)
+                    return preflightResult;
+
+                // Check if daemon is already running
+                if (stateStore.IsLockHeld())
+                {
+                    ConsoleOutput.Error("copilotd daemon is already running.");
+                    return 1;
+                }
+
+                // Build arguments for the run command
+                var args = $"run --interval {interval}";
+                if (logLevel is not null)
+                {
+                    args += $" --log-level {logLevel}";
+                }
+
+                var copilotdPath = Environment.ProcessPath;
+                if (copilotdPath is null)
+                {
+                    ConsoleOutput.Error("Cannot determine copilotd executable path.");
+                    return 1;
+                }
+
+                // Launch daemon as a detached background process
+                int childPid;
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    childPid = LaunchDetachedWindows(copilotdPath, args);
+                }
+                else
+                {
+                    childPid = LaunchDetachedUnix(copilotdPath, args);
+                }
+
+                if (childPid <= 0)
+                {
+                    ConsoleOutput.Error("Failed to start copilotd daemon process.");
+                    return 1;
+                }
+
+                // Poll until the daemon acquires the lock or the child dies
+                var deadline = DateTime.UtcNow + StartupTimeout;
+                var started = false;
+
+                while (DateTime.UtcNow < deadline)
+                {
+                    await Task.Delay(StartupPollInterval, ct);
+
+                    // Check if child process died early (preflight failure, etc.)
+                    try
+                    {
+                        using var child = Process.GetProcessById(childPid);
+                        if (child.HasExited)
+                        {
+                            ConsoleOutput.Error($"Daemon process exited unexpectedly (exit code: {child.ExitCode}).");
+                            return 1;
+                        }
+                    }
+                    catch (ArgumentException)
+                    {
+                        // Process already gone
+                        ConsoleOutput.Error("Daemon process exited unexpectedly.");
+                        return 1;
+                    }
+
+                    // Check if the daemon has acquired the lock and written its PID
+                    if (stateStore.IsLockHeld())
+                    {
+                        var pidInfo = stateStore.ReadDaemonPid();
+                        if (pidInfo is { } info && info.Pid == childPid)
+                        {
+                            started = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (!started)
+                {
+                    ConsoleOutput.Error("Daemon did not start within the expected time.");
+                    // Try to clean up the child process
+                    try
+                    {
+                        using var child = Process.GetProcessById(childPid);
+                        if (!child.HasExited)
+                            child.Kill(entireProcessTree: true);
+                    }
+                    catch { /* best effort */ }
+                    return 1;
+                }
+
+                ConsoleOutput.Success($"copilotd daemon started in background (PID: {childPid}). Use 'copilotd stop' to shut down.");
+                return 0;
+            }, logger);
+        });
+
+        return command;
+    }
+
+    /// <summary>
+    /// Windows: use CreateProcessW with CREATE_NEW_CONSOLE to give the daemon its own
+    /// console (hidden). This is required for shutdown-instance to attach and send signals.
+    /// </summary>
+    private static int LaunchDetachedWindows(string exePath, string args)
+    {
+        var si = new STARTUPINFO { cb = Marshal.SizeOf<STARTUPINFO>() };
+        si.dwFlags = STARTF_USESHOWWINDOW;
+        si.wShowWindow = SW_HIDE;
+
+        var cmdLine = $"\"{exePath}\" {args}";
+        var flags = CREATE_NEW_CONSOLE | CREATE_NEW_PROCESS_GROUP;
+
+        if (!CreateProcessW(null, cmdLine, IntPtr.Zero, IntPtr.Zero, false,
+            flags, IntPtr.Zero, null, ref si, out var pi))
+        {
+            return -1;
+        }
+
+        var pid = pi.dwProcessId;
+        CloseHandle(pi.hProcess);
+        CloseHandle(pi.hThread);
+        return pid;
+    }
+
+    /// <summary>
+    /// Unix: use setsid to create a new session, detaching from the terminal.
+    /// Stdin/stdout/stderr are redirected to /dev/null.
+    /// </summary>
+    private static int LaunchDetachedUnix(string exePath, string args)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "setsid",
+            Arguments = $"\"{exePath}\" {args}",
+            UseShellExecute = false,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+        };
+
+        try
+        {
+            using var process = Process.Start(psi);
+            if (process is null)
+                return -1;
+
+            // Close stdin so daemon doesn't wait for input.
+            // Don't close stdout/stderr - let them be inherited (they go to the
+            // hidden console or are silently discarded by setsid).
+            process.StandardInput.Close();
+
+            // setsid is the child we started; the actual daemon is its child.
+            // But on most systems setsid execs directly, so PID is the same.
+            // Wait briefly for setsid to exec, then check if copilotd is running.
+            // Since setsid replaces itself via exec, process.Id IS the daemon PID.
+            return process.Id;
+        }
+        catch
+        {
+            // setsid not available, fall back to direct launch
+            var fallbackPsi = new ProcessStartInfo
+            {
+                FileName = exePath,
+                Arguments = args,
+                UseShellExecute = false,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+            };
+
+            try
+            {
+                var process = Process.Start(fallbackPsi);
+                if (process is null)
+                    return -1;
+
+                process.StandardInput.Close();
+                var pid = process.Id;
+                // Don't dispose - we want the process to keep running
+                return pid;
+            }
+            catch
+            {
+                return -1;
+            }
+        }
+    }
+}

--- a/src/copilotd/Commands/StopCommand.cs
+++ b/src/copilotd/Commands/StopCommand.cs
@@ -1,0 +1,211 @@
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Copilotd.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using static Copilotd.Infrastructure.NativeInterop;
+
+namespace Copilotd.Commands;
+
+public static class StopCommand
+{
+    private static readonly TimeSpan SignalDelay = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan GracefulTimeout = TimeSpan.FromSeconds(15);
+
+    public static Command Create(IServiceProvider services)
+    {
+        var command = new Command("stop", "Stop the copilotd daemon");
+
+        command.SetAction(async (ParseResult parseResult, CancellationToken ct) =>
+        {
+            var logger = services.GetRequiredService<ILogger<Program>>();
+            return await ConsoleOutput.RunWithErrorHandling(async () =>
+            {
+                var stateStore = services.GetRequiredService<StateStore>();
+
+                // Check if daemon is running
+                if (!stateStore.IsLockHeld())
+                {
+                    ConsoleOutput.Warning("copilotd daemon is not running.");
+                    return 0;
+                }
+
+                // Read daemon PID
+                var pidInfo = stateStore.ReadDaemonPid();
+                if (pidInfo is null)
+                {
+                    ConsoleOutput.Error("Daemon appears to be running but PID file is missing. Cannot send shutdown signal.");
+                    ConsoleOutput.Info("If the daemon was started with 'copilotd run', press Ctrl+C in that terminal instead.");
+                    return 1;
+                }
+
+                var (pid, expectedStartTime) = pidInfo.Value;
+
+                // Verify the process is alive and matches
+                Process process;
+                try
+                {
+                    process = Process.GetProcessById(pid);
+                }
+                catch (ArgumentException)
+                {
+                    ConsoleOutput.Warning("Daemon process not found (may have already exited). Cleaning up.");
+                    return 0;
+                }
+
+                try
+                {
+                    // Verify start time to avoid signalling a wrong process after PID reuse
+                    try
+                    {
+                        var actualStart = new DateTimeOffset(process.StartTime.ToUniversalTime(), TimeSpan.Zero);
+                        if (Math.Abs((actualStart - expectedStartTime).TotalSeconds) > 5)
+                        {
+                            ConsoleOutput.Error($"PID {pid} belongs to a different process (start time mismatch). The daemon may have already exited.");
+                            return 1;
+                        }
+                    }
+                    catch
+                    {
+                        // Can't read start time — proceed anyway, lock file confirms daemon is running
+                    }
+
+                    if (process.HasExited)
+                    {
+                        ConsoleOutput.Warning("Daemon process has already exited.");
+                        return 0;
+                    }
+
+                    ConsoleOutput.Info($"Stopping copilotd daemon (PID: {pid})...");
+
+                    bool terminated;
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    {
+                        terminated = StopDaemonWindows(process, pid);
+                    }
+                    else
+                    {
+                        terminated = StopDaemonUnix(process, pid);
+                    }
+
+                    if (!terminated)
+                    {
+                        ConsoleOutput.Error("Failed to stop the daemon process.");
+                        return 1;
+                    }
+
+                    // Wait for the lock to be released (daemon cleans up on exit)
+                    var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+                    while (DateTime.UtcNow < deadline && stateStore.IsLockHeld())
+                    {
+                        await Task.Delay(250, ct);
+                    }
+
+                    ConsoleOutput.Success("copilotd daemon stopped.");
+                    return 0;
+                }
+                finally
+                {
+                    process.Dispose();
+                }
+            }, logger);
+        });
+
+        return command;
+    }
+
+    /// <summary>
+    /// Windows: use the shutdown-instance helper to attach to the daemon's console
+    /// and send Ctrl+Break/Ctrl+C, triggering Console.CancelKeyPress in the daemon.
+    /// </summary>
+    private static bool StopDaemonWindows(Process process, int pid)
+    {
+        var copilotdPath = Environment.ProcessPath;
+        if (copilotdPath is null)
+        {
+            ConsoleOutput.Warning("Cannot determine copilotd path, forcing termination.");
+            return FallbackKill(process);
+        }
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = copilotdPath,
+            Arguments = $"shutdown-instance --pid {pid}",
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        try
+        {
+            using var helper = Process.Start(psi);
+            if (helper is null)
+            {
+                ConsoleOutput.Warning("Failed to start shutdown helper, forcing termination.");
+                return FallbackKill(process);
+            }
+
+            if (helper.WaitForExit(TimeSpan.FromSeconds(20)))
+            {
+                if (helper.ExitCode == 0)
+                    return true;
+            }
+            else
+            {
+                try { helper.Kill(); } catch { }
+            }
+
+            // Fallback if shutdown-instance didn't fully clean up
+            if (!process.HasExited)
+                return FallbackKill(process);
+
+            return true;
+        }
+        catch
+        {
+            return FallbackKill(process);
+        }
+    }
+
+    /// <summary>
+    /// Unix: send SIGINT directly to the daemon, which triggers Console.CancelKeyPress
+    /// for graceful shutdown.
+    /// </summary>
+    private static bool StopDaemonUnix(Process process, int pid)
+    {
+        try
+        {
+            sys_kill(pid, SIGINT);
+
+            if (process.WaitForExit(SignalDelay))
+                return true;
+
+            // Second SIGINT
+            sys_kill(pid, SIGINT);
+
+            if (process.WaitForExit(GracefulTimeout))
+                return true;
+        }
+        catch
+        {
+            // Fall through to kill
+        }
+
+        return FallbackKill(process);
+    }
+
+    private static bool FallbackKill(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/src/copilotd/Infrastructure/NativeInterop.cs
+++ b/src/copilotd/Infrastructure/NativeInterop.cs
@@ -1,0 +1,73 @@
+using System.Runtime.InteropServices;
+
+namespace Copilotd.Infrastructure;
+
+/// <summary>
+/// Shared platform-specific interop declarations used by process management and
+/// daemon lifecycle commands.
+/// </summary>
+internal static class NativeInterop
+{
+    // --- Windows process creation ---
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    public static extern bool CreateProcessW(
+        string? lpApplicationName,
+        string lpCommandLine,
+        IntPtr lpProcessAttributes,
+        IntPtr lpThreadAttributes,
+        bool bInheritHandles,
+        uint dwCreationFlags,
+        IntPtr lpEnvironment,
+        string? lpCurrentDirectory,
+        ref STARTUPINFO lpStartupInfo,
+        out PROCESS_INFORMATION lpProcessInformation);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern bool CloseHandle(IntPtr hObject);
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    public struct STARTUPINFO
+    {
+        public int cb;
+        public IntPtr lpReserved;
+        public IntPtr lpDesktop;
+        public IntPtr lpTitle;
+        public int dwX;
+        public int dwY;
+        public int dwXSize;
+        public int dwYSize;
+        public int dwXCountChars;
+        public int dwYCountChars;
+        public int dwFillAttribute;
+        public int dwFlags;
+        public short wShowWindow;
+        public short cbReserved2;
+        public IntPtr lpReserved2;
+        public IntPtr hStdInput;
+        public IntPtr hStdOutput;
+        public IntPtr hStdError;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct PROCESS_INFORMATION
+    {
+        public IntPtr hProcess;
+        public IntPtr hThread;
+        public int dwProcessId;
+        public int dwThreadId;
+    }
+
+    public const uint CREATE_NEW_CONSOLE = 0x00000010;
+    public const uint CREATE_NEW_PROCESS_GROUP = 0x00000200;
+    public const int STARTF_USESHOWWINDOW = 0x00000001;
+    public const short SW_HIDE = 0;
+
+    // --- Unix signal APIs ---
+
+    [DllImport("libc", EntryPoint = "kill", SetLastError = true)]
+    public static extern int sys_kill(int pid, int sig);
+
+    public const int SIGINT = 2;
+    public const int SIGKILL = 9;
+}

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Copilotd.Models;
 using Microsoft.Extensions.Logging;
+using static Copilotd.Infrastructure.NativeInterop;
 
 namespace Copilotd.Infrastructure;
 
@@ -622,71 +623,6 @@ public sealed partial class ProcessManager
     {
         return RunGit(workingDir, arguments);
     }
-
-    #region Platform Interop
-
-    // Windows process creation API (for launching copilot with its own console)
-    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-    private static extern bool CreateProcessW(
-        string? lpApplicationName,
-        string lpCommandLine,
-        IntPtr lpProcessAttributes,
-        IntPtr lpThreadAttributes,
-        bool bInheritHandles,
-        uint dwCreationFlags,
-        IntPtr lpEnvironment,
-        string? lpCurrentDirectory,
-        ref STARTUPINFO lpStartupInfo,
-        out PROCESS_INFORMATION lpProcessInformation);
-
-    [DllImport("kernel32.dll", SetLastError = true)]
-    private static extern bool CloseHandle(IntPtr hObject);
-
-    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-    private struct STARTUPINFO
-    {
-        public int cb;
-        public IntPtr lpReserved;
-        public IntPtr lpDesktop;
-        public IntPtr lpTitle;
-        public int dwX;
-        public int dwY;
-        public int dwXSize;
-        public int dwYSize;
-        public int dwXCountChars;
-        public int dwYCountChars;
-        public int dwFillAttribute;
-        public int dwFlags;
-        public short wShowWindow;
-        public short cbReserved2;
-        public IntPtr lpReserved2;
-        public IntPtr hStdInput;
-        public IntPtr hStdOutput;
-        public IntPtr hStdError;
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    private struct PROCESS_INFORMATION
-    {
-        public IntPtr hProcess;
-        public IntPtr hThread;
-        public int dwProcessId;
-        public int dwThreadId;
-    }
-
-    private const uint CREATE_NEW_CONSOLE = 0x00000010;
-    private const uint CREATE_NEW_PROCESS_GROUP = 0x00000200;
-    private const int STARTF_USESHOWWINDOW = 0x00000001;
-    private const short SW_HIDE = 0;
-
-    // Unix signal APIs
-    [DllImport("libc", EntryPoint = "kill", SetLastError = true)]
-    private static extern int sys_kill(int pid, int sig);
-
-    private const int SIGINT = 2;
-    private const int SIGKILL = 9;
-
-    #endregion
 }
 
 public enum ProcessLivenessResult

--- a/src/copilotd/Infrastructure/StateStore.cs
+++ b/src/copilotd/Infrastructure/StateStore.cs
@@ -15,6 +15,7 @@ public sealed class StateStore
     private readonly string _configPath;
     private readonly string _statePath;
     private readonly string _lockPath;
+    private readonly string _pidPath;
     private readonly ILogger<StateStore> _logger;
 
     public string ConfigDir => _configDir;
@@ -29,6 +30,7 @@ public sealed class StateStore
         _configPath = Path.Combine(_configDir, "config.json");
         _statePath = Path.Combine(_configDir, "state.json");
         _lockPath = Path.Combine(_configDir, ".lock");
+        _pidPath = Path.Combine(_configDir, ".pid");
         Directory.CreateDirectory(_configDir);
     }
 
@@ -147,12 +149,14 @@ public sealed class StateStore
 
     /// <summary>
     /// Attempts to acquire an exclusive lock. Returns false if another instance holds it.
+    /// Writes daemon PID and start time to a .pid file for the stop command.
     /// </summary>
     public bool TryAcquireLock()
     {
         try
         {
             _lockStream = new FileStream(_lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+            WriteDaemonPid();
             return true;
         }
         catch (IOException)
@@ -163,6 +167,9 @@ public sealed class StateStore
 
     public void ReleaseLock()
     {
+        // Clear PID file BEFORE releasing lock to prevent a new daemon from
+        // writing its PID and then having it deleted by the old daemon
+        ClearDaemonPid();
         _lockStream?.Dispose();
         _lockStream = null;
         try { File.Delete(_lockPath); } catch { /* best effort */ }
@@ -188,6 +195,59 @@ public sealed class StateStore
             // Another process holds the lock
             return true;
         }
+    }
+
+    // --- Daemon PID tracking ---
+
+    /// <summary>
+    /// Writes the current process ID and start time to ~/.copilotd/.pid.
+    /// Used by the stop command to locate and verify the daemon process.
+    /// </summary>
+    private void WriteDaemonPid()
+    {
+        try
+        {
+            var startTime = System.Diagnostics.Process.GetCurrentProcess().StartTime.ToUniversalTime();
+            var content = $"{Environment.ProcessId}\n{startTime:O}";
+            File.WriteAllText(_pidPath, content);
+            _logger.LogDebug("Wrote daemon PID {Pid} to {Path}", Environment.ProcessId, _pidPath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to write daemon PID file");
+        }
+    }
+
+    /// <summary>
+    /// Reads the daemon PID and start time from the .pid file.
+    /// Returns null if the file is missing, corrupt, or unreadable.
+    /// </summary>
+    public (int Pid, DateTimeOffset StartTime)? ReadDaemonPid()
+    {
+        if (!File.Exists(_pidPath))
+            return null;
+
+        try
+        {
+            var lines = File.ReadAllLines(_pidPath);
+            if (lines.Length >= 2
+                && int.TryParse(lines[0].Trim(), out var pid)
+                && DateTimeOffset.TryParse(lines[1].Trim(), out var startTime))
+            {
+                return (pid, startTime);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to read daemon PID file");
+        }
+
+        return null;
+    }
+
+    private void ClearDaemonPid()
+    {
+        try { File.Delete(_pidPath); } catch { /* best effort */ }
     }
 
     // --- Helpers ---

--- a/src/copilotd/Program.cs
+++ b/src/copilotd/Program.cs
@@ -22,6 +22,8 @@ public class Program
             rootCommand.Subcommands.Add(ConfigCommand.Create(services));
             rootCommand.Subcommands.Add(RulesCommand.Create(services));
             rootCommand.Subcommands.Add(RunCommand.Create(services));
+            rootCommand.Subcommands.Add(StartCommand.Create(services));
+            rootCommand.Subcommands.Add(StopCommand.Create(services));
             rootCommand.Subcommands.Add(StatusCommand.Create(services));
             rootCommand.Subcommands.Add(SessionCommand.Create(services));
             rootCommand.Subcommands.Add(ShutdownInstanceCommand.Create());
@@ -72,10 +74,11 @@ public class Program
             }
         }
 
-        // Default to Information level for the 'run' command so users can see
+        // Default to Information level for the 'run' and 'start' commands so users can see
         // poll cycle activity and session status changes without needing --log-level
         var command = args.FirstOrDefault(a => !a.StartsWith('-'));
-        if (string.Equals(command, "run", StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(command, "run", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(command, "start", StringComparison.OrdinalIgnoreCase))
         {
             return LogLevel.Information;
         }


### PR DESCRIPTION
## Summary

Implements \copilotd start\ and \copilotd stop\ commands to support running the daemon in a detached/background state, as requested in #25.

## Changes

### New Commands
- **\copilotd start\** — Launches the daemon as a detached background process
  - Runs the same pre-flight checks as \copilotd run\ (gh CLI, copilot CLI, auth, config)
  - On Windows: uses \CreateProcessW\ with \CREATE_NEW_CONSOLE\ + hidden window, required for \shutdown-instance\ to attach for graceful shutdown
  - On Unix: uses \setsid\ to create a new session detached from the terminal
  - Polls for startup verification (lock acquired + PID match) with timeout
  - Passes through \--interval\ and \--log-level\ options to the \un\ command

- **\copilotd stop\** — Gracefully stops the background daemon
  - Reads daemon PID from \~/.copilotd/.pid\ file
  - Verifies process identity via start time comparison (PID reuse detection)
  - On Windows: reuses the existing \shutdown-instance\ helper mechanism
  - On Unix: sends \SIGINT\ directly, with fallback to \SIGKILL\
  - Waits for lock file release to confirm clean shutdown

### Infrastructure
- **PID file** (\~/.copilotd/.pid\) — Stores daemon PID + start time; written on lock acquisition, cleared before lock release to prevent race conditions
- **NativeInterop** — Extracted shared P/Invoke declarations from \ProcessManager\ into a shared class, used by both \ProcessManager\ and \StartCommand\
- **PreflightChecks** — Extracted shared validation logic used by both \un\ and \start\ commands

## Testing

Verified locally on Windows:
- \copilotd start\ launches daemon in background, reports PID ✅
- \copilotd start\ when already running returns error ✅
- \copilotd status\ shows daemon as running after start ✅
- \copilotd stop\ gracefully shuts down daemon ✅
- PID and lock files cleaned up after stop ✅
- \copilotd stop\ when not running shows warning ✅
- Start → stop → start round-trip works correctly ✅

Closes #25