### PR TITLE
Append custom prompt to default instead of replacing it

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Convenience scripts `copilotd.sh` and `copilotd.cmd` in the repo root run the pr
 | `copilotd session complete <issue>` | Mark a session as completed (callable from within a copilot session) |
 | `copilotd session reset <issue>` | Reset a completed/failed session to pending for re-dispatch |
 | `copilotd config` | Display current configuration |
-| `copilotd config --set key=value` | Set a config value (`repo_home`, `prompt`, `max_instances`) |
+| `copilotd config --set key=value` | Set a config value (`repo_home`, `custom_prompt`, `max_instances`) |
 | `copilotd rules list` | List all dispatch rules |
 | `copilotd rules add <name>` | Add a new dispatch rule |
 | `copilotd rules update <name>` | Update an existing rule |
@@ -101,7 +101,7 @@ copilotd rules update Default --add-repo "org/repo" --delete-repo "org/old-repo"
 
 ### Prompt templating
 
-The base prompt supports token replacement:
+The built-in prompt supports token replacement:
 
 | Token | Value |
 |-------|-------|
@@ -110,7 +110,9 @@ The base prompt supports token replacement:
 | `$(issue.type)` | Issue type (e.g., `bug`) |
 | `$(issue.milestone)` | Milestone title |
 
-Per-rule extra prompts are appended after the base prompt.
+Custom prompt text (configured via `custom_prompt` or `~/.copilotd/prompt.md`) is appended after
+the built-in prompt with a trailer. Tokens are replaced in both the built-in and custom prompt
+text. Per-rule extra prompts are appended last.
 
 ## Session lifecycle
 
@@ -213,7 +215,7 @@ Use `copilotd session join <issue>` to take over any tracked session:
 
 Stored in `~/.copilotd/`:
 
-- `config.json` — user-managed settings (repo home, prompt template, rules)
+- `config.json` — user-managed settings (repo home, custom prompt, rules)
 - `state.json` — runtime session tracking (auto-managed, self-healing)
 - `.lock` — single-instance guard (present while daemon is running)
 
@@ -222,7 +224,7 @@ Stored in `~/.copilotd/`:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `repo_home` | — | Root directory where repos are cloned (`<org>/<repo>` sub-folders expected) |
-| `prompt` | *(see below)* | Base prompt template with token replacement |
+| `prompt` | *(empty)* | Custom prompt text appended to the built-in prompt |
 | `max_instances` | `3` | Maximum concurrent copilot processes; excess sessions queue as Pending |
 
 ### Rule settings
@@ -271,10 +273,10 @@ when sessions complete, are reset, or are pruned.
 
 ### Prompt customization
 
-The prompt template is stored at `~/.copilotd/prompt.md` (created during `copilotd init`).
-Edit this file to customize the instructions given to dispatched copilot sessions. Token
-replacement is applied at dispatch time. Per-rule extra prompts are appended after the base
-prompt.
+Custom prompt text can be provided via `~/.copilotd/prompt.md` or the `prompt` config property.
+This text is **appended** to the built-in copilotd prompt (not a replacement) with a trailer:
+"The user has supplied the following additional context:". Token replacement is applied to both
+the built-in and custom prompt at dispatch time. Per-rule extra prompts are appended last.
 
 ## License
 

--- a/src/copilotd/Commands/ConfigCommand.cs
+++ b/src/copilotd/Commands/ConfigCommand.cs
@@ -34,7 +34,7 @@ public static class ConfigCommand
                     table.AddColumn(new TableColumn("[bold]Value[/]"));
 
                     table.AddRow("repo_home", Markup.Escape(config.RepoHome ?? "(not set)"));
-                    table.AddRow("prompt", Markup.Escape(config.Prompt));
+                    table.AddRow("custom_prompt", Markup.Escape(string.IsNullOrEmpty(config.Prompt) ? "(not set)" : config.Prompt));
                     table.AddRow("current_user", Markup.Escape(config.CurrentUser ?? "(not set)"));
                     table.AddRow("max_instances", Markup.Escape(config.MaxInstances.ToString()));
                     table.AddRow("rules", Markup.Escape($"{config.Rules.Count} rule(s)"));
@@ -91,9 +91,10 @@ public static class ConfigCommand
                         ConsoleOutput.Success($"repo_home set to: {cfg.RepoHome}");
                         break;
 
-                    case "prompt":
+                    case "custom_prompt":
+                    case "prompt": // backward compat
                         cfg.Prompt = value;
-                        ConsoleOutput.Success("prompt updated.");
+                        ConsoleOutput.Success("custom_prompt updated.");
                         break;
 
                     case "max_instances":
@@ -111,7 +112,7 @@ public static class ConfigCommand
 
                     default:
                         ConsoleOutput.Error($"Unknown config key: {key}");
-                        ConsoleOutput.Info("Valid keys: repo_home, prompt, max_instances");
+                        ConsoleOutput.Info("Valid keys: repo_home, custom_prompt, max_instances");
                         return 1;
                 }
 

--- a/src/copilotd/Commands/InitCommand.cs
+++ b/src/copilotd/Commands/InitCommand.cs
@@ -152,7 +152,6 @@ public static class InitCommand
                 }
 
                 stateStore.SaveConfig(config);
-                stateStore.EnsurePromptFile();
                 ConsoleOutput.Success("Configuration saved successfully!");
                 ConsoleOutput.Info($"Config stored in: {stateStore.ConfigDir}");
 

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -40,8 +40,8 @@ public sealed partial class ProcessManager
             return null;
         }
 
-        var promptTemplate = _stateStore.LoadPromptTemplate(config);
-        var prompt = BuildPrompt(promptTemplate, issue, session, config);
+        var customPrompt = _stateStore.LoadCustomPrompt(config);
+        var prompt = BuildPrompt(customPrompt, issue, session, config);
         var args = BuildArguments(session, prompt, config.Rules.GetValueOrDefault(session.RuleName), repoPath);
 
         _logger.LogInformation("Launching copilot for {IssueKey} with session {SessionId}", session.IssueKey, session.CopilotSessionId);
@@ -355,19 +355,27 @@ public sealed partial class ProcessManager
         return true;
     }
 
-    private static string BuildPrompt(string template, GitHubIssue issue, DispatchSession session, CopilotdConfig config)
+    private static string BuildPrompt(string customPrompt, GitHubIssue issue, DispatchSession session, CopilotdConfig config)
     {
-        var prompt = template
-            .Replace("$(issue.repo)", issue.Repo)
-            .Replace("$(issue.id)", issue.Number.ToString())
-            .Replace("$(issue.type)", issue.Type ?? "issue")
-            .Replace("$(issue.milestone)", issue.Milestone ?? "none");
+        var prompt = CopilotdConfig.DefaultPrompt;
+
+        if (!string.IsNullOrWhiteSpace(customPrompt))
+        {
+            prompt += "\n\nThe user has supplied the following additional context:\n\n" + customPrompt;
+        }
 
         var rule = config.Rules.GetValueOrDefault(session.RuleName);
         if (!string.IsNullOrWhiteSpace(rule?.ExtraPrompt))
         {
             prompt += "\n\n" + rule.ExtraPrompt;
         }
+
+        // Replace tokens in the entire prompt (default + custom + extra)
+        prompt = prompt
+            .Replace("$(issue.repo)", issue.Repo)
+            .Replace("$(issue.id)", issue.Number.ToString())
+            .Replace("$(issue.type)", issue.Type ?? "issue")
+            .Replace("$(issue.milestone)", issue.Milestone ?? "none");
 
         return prompt;
     }

--- a/src/copilotd/Infrastructure/StateStore.cs
+++ b/src/copilotd/Infrastructure/StateStore.cs
@@ -99,10 +99,11 @@ public sealed class StateStore
     // --- Prompt ---
 
     /// <summary>
-    /// Loads the prompt template from ~/.copilotd/prompt.md if it exists,
-    /// falling back to the config's inline Prompt property.
+    /// Loads the user's custom prompt addition from ~/.copilotd/prompt.md if it exists
+    /// and contains non-default content, falling back to the config's inline Prompt property.
+    /// Returns empty string if no custom prompt is configured.
     /// </summary>
-    public string LoadPromptTemplate(CopilotdConfig config)
+    public string LoadCustomPrompt(CopilotdConfig config)
     {
         if (File.Exists(PromptPath))
         {
@@ -111,8 +112,14 @@ public sealed class StateStore
                 var content = File.ReadAllText(PromptPath).Trim();
                 if (!string.IsNullOrEmpty(content))
                 {
-                    _logger.LogDebug("Loaded prompt template from {Path}", PromptPath);
-                    return content;
+                    // Strip the old default prompt prefix if present (backward compat
+                    // for users who appended to the auto-generated prompt.md)
+                    content = StripDefaultPromptPrefix(content);
+                    if (!string.IsNullOrEmpty(content))
+                    {
+                        _logger.LogDebug("Loaded custom prompt from {Path}", PromptPath);
+                        return content;
+                    }
                 }
             }
             catch (Exception ex)
@@ -121,27 +128,43 @@ public sealed class StateStore
             }
         }
 
-        return config.Prompt;
+        var configPrompt = config.Prompt.Trim();
+        if (!string.IsNullOrEmpty(configPrompt) && !IsDefaultPrompt(configPrompt))
+        {
+            return configPrompt;
+        }
+
+        return "";
     }
 
     /// <summary>
-    /// Writes the default prompt template to ~/.copilotd/prompt.md if it doesn't exist.
+    /// Returns true if the content matches the built-in default prompt (backward compat).
+    /// Older versions wrote the default prompt to prompt.md and config.Prompt; these
+    /// should be treated as "no custom prompt" rather than appended content.
     /// </summary>
-    public void EnsurePromptFile()
-    {
-        if (File.Exists(PromptPath))
-            return;
+    private static bool IsDefaultPrompt(string content)
+        => NormalizeForComparison(content) == NormalizeForComparison(CopilotdConfig.DefaultPrompt);
 
-        try
+    /// <summary>
+    /// If the content starts with the default prompt (e.g. a user appended to the old
+    /// auto-generated prompt.md), strips the default prefix and returns only the custom part.
+    /// </summary>
+    private static string StripDefaultPromptPrefix(string content)
+    {
+        var normalizedContent = NormalizeForComparison(content);
+        var normalizedDefault = NormalizeForComparison(CopilotdConfig.DefaultPrompt);
+
+        if (normalizedContent.StartsWith(normalizedDefault, StringComparison.Ordinal))
         {
-            File.WriteAllText(PromptPath, CopilotdConfig.DefaultPrompt);
-            _logger.LogDebug("Created default prompt file at {Path}", PromptPath);
+            var remainder = content.Trim()[CopilotdConfig.DefaultPrompt.Trim().Length..].Trim();
+            return remainder;
         }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to create prompt.md");
-        }
+
+        return content;
     }
+
+    private static string NormalizeForComparison(string s)
+        => s.Trim().ReplaceLineEndings("\n");
 
     // --- Single-instance guard ---
 

--- a/src/copilotd/Models/CopilotdConfig.cs
+++ b/src/copilotd/Models/CopilotdConfig.cs
@@ -23,10 +23,10 @@ public sealed class CopilotdConfig
         => Path.GetFullPath(Path.Combine(RepoHome ?? ".", repo));
 
     /// <summary>
-    /// Base prompt template for dispatched copilot sessions.
-    /// Supports tokens: $(issue.repo), $(issue.id), $(issue.type), $(issue.milestone).
+    /// Custom prompt text appended to the default copilotd prompt.
+    /// When non-empty, this is added after the built-in prompt with a trailer.
     /// </summary>
-    public string Prompt { get; set; } = DefaultPrompt;
+    public string Prompt { get; set; } = "";
 
     /// <summary>
     /// The GitHub username of the authenticated user (populated during init).


### PR DESCRIPTION
## Summary

Changes prompt customization to **append** user-supplied prompt text to the built-in copilotd prompt rather than replacing it entirely. This prevents users from accidentally breaking copilotd functionality by overriding the operational instructions in the default prompt.

When a custom prompt is configured (via \~/.copilotd/prompt.md\ or \config.json\), it is appended after the default prompt with a trailer:
> The user has supplied the following additional context:

## Changes

- **CopilotdConfig.Prompt** now defaults to empty string (represents custom additions only)
- **StateStore.LoadCustomPrompt** (renamed from \LoadPromptTemplate\) returns only user-provided content, with backward-compat logic to detect and strip old default prompt content from legacy \prompt.md\ files
- **ProcessManager.BuildPrompt** always uses \DefaultPrompt\ as the base template, appending custom prompt and rule \ExtraPrompt\ after it. Token replacement (\\\) runs over the full combined prompt
- **ConfigCommand** uses \custom_prompt\ key (with \prompt\ backward compat)
- **InitCommand** no longer auto-creates \prompt.md\ with default content

## Backward compatibility

- Existing \prompt.md\ files containing the old default prompt are detected and treated as no custom prompt
- Existing \prompt.md\ files where users appended to the default have the default prefix stripped, preserving only the custom additions
- The \prompt\ config key still works via \--set prompt=...\ (maps to the same property)
- JSON property name in \config.json\ remains \prompt\

Closes #39