### PR TITLE
Add flexible repo path resolution

### DIFF
--- a/src/copilotd/Commands/InitCommand.cs
+++ b/src/copilotd/Commands/InitCommand.cs
@@ -92,14 +92,9 @@ public static class InitCommand
                 }
                 else
                 {
-                    // Check which repos are cloned locally under RepoHome
+                    // Check which repos are cloned locally under RepoHome (single scan, not per-repo)
                     var repoResolver = services.GetRequiredService<RepoPathResolver>();
-                    var dummyState = new DaemonState();
-                    var cloneStatus = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
-                    foreach (var repo in repos)
-                    {
-                        cloneStatus[repo] = repoResolver.ResolveRepoPath(repo, config, dummyState) is not null;
-                    }
+                    var cloneStatus = repoResolver.BuildCloneStatusMap(repos, config);
 
                     var clonedCount = cloneStatus.Values.Count(v => v);
                     AnsiConsole.MarkupLine($"[grey]Found {clonedCount} of {repos.Count} repos cloned under {Markup.Escape(config.RepoHome)}[/]");

--- a/src/copilotd/Commands/InitCommand.cs
+++ b/src/copilotd/Commands/InitCommand.cs
@@ -61,7 +61,7 @@ public static class InitCommand
 
                 // Prompt for repo home directory
                 var examplePath = OperatingSystem.IsWindows() ? @"C:\source" : "~/repos";
-                var prompt = $"Enter the directory where repos are cloned (e.g., {examplePath}):";
+                var prompt = $"Enter the directory where your repos are cloned (e.g., {examplePath}):";
                 var repoHome = config.RepoHome is not null
                     ? AnsiConsole.Ask(prompt, config.RepoHome)
                     : AnsiConsole.Ask<string>(prompt);
@@ -92,13 +92,40 @@ public static class InitCommand
                 }
                 else
                 {
+                    // Check which repos are cloned locally under RepoHome
+                    var repoResolver = services.GetRequiredService<RepoPathResolver>();
+                    var dummyState = new DaemonState();
+                    var cloneStatus = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+                    foreach (var repo in repos)
+                    {
+                        cloneStatus[repo] = repoResolver.ResolveRepoPath(repo, config, dummyState) is not null;
+                    }
+
+                    var clonedCount = cloneStatus.Values.Count(v => v);
+                    AnsiConsole.MarkupLine($"[grey]Found {clonedCount} of {repos.Count} repos cloned under {Markup.Escape(config.RepoHome)}[/]");
+                    AnsiConsole.MarkupLine("[grey]Only cloned repos can be dispatched — repos are not auto-cloned.[/]");
+                    AnsiConsole.WriteLine();
+
                     var selected = AnsiConsole.Prompt(
                         new MultiSelectionPrompt<string>()
-                            .Title("Select repositories to watch:")
+                            .Title("Select repositories to watch ([green]cloned[/] repos will dispatch, [red]not cloned[/] repos will be skipped until cloned):")
                             .PageSize(15)
                             .MoreChoicesText("[grey](Move up/down, space to select, enter to confirm)[/]")
                             .InstructionsText("[grey](Press space to toggle, enter to accept)[/]")
+                            .UseConverter(r => cloneStatus.GetValueOrDefault(r)
+                                ? $"{Markup.Escape(r)} [green](cloned)[/]"
+                                : $"{Markup.Escape(r)} [red](not cloned)[/]")
                             .AddChoices(repos));
+
+                    var notClonedSelected = selected.Where(r => !cloneStatus.GetValueOrDefault(r)).ToList();
+                    if (notClonedSelected.Count > 0)
+                    {
+                        AnsiConsole.WriteLine();
+                        ConsoleOutput.Warning($"{notClonedSelected.Count} selected repo(s) are not cloned yet and will be skipped during dispatch:");
+                        foreach (var repo in notClonedSelected)
+                            AnsiConsole.MarkupLine($"  [yellow]• {Markup.Escape(repo)}[/]");
+                        AnsiConsole.MarkupLine($"[grey]Clone them under {Markup.Escape(config.RepoHome)} to enable dispatching.[/]");
+                    }
 
                     if (selected.Count == 0)
                     {

--- a/src/copilotd/Commands/SessionCommand.cs
+++ b/src/copilotd/Commands/SessionCommand.cs
@@ -127,11 +127,12 @@ public static class SessionCommand
                     return 1;
                 }
 
-                // Use worktree path if available, otherwise fall back to main repo
-                var workingDir = session.WorktreePath ?? config.GetRepoPath(session.Repo);
-                if (!Directory.Exists(workingDir))
+                // Use worktree path if available, otherwise resolve the main repo
+                var repoResolver = services.GetRequiredService<RepoPathResolver>();
+                var workingDir = session.WorktreePath ?? repoResolver.ResolveRepoPath(session.Repo, config, state);
+                if (workingDir is null || !Directory.Exists(workingDir))
                 {
-                    ConsoleOutput.Error($"Working directory not found: {workingDir}");
+                    ConsoleOutput.Error($"Working directory not found for {session.Repo}. Ensure the repository is cloned under the configured RepoHome directory.");
                     return 1;
                 }
 
@@ -366,7 +367,7 @@ public static class SessionCommand
                 }
 
                 // Clean up old worktree before resetting
-                processManager.CleanupWorktree(session, config);
+                processManager.CleanupWorktree(session, config, state);
 
                 session.Status = SessionStatus.Pending;
                 session.CompletedBySession = false;

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -16,11 +16,13 @@ public sealed partial class ProcessManager
     private static readonly TimeSpan GracefulTimeout = TimeSpan.FromSeconds(10);
 
     private readonly StateStore _stateStore;
+    private readonly RepoPathResolver _repoResolver;
     private readonly ILogger<ProcessManager> _logger;
 
-    public ProcessManager(StateStore stateStore, ILogger<ProcessManager> logger)
+    public ProcessManager(StateStore stateStore, RepoPathResolver repoResolver, ILogger<ProcessManager> logger)
     {
         _stateStore = stateStore;
+        _repoResolver = repoResolver;
         _logger = logger;
     }
 
@@ -28,13 +30,13 @@ public sealed partial class ProcessManager
     /// Launches a copilot process detached from this daemon so it survives daemon crashes.
     /// Returns the populated session on success, or null on failure.
     /// </summary>
-    public DispatchSession? LaunchCopilot(DispatchSession session, CopilotdConfig config, GitHubIssue issue)
+    public DispatchSession? LaunchCopilot(DispatchSession session, CopilotdConfig config, GitHubIssue issue, DaemonState state)
     {
-        // Use worktree path if available, otherwise fall back to main repo path
-        var repoPath = session.WorktreePath ?? config.GetRepoPath(issue.Repo);
-        if (!Directory.Exists(repoPath))
+        // Use worktree path if available, otherwise resolve the main repo path
+        var repoPath = session.WorktreePath ?? _repoResolver.ResolveRepoPath(issue.Repo, config, state);
+        if (repoPath is null || !Directory.Exists(repoPath))
         {
-            _logger.LogWarning("Working directory not found: {Path}", repoPath);
+            _logger.LogWarning("Working directory not found for {Repo}", issue.Repo);
             return null;
         }
 
@@ -425,12 +427,12 @@ public sealed partial class ProcessManager
     /// Creates a git worktree for the session on a new branch from the latest default branch.
     /// Layout: &lt;repo_home&gt;/org/repo_sessions/issue-N/
     /// </summary>
-    public bool PrepareWorktree(DispatchSession session, CopilotdConfig config)
+    public bool PrepareWorktree(DispatchSession session, CopilotdConfig config, DaemonState state)
     {
-        var mainRepoPath = config.GetRepoPath(session.Repo);
-        if (!Directory.Exists(mainRepoPath))
+        var mainRepoPath = _repoResolver.ResolveRepoPath(session.Repo, config, state);
+        if (mainRepoPath is null || !Directory.Exists(mainRepoPath))
         {
-            _logger.LogWarning("Main repo directory not found: {Path}", mainRepoPath);
+            _logger.LogWarning("Main repo directory not found for {Repo}", session.Repo);
             return false;
         }
 
@@ -507,9 +509,9 @@ public sealed partial class ProcessManager
     /// Removes the git worktree and branch associated with a session.
     /// Safe to call even when WorktreePath is null (e.g., after a failed PrepareWorktree).
     /// </summary>
-    public void CleanupWorktree(DispatchSession session, CopilotdConfig config)
+    public void CleanupWorktree(DispatchSession session, CopilotdConfig config, DaemonState state)
     {
-        var mainRepoPath = config.GetRepoPath(session.Repo);
+        var mainRepoPath = _repoResolver.ResolveRepoPath(session.Repo, config, state);
 
         // Remove the worktree directory if it exists
         if (!string.IsNullOrEmpty(session.WorktreePath))
@@ -518,7 +520,10 @@ public sealed partial class ProcessManager
 
             if (Directory.Exists(session.WorktreePath))
             {
-                RunGit(mainRepoPath, $"worktree remove \"{session.WorktreePath}\" --force");
+                if (mainRepoPath is not null)
+                    RunGit(mainRepoPath, $"worktree remove \"{session.WorktreePath}\" --force");
+                else
+                    _logger.LogWarning("Cannot run 'git worktree remove' for {Key}: main repo path not found", session.IssueKey);
             }
 
             session.WorktreePath = null;
@@ -527,10 +532,17 @@ public sealed partial class ProcessManager
         // Delete the branch — use the stored name, falling back to the legacy
         // naming scheme for sessions created before BranchName tracking was added.
         // Only clear BranchName on success so a future cleanup can retry.
-        var branchName = session.BranchName ?? $"copilotd/issue-{session.IssueNumber}";
-        if (RunGit(mainRepoPath, $"branch -D {branchName}"))
+        if (mainRepoPath is not null)
         {
-            session.BranchName = null;
+            var branchName = session.BranchName ?? $"copilotd/issue-{session.IssueNumber}";
+            if (RunGit(mainRepoPath, $"branch -D {branchName}"))
+            {
+                session.BranchName = null;
+            }
+        }
+        else
+        {
+            _logger.LogWarning("Cannot clean up branch for {Key}: main repo path not found", session.IssueKey);
         }
     }
 

--- a/src/copilotd/Infrastructure/RepoPathResolver.cs
+++ b/src/copilotd/Infrastructure/RepoPathResolver.cs
@@ -202,8 +202,10 @@ public sealed class RepoPathResolver
 
         // Check candidates in parallel — each check shells out to git which is ~50-100ms,
         // so parallelism helps when RepoHome contains many repositories
+        var maxParallelism = Math.Min(Environment.ProcessorCount / 2, 8);
+        maxParallelism = Math.Max(maxParallelism, 1);
         string? match = null;
-        Parallel.ForEach(candidates, new ParallelOptions { MaxDegreeOfParallelism = 8 }, (candidate, loopState) =>
+        Parallel.ForEach(candidates, new ParallelOptions { MaxDegreeOfParallelism = maxParallelism }, (candidate, loopState) =>
         {
             if (MatchesRemote(candidate, expectedSlug))
             {

--- a/src/copilotd/Infrastructure/RepoPathResolver.cs
+++ b/src/copilotd/Infrastructure/RepoPathResolver.cs
@@ -200,14 +200,19 @@ public sealed class RepoPathResolver
 
         _logger.LogDebug("Found {Count} git repositories to check under {RepoHome}", candidates.Count, repoHome);
 
-        // Check candidates sequentially — the candidate set is small and bounded
-        foreach (var candidate in candidates)
+        // Check candidates in parallel — each check shells out to git which is ~50-100ms,
+        // so parallelism helps when RepoHome contains many repositories
+        string? match = null;
+        Parallel.ForEach(candidates, new ParallelOptions { MaxDegreeOfParallelism = 8 }, (candidate, loopState) =>
         {
             if (MatchesRemote(candidate, expectedSlug))
-                return candidate;
-        }
+            {
+                Interlocked.CompareExchange(ref match, candidate, null);
+                loopState.Stop();
+            }
+        });
 
-        return null;
+        return match;
     }
 
     /// <summary>

--- a/src/copilotd/Infrastructure/RepoPathResolver.cs
+++ b/src/copilotd/Infrastructure/RepoPathResolver.cs
@@ -1,0 +1,288 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using Copilotd.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Copilotd.Infrastructure;
+
+/// <summary>
+/// Resolves the local filesystem path for a GitHub repository using a tiered strategy:
+/// 1. Check in-memory + persisted cache (validated against remote URL)
+/// 2. Direct check: &lt;RepoHome&gt;/&lt;repo_name&gt; (flat layout)
+/// 3. Direct check: &lt;RepoHome&gt;/&lt;org&gt;/&lt;repo_name&gt; (nested layout)
+/// 4. Scan RepoHome (up to 2 levels) for matching git remotes
+/// </summary>
+public sealed class RepoPathResolver
+{
+    private readonly ILogger<RepoPathResolver> _logger;
+    private readonly ConcurrentDictionary<string, string> _memoryCache = new(StringComparer.OrdinalIgnoreCase);
+
+    public RepoPathResolver(ILogger<RepoPathResolver> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Resolves the local path for a repo slug (e.g., "org/repo").
+    /// Returns null if the repo cannot be found locally.
+    /// </summary>
+    public string? ResolveRepoPath(string repoSlug, CopilotdConfig config, DaemonState state)
+    {
+        var repoHome = config.RepoHome;
+        if (string.IsNullOrEmpty(repoHome))
+        {
+            _logger.LogWarning("RepoHome is not configured");
+            return null;
+        }
+
+        var parts = repoSlug.Split('/', 2);
+        if (parts.Length != 2)
+        {
+            _logger.LogWarning("Invalid repo slug format: {Slug} (expected org/repo)", repoSlug);
+            return null;
+        }
+
+        var org = parts[0];
+        var repoName = parts[1];
+
+        // 1. Check cache (memory first, then persisted state) — validate remote still matches
+        if (_memoryCache.TryGetValue(repoSlug, out var cached) && IsValidRepoForSlug(cached, repoSlug, repoHome))
+        {
+            _logger.LogDebug("Resolved {Slug} from memory cache: {Path}", repoSlug, cached);
+            return cached;
+        }
+
+        if (state.ResolvedRepoPaths.TryGetValue(repoSlug, out var persisted) && IsValidRepoForSlug(persisted, repoSlug, repoHome))
+        {
+            _memoryCache[repoSlug] = persisted;
+            _logger.LogDebug("Resolved {Slug} from persisted cache: {Path}", repoSlug, persisted);
+            return persisted;
+        }
+
+        // Invalidate stale cache entries
+        _memoryCache.TryRemove(repoSlug, out _);
+        state.ResolvedRepoPaths.Remove(repoSlug);
+
+        // 2. Direct check: <RepoHome>/<repo_name> (flat layout)
+        var flatPath = Path.GetFullPath(Path.Combine(repoHome, repoName));
+        if (IsValidRepoForSlug(flatPath, repoSlug, repoHome))
+        {
+            CachePath(repoSlug, flatPath, state);
+            _logger.LogInformation("Resolved {Slug} via flat layout: {Path}", repoSlug, flatPath);
+            return flatPath;
+        }
+
+        // 3. Direct check: <RepoHome>/<org>/<repo_name> (nested layout)
+        var nestedPath = Path.GetFullPath(Path.Combine(repoHome, org, repoName));
+        if (IsValidRepoForSlug(nestedPath, repoSlug, repoHome))
+        {
+            CachePath(repoSlug, nestedPath, state);
+            _logger.LogInformation("Resolved {Slug} via nested layout: {Path}", repoSlug, nestedPath);
+            return nestedPath;
+        }
+
+        // 4. Scan RepoHome for matching git remotes (up to 2 levels deep)
+        var scanResult = ScanForRepo(repoHome, repoSlug);
+        if (scanResult is not null)
+        {
+            CachePath(repoSlug, scanResult, state);
+            _logger.LogInformation("Resolved {Slug} via scan: {Path}", repoSlug, scanResult);
+            return scanResult;
+        }
+
+        _logger.LogWarning("Could not find local clone for {Slug} under {RepoHome}. " +
+            "Ensure the repository is cloned somewhere under the configured RepoHome directory.",
+            repoSlug, repoHome);
+        return null;
+    }
+
+    /// <summary>
+    /// Invalidates the cached path for a repo slug (e.g., after detecting it's stale).
+    /// </summary>
+    public void InvalidateCache(string repoSlug, DaemonState state)
+    {
+        _memoryCache.TryRemove(repoSlug, out _);
+        state.ResolvedRepoPaths.Remove(repoSlug);
+    }
+
+    private void CachePath(string repoSlug, string path, DaemonState state)
+    {
+        _memoryCache[repoSlug] = path;
+        state.ResolvedRepoPaths[repoSlug] = path;
+    }
+
+    /// <summary>
+    /// Validates that a directory is a git repo whose remote matches the expected slug,
+    /// and that the path is under the current RepoHome.
+    /// </summary>
+    private bool IsValidRepoForSlug(string path, string expectedSlug, string repoHome)
+        => path.StartsWith(Path.GetFullPath(repoHome), StringComparison.OrdinalIgnoreCase)
+           && IsValidRepoDir(path)
+           && MatchesRemote(path, expectedSlug);
+
+    /// <summary>
+    /// Checks if a directory exists and contains a .git folder or file (worktrees use a .git file).
+    /// </summary>
+    private static bool IsValidRepoDir(string path)
+        => Directory.Exists(path) && (Directory.Exists(Path.Combine(path, ".git")) || File.Exists(Path.Combine(path, ".git")));
+
+    /// <summary>
+    /// Checks if a directory name indicates a daemon-managed worktree (e.g., repo_sessions/).
+    /// These should be excluded from scan results.
+    /// </summary>
+    private static bool IsDaemonWorktreeDir(string dirName)
+        => dirName.EndsWith("_sessions", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Runs 'git remote get-url origin' and checks if it matches the expected slug.
+    /// Only checks origin (not upstream) because PrepareWorktree always fetches from origin
+    /// and creates branches from origin's default branch.
+    /// </summary>
+    private bool MatchesRemote(string repoDir, string expectedSlug)
+    {
+        try
+        {
+            var originUrl = GetGitRemoteUrl(repoDir, "origin");
+            if (originUrl is null) return false;
+
+            var slug = NormalizeRemoteUrl(originUrl);
+            return string.Equals(slug, expectedSlug, StringComparison.OrdinalIgnoreCase);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to check remote for {Path}", repoDir);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Scans RepoHome up to 2 levels deep for directories containing a .git folder/file,
+    /// then checks each one's remote URL against the expected repo slug.
+    /// Excludes daemon-managed worktree directories.
+    /// </summary>
+    private string? ScanForRepo(string repoHome, string expectedSlug)
+    {
+        _logger.LogDebug("Scanning {RepoHome} for clone of {Slug}", repoHome, expectedSlug);
+
+        var candidates = new List<string>();
+
+        try
+        {
+            // Level 1: immediate children
+            foreach (var dir in Directory.EnumerateDirectories(repoHome))
+            {
+                var dirName = Path.GetFileName(dir);
+                if (IsDaemonWorktreeDir(dirName))
+                    continue;
+
+                if (IsValidRepoDir(dir))
+                    candidates.Add(dir);
+
+                // Level 2: grandchildren (org/repo layout variations)
+                try
+                {
+                    foreach (var subDir in Directory.EnumerateDirectories(dir))
+                    {
+                        var subDirName = Path.GetFileName(subDir);
+                        if (IsDaemonWorktreeDir(subDirName))
+                            continue;
+
+                        if (IsValidRepoDir(subDir))
+                            candidates.Add(subDir);
+                    }
+                }
+                catch (UnauthorizedAccessException) { }
+                catch (DirectoryNotFoundException) { }
+            }
+        }
+        catch (UnauthorizedAccessException) { }
+        catch (DirectoryNotFoundException) { }
+
+        _logger.LogDebug("Found {Count} git repositories to check under {RepoHome}", candidates.Count, repoHome);
+
+        // Check candidates sequentially — the candidate set is small and bounded
+        foreach (var candidate in candidates)
+        {
+            if (MatchesRemote(candidate, expectedSlug))
+                return candidate;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Runs 'git remote get-url' for the specified remote name in the given directory.
+    /// </summary>
+    private static string? GetGitRemoteUrl(string repoDir, string remoteName)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "git",
+                Arguments = $"remote get-url {remoteName}",
+                WorkingDirectory = repoDir,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = false,
+                CreateNoWindow = true,
+            };
+
+            using var process = Process.Start(psi);
+            if (process is null) return null;
+
+            var output = process.StandardOutput.ReadToEnd().Trim();
+            process.WaitForExit(5000);
+
+            return process.ExitCode == 0 && !string.IsNullOrEmpty(output) ? output : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Normalizes a git remote URL to an "org/repo" slug.
+    /// Handles HTTPS, SSH, and various trailing formats.
+    /// </summary>
+    internal static string? NormalizeRemoteUrl(string url)
+    {
+        // Strip trailing .git
+        if (url.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+            url = url[..^4];
+
+        // Strip trailing slash
+        url = url.TrimEnd('/');
+
+        // SSH format: git@github.com:org/repo
+        if (url.StartsWith("git@", StringComparison.OrdinalIgnoreCase))
+        {
+            var colonIndex = url.IndexOf(':');
+            if (colonIndex >= 0 && colonIndex < url.Length - 1)
+            {
+                return url[(colonIndex + 1)..];
+            }
+            return null;
+        }
+
+        // HTTPS format: https://github.com/org/repo
+        if (url.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
+            || url.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
+        {
+            var uri = new Uri(url);
+            var path = uri.AbsolutePath.TrimStart('/').TrimEnd('/');
+            return string.IsNullOrEmpty(path) ? null : path;
+        }
+
+        // ssh://git@github.com/org/repo
+        if (url.StartsWith("ssh://", StringComparison.OrdinalIgnoreCase))
+        {
+            var uri = new Uri(url);
+            var path = uri.AbsolutePath.TrimStart('/').TrimEnd('/');
+            return string.IsNullOrEmpty(path) ? null : path;
+        }
+
+        return null;
+    }
+}

--- a/src/copilotd/Infrastructure/RepoPathResolver.cs
+++ b/src/copilotd/Infrastructure/RepoPathResolver.cs
@@ -105,6 +105,111 @@ public sealed class RepoPathResolver
         state.ResolvedRepoPaths.Remove(repoSlug);
     }
 
+    /// <summary>
+    /// Efficiently checks clone status for many repos at once by scanning RepoHome once
+    /// and building a complete slug→path map, then looking up each repo.
+    /// Much faster than calling ResolveRepoPath per-repo when many repos aren't cloned
+    /// (avoids repeated full scans).
+    /// </summary>
+    public Dictionary<string, bool> BuildCloneStatusMap(IReadOnlyList<string> repoSlugs, CopilotdConfig config)
+    {
+        var repoHome = config.RepoHome;
+        var result = new Dictionary<string, bool>(repoSlugs.Count, StringComparer.OrdinalIgnoreCase);
+
+        if (string.IsNullOrEmpty(repoHome))
+        {
+            foreach (var slug in repoSlugs)
+                result[slug] = false;
+            return result;
+        }
+
+        // Scan once to build a map of all local repos: slug → path
+        var localRepos = ScanAllRepos(repoHome);
+
+        foreach (var slug in repoSlugs)
+            result[slug] = localRepos.ContainsKey(slug);
+
+        return result;
+    }
+
+    /// <summary>
+    /// Scans RepoHome up to 2 levels deep and resolves the origin remote for every git repo found.
+    /// Returns a dictionary mapping normalized repo slugs to their local paths.
+    /// </summary>
+    private Dictionary<string, string> ScanAllRepos(string repoHome)
+    {
+        _logger.LogDebug("Scanning all repos under {RepoHome}", repoHome);
+
+        var candidates = FindGitRepoDirs(repoHome);
+
+        _logger.LogDebug("Found {Count} git repositories to index under {RepoHome}", candidates.Count, repoHome);
+
+        // Resolve remotes in parallel
+        var maxParallelism = Math.Max(Math.Min(Environment.ProcessorCount / 2, 8), 1);
+        var result = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        Parallel.ForEach(candidates, new ParallelOptions { MaxDegreeOfParallelism = maxParallelism }, candidate =>
+        {
+            try
+            {
+                var originUrl = GetGitRemoteUrl(candidate, "origin");
+                if (originUrl is null) return;
+
+                var slug = NormalizeRemoteUrl(originUrl);
+                if (slug is not null)
+                    result.TryAdd(slug, candidate);
+            }
+            catch
+            {
+                // Skip repos we can't read
+            }
+        });
+
+        _logger.LogDebug("Indexed {Count} repos with valid origins under {RepoHome}", result.Count, repoHome);
+        return new Dictionary<string, string>(result, StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Finds all directories containing a .git folder/file up to 2 levels under repoHome.
+    /// Excludes daemon-managed worktree directories.
+    /// </summary>
+    private List<string> FindGitRepoDirs(string repoHome)
+    {
+        var candidates = new List<string>();
+
+        try
+        {
+            foreach (var dir in Directory.EnumerateDirectories(repoHome))
+            {
+                var dirName = Path.GetFileName(dir);
+                if (IsDaemonWorktreeDir(dirName))
+                    continue;
+
+                if (IsValidRepoDir(dir))
+                    candidates.Add(dir);
+
+                try
+                {
+                    foreach (var subDir in Directory.EnumerateDirectories(dir))
+                    {
+                        var subDirName = Path.GetFileName(subDir);
+                        if (IsDaemonWorktreeDir(subDirName))
+                            continue;
+
+                        if (IsValidRepoDir(subDir))
+                            candidates.Add(subDir);
+                    }
+                }
+                catch (UnauthorizedAccessException) { }
+                catch (DirectoryNotFoundException) { }
+            }
+        }
+        catch (UnauthorizedAccessException) { }
+        catch (DirectoryNotFoundException) { }
+
+        return candidates;
+    }
+
     private void CachePath(string repoSlug, string path, DaemonState state)
     {
         _memoryCache[repoSlug] = path;
@@ -156,47 +261,14 @@ public sealed class RepoPathResolver
     }
 
     /// <summary>
-    /// Scans RepoHome up to 2 levels deep for directories containing a .git folder/file,
-    /// then checks each one's remote URL against the expected repo slug.
+    /// Scans RepoHome up to 2 levels deep for a matching git remote.
     /// Excludes daemon-managed worktree directories.
     /// </summary>
     private string? ScanForRepo(string repoHome, string expectedSlug)
     {
         _logger.LogDebug("Scanning {RepoHome} for clone of {Slug}", repoHome, expectedSlug);
 
-        var candidates = new List<string>();
-
-        try
-        {
-            // Level 1: immediate children
-            foreach (var dir in Directory.EnumerateDirectories(repoHome))
-            {
-                var dirName = Path.GetFileName(dir);
-                if (IsDaemonWorktreeDir(dirName))
-                    continue;
-
-                if (IsValidRepoDir(dir))
-                    candidates.Add(dir);
-
-                // Level 2: grandchildren (org/repo layout variations)
-                try
-                {
-                    foreach (var subDir in Directory.EnumerateDirectories(dir))
-                    {
-                        var subDirName = Path.GetFileName(subDir);
-                        if (IsDaemonWorktreeDir(subDirName))
-                            continue;
-
-                        if (IsValidRepoDir(subDir))
-                            candidates.Add(subDir);
-                    }
-                }
-                catch (UnauthorizedAccessException) { }
-                catch (DirectoryNotFoundException) { }
-            }
-        }
-        catch (UnauthorizedAccessException) { }
-        catch (DirectoryNotFoundException) { }
+        var candidates = FindGitRepoDirs(repoHome);
 
         _logger.LogDebug("Found {Count} git repositories to check under {RepoHome}", candidates.Count, repoHome);
 

--- a/src/copilotd/Models/CopilotdConfig.cs
+++ b/src/copilotd/Models/CopilotdConfig.cs
@@ -8,7 +8,8 @@ public sealed class CopilotdConfig
     public int SchemaVersion { get; set; } = 1;
 
     /// <summary>
-    /// Root directory where repos are cloned, expecting &lt;org&gt;/&lt;repo_name&gt; sub-folders.
+    /// Root directory where repos are cloned. Supports both flat (&lt;repo_name&gt;) and
+    /// nested (&lt;org&gt;/&lt;repo_name&gt;) layouts. The resolver will scan to find clones.
     /// </summary>
     public string? RepoHome { get; set; }
 
@@ -16,6 +17,8 @@ public sealed class CopilotdConfig
     /// Returns the normalized local filesystem path for a given repo slug (e.g., "org/repo").
     /// Ensures consistent path separators for the current platform.
     /// </summary>
+    [Obsolete("Use RepoPathResolver.ResolveRepoPath() for flexible repo layout support. " +
+              "This method assumes <RepoHome>/<org>/<repo> which doesn't work for all users.")]
     public string GetRepoPath(string repo)
         => Path.GetFullPath(Path.Combine(RepoHome ?? ".", repo));
 

--- a/src/copilotd/Models/SessionState.cs
+++ b/src/copilotd/Models/SessionState.cs
@@ -15,6 +15,12 @@ public sealed class DaemonState
 
     /// <summary>Timestamp of the last successful poll cycle.</summary>
     public DateTimeOffset? LastPollTime { get; set; }
+
+    /// <summary>
+    /// Cached resolved local paths for repos, keyed by repo slug ("org/repo").
+    /// Populated by <see cref="Infrastructure.RepoPathResolver"/> and validated on each use.
+    /// </summary>
+    public Dictionary<string, string> ResolvedRepoPaths { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 }
 
 /// <summary>

--- a/src/copilotd/Program.cs
+++ b/src/copilotd/Program.cs
@@ -49,6 +49,7 @@ public class Program
         });
 
         serviceCollection.AddSingleton<StateStore>();
+        serviceCollection.AddSingleton<RepoPathResolver>();
         serviceCollection.AddSingleton<ProcessManager>();
         serviceCollection.AddSingleton<GhCliService>();
         serviceCollection.AddSingleton<CopilotCliService>();

--- a/src/copilotd/Services/ReconciliationEngine.cs
+++ b/src/copilotd/Services/ReconciliationEngine.cs
@@ -84,7 +84,7 @@ public sealed class ReconciliationEngine
             if (!string.IsNullOrEmpty(session.WorktreePath) || !string.IsNullOrEmpty(session.BranchName))
             {
                 var config = _stateStore.LoadConfig();
-                _processManager.CleanupWorktree(session, config);
+                _processManager.CleanupWorktree(session, config, state);
             }
             state.Sessions.Remove(key);
             _logger.LogDebug("Pruned terminal session {Key}", key);
@@ -260,7 +260,7 @@ public sealed class ReconciliationEngine
                     session.Status = SessionStatus.Completed;
                     session.WaitingSince = null;
                     session.UpdatedAt = DateTimeOffset.UtcNow;
-                    _processManager.CleanupWorktree(session, config);
+                    _processManager.CleanupWorktree(session, config, state);
                     continue;
                 }
 
@@ -281,7 +281,7 @@ public sealed class ReconciliationEngine
             {
                 session.Status = SessionStatus.Completed;
                 session.UpdatedAt = DateTimeOffset.UtcNow;
-                _processManager.CleanupWorktree(session, config);
+                _processManager.CleanupWorktree(session, config, state);
             }
         }
 
@@ -321,7 +321,7 @@ public sealed class ReconciliationEngine
                     case SessionStatus.Orphaned when existing.CanRetry:
                         _logger.LogInformation("Re-dispatching orphaned session {Key} (retry {N}/{Max})",
                             issueKey, existing.RetryCount + 1, DispatchSession.MaxRetries);
-                        _processManager.CleanupWorktree(existing, config);
+                        _processManager.CleanupWorktree(existing, config, state);
                         existing.Status = SessionStatus.Pending;
                         existing.RetryCount++;
                         existing.CopilotSessionId = Guid.NewGuid().ToString();
@@ -351,7 +351,7 @@ public sealed class ReconciliationEngine
                         }
                         // Issue re-appeared after completion — re-dispatch with a fresh session
                         _logger.LogInformation("Issue {Key} re-matched after completion, re-dispatching", issueKey);
-                        _processManager.CleanupWorktree(existing, config);
+                        _processManager.CleanupWorktree(existing, config, state);
                         existing.Status = SessionStatus.Pending;
                         existing.CopilotSessionId = Guid.NewGuid().ToString();
                         existing.ProcessId = null;
@@ -409,7 +409,7 @@ public sealed class ReconciliationEngine
             session.UpdatedAt = DateTimeOffset.UtcNow;
 
             // Create worktree for isolated working directory
-            if (!_processManager.PrepareWorktree(session, config))
+            if (!_processManager.PrepareWorktree(session, config, state))
             {
                 _logger.LogWarning("Failed to prepare worktree for {Key}", session.IssueKey);
                 session.Status = SessionStatus.Failed;
@@ -427,7 +427,7 @@ public sealed class ReconciliationEngine
                 Repo = session.Repo,
             };
 
-            var result = _processManager.LaunchCopilot(session, config, issue);
+            var result = _processManager.LaunchCopilot(session, config, issue, state);
             if (result is null)
             {
                 _logger.LogWarning("Failed to launch copilot for {Key}", session.IssueKey);
@@ -436,7 +436,7 @@ public sealed class ReconciliationEngine
                 session.LastFailureAt = DateTimeOffset.UtcNow;
                 session.UpdatedAt = DateTimeOffset.UtcNow;
                 // Clean up the worktree we just created
-                _processManager.CleanupWorktree(session, config);
+                _processManager.CleanupWorktree(session, config, state);
             }
             // else: session was updated in-place by LaunchCopilot
 


### PR DESCRIPTION
## Summary

Fixes #37

Replaces the hard-coded `<RepoHome>/<org>/<repo>` lookup with a tiered resolution strategy supporting any local clone layout.

## Resolution Strategy

1. **Check cache** - validated against remote URL and current RepoHome
2. **`<RepoHome>/<repo_name>`** - flat layout
3. **`<RepoHome>/<org>/<repo_name>`** - nested layout
4. **Scan RepoHome** - up to 2 levels deep, verifying `git remote get-url origin`

## Key Decisions

- Remote URL verification at every step prevents false positives
- Cache validated on each use (dir exists, .git present, remote matches, under RepoHome)
- Only matches `origin` remote (not `upstream`) since PrepareWorktree uses origin
- Daemon `*_sessions/` worktree dirs excluded from scan
- Sequential scan (small bounded candidate set)

## Files Changed

- **NEW** `Infrastructure/RepoPathResolver.cs` - tiered resolver with cache and URL normalization
- `Models/SessionState.cs` - added `ResolvedRepoPaths` cache to DaemonState
- `Models/CopilotdConfig.cs` - marked `GetRepoPath` obsolete
- `Infrastructure/ProcessManager.cs` - injected resolver, updated 4 call sites
- `Commands/SessionCommand.cs` - updated join + reset call sites
- `Services/ReconciliationEngine.cs` - updated all worktree/launch calls
- `Program.cs` - registered RepoPathResolver in DI
