### PR TITLE
Add per-rule custom prompt with append/override mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,14 @@ Convenience scripts `copilotd.sh` and `copilotd.cmd` in the repo root run the pr
 
 ### Rules options
 
-Rules support conditions (`--user`, `--label`, `--milestone`, `--type`) and launch options (`--yolo`, `--allow-all-tools`, `--allow-all-urls`, `--prompt`, `--repo`). All conditions are logical AND.
+Rules support conditions (`--user`, `--label`, `--milestone`, `--type`) and launch options (`--yolo`, `--allow-all-tools`, `--allow-all-urls`, `--prompt`, `--custom-prompt`, `--custom-prompt-mode`, `--repo`). All conditions are logical AND.
 
 ```bash
 # Add a rule
 copilotd rules add "Dashboard issues" --label area-dashboard --yolo --repo "org/repo"
+
+# Add a rule with a per-rule custom prompt that overrides the global custom prompt
+copilotd rules add "Backend" --label area-backend --custom-prompt "Focus on API design" --custom-prompt-mode override
 
 # Update labels on a rule
 copilotd rules update Default --delete-label copilotd --add-label dispatch
@@ -111,8 +114,9 @@ The built-in prompt supports token replacement:
 | `$(issue.milestone)` | Milestone title |
 
 Custom prompt text (configured via `custom_prompt` or `~/.copilotd/prompt.md`) is appended after
-the built-in prompt with a trailer. Tokens are replaced in both the built-in and custom prompt
-text. Per-rule extra prompts are appended last.
+the built-in prompt with a trailer. Rules can also specify a `custom_prompt` that either appends
+to or overrides the global custom prompt (controlled by `custom_prompt_mode`). Tokens are replaced
+in both the built-in and custom prompt text. Per-rule extra prompts are appended last.
 
 ## Session lifecycle
 
@@ -240,6 +244,8 @@ Stored in `~/.copilotd/`:
 | `allow_all_tools` | `true` | Pass `--allow-all-tools` to copilot |
 | `allow_all_urls` | `false` | Pass `--allow-all-urls` to copilot |
 | `extra_prompt` | *(none)* | Additional prompt text appended when this rule triggers |
+| `custom_prompt` | *(none)* | Per-rule custom prompt text (appended to or overrides global custom prompt) |
+| `custom_prompt_mode` | `append` | How rule custom prompt interacts with global: `append` or `override` |
 
 Log files are written to `$TEMP/copilotd/logs/` with daily rollover.
 
@@ -273,10 +279,16 @@ when sessions complete, are reset, or are pruned.
 
 ### Prompt customization
 
-Custom prompt text can be provided via `~/.copilotd/prompt.md` or the `prompt` config property.
-This text is **appended** to the built-in copilotd prompt (not a replacement) with a trailer:
-"The user has supplied the following additional context:". Token replacement is applied to both
-the built-in and custom prompt at dispatch time. Per-rule extra prompts are appended last.
+Custom prompt text can be provided at two levels:
+
+- **Global**: via `~/.copilotd/prompt.md` or the `prompt` config property
+- **Per-rule**: via the `custom_prompt` rule setting (set with `--custom-prompt`)
+
+Global custom text is **appended** to the built-in copilotd prompt (not a replacement) with a
+trailer: "The user has supplied the following additional context:". Per-rule custom prompts can
+either append to the global custom prompt (`--custom-prompt-mode append`, the default) or
+override it entirely (`--custom-prompt-mode override`). Token replacement is applied to the
+full combined prompt at dispatch time. Per-rule extra prompts (`--prompt`) are appended last.
 
 ## License
 

--- a/src/copilotd/Commands/ConfigCommand.cs
+++ b/src/copilotd/Commands/ConfigCommand.cs
@@ -56,6 +56,8 @@ public static class ConfigCommand
                                 if (rule.AllowAllUrls) details.Add("allow_all_urls=true");
                             }
                             if (rule.ExtraPrompt is not null) details.Add($"extra_prompt={rule.ExtraPrompt}");
+                            if (rule.CustomPrompt is not null) details.Add($"custom_prompt={rule.CustomPrompt}");
+                            if (rule.CustomPrompt is not null) details.Add($"custom_prompt_mode={rule.CustomPromptMode.ToString().ToLowerInvariant()}");
 
                             table.AddRow(
                                 Markup.Escape($"  rule[{name}]"),

--- a/src/copilotd/Commands/RulesCommand.cs
+++ b/src/copilotd/Commands/RulesCommand.cs
@@ -129,6 +129,8 @@ public static class RulesCommand
         var allowAllToolsOption = new Option<bool?>("--allow-all-tools") { Description = "Pass --allow-all-tools to copilot (default: true)" };
         var allowAllUrlsOption = new Option<bool?>("--allow-all-urls") { Description = "Pass --allow-all-urls to copilot (default: false)" };
         var promptOption = new Option<string?>("--prompt") { Description = "Extra prompt for this rule" };
+        var customPromptOption = new Option<string?>("--custom-prompt") { Description = "Per-rule custom prompt (appended to or overrides global custom prompt)" };
+        var customPromptModeOption = new Option<string?>("--custom-prompt-mode") { Description = "How rule custom prompt interacts with global: 'append' (default) or 'override'" };
         var repoOption = new Option<string[]>("--repo") { Description = "Repository to add (can be specified multiple times)", AllowMultipleArgumentsPerToken = true };
 
         command.Arguments.Add(nameArg);
@@ -140,6 +142,8 @@ public static class RulesCommand
         command.Options.Add(allowAllToolsOption);
         command.Options.Add(allowAllUrlsOption);
         command.Options.Add(promptOption);
+        command.Options.Add(customPromptOption);
+        command.Options.Add(customPromptModeOption);
         command.Options.Add(repoOption);
 
         command.SetAction(async (ParseResult parseResult, CancellationToken ct) =>
@@ -168,8 +172,20 @@ public static class RulesCommand
                     AllowAllTools = parseResult.GetValue(allowAllToolsOption) ?? true,
                     AllowAllUrls = parseResult.GetValue(allowAllUrlsOption) ?? false,
                     ExtraPrompt = parseResult.GetValue(promptOption),
+                    CustomPrompt = parseResult.GetValue(customPromptOption),
                     Repos = [.. parseResult.GetValue(repoOption) ?? []],
                 };
+
+                var modeValue = parseResult.GetValue(customPromptModeOption);
+                if (modeValue is not null)
+                {
+                    if (!TryParsePromptMode(modeValue, out var mode))
+                    {
+                        ConsoleOutput.Error("Invalid --custom-prompt-mode. Use 'append' or 'override'.");
+                        return 1;
+                    }
+                    rule.CustomPromptMode = mode;
+                }
 
                 config.Rules[name] = rule;
                 stateStore.SaveConfig(config);
@@ -194,6 +210,8 @@ public static class RulesCommand
         var allowAllToolsOption = new Option<bool?>("--allow-all-tools") { Description = "Update allow-all-tools setting" };
         var allowAllUrlsOption = new Option<bool?>("--allow-all-urls") { Description = "Update allow-all-urls setting" };
         var promptOption = new Option<string?>("--prompt") { Description = "Update extra prompt" };
+        var customPromptOption = new Option<string?>("--custom-prompt") { Description = "Update per-rule custom prompt" };
+        var customPromptModeOption = new Option<string?>("--custom-prompt-mode") { Description = "Update custom prompt mode: 'append' or 'override'" };
         var addRepoOption = new Option<string[]>("--add-repo") { Description = "Add a repository", AllowMultipleArgumentsPerToken = true };
         var deleteRepoOption = new Option<string[]>("--delete-repo") { Description = "Remove a repository", AllowMultipleArgumentsPerToken = true };
 
@@ -207,6 +225,8 @@ public static class RulesCommand
         command.Options.Add(allowAllToolsOption);
         command.Options.Add(allowAllUrlsOption);
         command.Options.Add(promptOption);
+        command.Options.Add(customPromptOption);
+        command.Options.Add(customPromptModeOption);
         command.Options.Add(addRepoOption);
         command.Options.Add(deleteRepoOption);
 
@@ -256,6 +276,20 @@ public static class RulesCommand
 
                 if (parseResult.GetResult(promptOption) is not null)
                     rule.ExtraPrompt = parseResult.GetValue(promptOption);
+
+                if (parseResult.GetResult(customPromptOption) is not null)
+                    rule.CustomPrompt = parseResult.GetValue(customPromptOption);
+
+                if (parseResult.GetResult(customPromptModeOption) is not null)
+                {
+                    var modeValue = parseResult.GetValue(customPromptModeOption);
+                    if (!TryParsePromptMode(modeValue, out var mode))
+                    {
+                        ConsoleOutput.Error("Invalid --custom-prompt-mode. Use 'append' or 'override'.");
+                        return 1;
+                    }
+                    rule.CustomPromptMode = mode;
+                }
 
                 var addRepos = parseResult.GetValue(addRepoOption) ?? [];
                 var deleteRepos = parseResult.GetValue(deleteRepoOption) ?? [];
@@ -311,5 +345,26 @@ public static class RulesCommand
         });
 
         return command;
+    }
+
+    private static bool TryParsePromptMode(string? value, out PromptMode mode)
+    {
+        mode = PromptMode.Append;
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+
+        if (string.Equals(value, "append", StringComparison.OrdinalIgnoreCase))
+        {
+            mode = PromptMode.Append;
+            return true;
+        }
+
+        if (string.Equals(value, "override", StringComparison.OrdinalIgnoreCase))
+        {
+            mode = PromptMode.Override;
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -355,16 +355,20 @@ public sealed partial class ProcessManager
         return true;
     }
 
-    private static string BuildPrompt(string customPrompt, GitHubIssue issue, DispatchSession session, CopilotdConfig config)
+    private static string BuildPrompt(string globalCustomPrompt, GitHubIssue issue, DispatchSession session, CopilotdConfig config)
     {
         var prompt = CopilotdConfig.DefaultPrompt;
 
-        if (!string.IsNullOrWhiteSpace(customPrompt))
+        var rule = config.Rules.GetValueOrDefault(session.RuleName);
+
+        // Resolve the effective custom prompt based on rule settings
+        var effectiveCustomPrompt = ResolveCustomPrompt(globalCustomPrompt, rule);
+
+        if (!string.IsNullOrWhiteSpace(effectiveCustomPrompt))
         {
-            prompt += "\n\nThe user has supplied the following additional context:\n\n" + customPrompt;
+            prompt += "\n\nThe user has supplied the following additional context:\n\n" + effectiveCustomPrompt;
         }
 
-        var rule = config.Rules.GetValueOrDefault(session.RuleName);
         if (!string.IsNullOrWhiteSpace(rule?.ExtraPrompt))
         {
             prompt += "\n\n" + rule.ExtraPrompt;
@@ -378,6 +382,29 @@ public sealed partial class ProcessManager
             .Replace("$(issue.milestone)", issue.Milestone ?? "none");
 
         return prompt;
+    }
+
+    /// <summary>
+    /// Resolves the effective custom prompt by combining the global custom prompt
+    /// with the rule's custom prompt based on the rule's <see cref="PromptMode"/>.
+    /// </summary>
+    private static string ResolveCustomPrompt(string globalCustomPrompt, DispatchRule? rule)
+    {
+        var ruleCustomPrompt = rule?.CustomPrompt;
+
+        if (string.IsNullOrWhiteSpace(ruleCustomPrompt))
+        {
+            return globalCustomPrompt;
+        }
+
+        return rule!.CustomPromptMode switch
+        {
+            PromptMode.Override => ruleCustomPrompt,
+            // Append (default): combine global + rule custom prompts
+            _ => string.IsNullOrWhiteSpace(globalCustomPrompt)
+                ? ruleCustomPrompt
+                : globalCustomPrompt + "\n\n" + ruleCustomPrompt,
+        };
     }
 
     private static string BuildArguments(DispatchSession session, string prompt, DispatchRule? rule, string repoPath)

--- a/src/copilotd/Models/CopilotdConfig.cs
+++ b/src/copilotd/Models/CopilotdConfig.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Copilotd.Models;
 
 /// <summary>
@@ -98,6 +100,20 @@ public sealed class DispatchRule
     public string? ExtraPrompt { get; set; }
 
     /// <summary>
+    /// Per-rule custom prompt text. When set, this is used as the custom prompt
+    /// for sessions matching this rule. See <see cref="CustomPromptMode"/> for
+    /// how it interacts with the global custom prompt.
+    /// </summary>
+    public string? CustomPrompt { get; set; }
+
+    /// <summary>
+    /// Controls how <see cref="CustomPrompt"/> interacts with the global custom prompt.
+    /// <see cref="PromptMode.Append"/>: rule prompt is appended after the global custom prompt (default).
+    /// <see cref="PromptMode.Override"/>: rule prompt replaces the global custom prompt entirely.
+    /// </summary>
+    public PromptMode CustomPromptMode { get; set; } = PromptMode.Append;
+
+    /// <summary>
     /// Returns true if the given issue matches all conditions on this rule.
     /// All conditions are logical AND.
     /// </summary>
@@ -117,4 +133,17 @@ public sealed class DispatchRule
 
         return true;
     }
+}
+
+/// <summary>
+/// Controls how a rule's custom prompt interacts with the global custom prompt.
+/// </summary>
+[JsonConverter(typeof(TolerantPromptModeConverter))]
+public enum PromptMode
+{
+    /// <summary>Rule prompt is appended after the global custom prompt.</summary>
+    Append,
+
+    /// <summary>Rule prompt replaces the global custom prompt entirely.</summary>
+    Override,
 }

--- a/src/copilotd/Models/JsonContext.cs
+++ b/src/copilotd/Models/JsonContext.cs
@@ -4,6 +4,43 @@ using System.Text.Json.Serialization;
 namespace Copilotd.Models;
 
 /// <summary>
+/// AOT-compatible JSON converter for <see cref="PromptMode"/> that gracefully handles
+/// unknown enum values by falling back to <see cref="PromptMode.Append"/>.
+/// This prevents a typo or future enum value in config.json from discarding
+/// the entire configuration.
+/// </summary>
+public sealed class TolerantPromptModeConverter : JsonConverter<PromptMode>
+{
+    public override PromptMode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            var value = reader.GetString();
+            if (Enum.TryParse<PromptMode>(value, ignoreCase: true, out var mode))
+                return mode;
+
+            return PromptMode.Append;
+        }
+
+        if (reader.TokenType == JsonTokenType.Number)
+        {
+            var intValue = reader.GetInt32();
+            if (Enum.IsDefined(typeof(PromptMode), intValue))
+                return (PromptMode)intValue;
+
+            return PromptMode.Append;
+        }
+
+        return PromptMode.Append;
+    }
+
+    public override void Write(Utf8JsonWriter writer, PromptMode value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToString());
+    }
+}
+
+/// <summary>
 /// AOT-compatible JSON converter for <see cref="SessionStatus"/> that gracefully handles
 /// unknown enum values by falling back to <see cref="SessionStatus.Pending"/>.
 /// This prevents older binaries from losing all persisted state when encountering
@@ -85,7 +122,7 @@ public sealed class TolerantUpdateStatusConverter : JsonConverter<UpdateStatus>
     WriteIndented = true,
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-    Converters = [typeof(TolerantSessionStatusConverter), typeof(TolerantUpdateStatusConverter)])]
+    Converters = [typeof(TolerantSessionStatusConverter), typeof(TolerantUpdateStatusConverter), typeof(TolerantPromptModeConverter)])]
 [JsonSerializable(typeof(CopilotdConfig))]
 [JsonSerializable(typeof(DaemonState))]
 [JsonSerializable(typeof(DispatchRule))]


### PR DESCRIPTION
## Summary

Adds support for prompt customization at the rule level, not just globally. Each dispatch rule can now specify its own custom prompt text and control how it interacts with the global custom prompt.

## New rule settings

| Setting | Default | Description |
|---------|---------|-------------|
| `custom_prompt` | *(none)* | Per-rule custom prompt text |
| `custom_prompt_mode` | `append` | How rule prompt interacts with global: `append` or `override` |

### Behavior

- **Append** (default): rule custom prompt is appended after the global custom prompt
- **Override**: rule custom prompt replaces the global custom prompt entirely
- If no rule custom prompt is set, the global custom prompt is used as before

### CLI usage

```bash
# Add a rule with per-rule custom prompt
copilotd rules add Backend --custom-prompt "Focus on API design" --custom-prompt-mode override

# Update an existing rule
copilotd rules update Default --custom-prompt "Additional context for this rule"
```

## Changes

- **CopilotdConfig.cs**: Added `PromptMode` enum (Append/Override), `CustomPrompt` and `CustomPromptMode` properties to `DispatchRule`
- **JsonContext.cs**: Added `TolerantPromptModeConverter` — gracefully handles unknown enum values by defaulting to Append (prevents bad config values from discarding the entire configuration)
- **ProcessManager.cs**: Added `ResolveCustomPrompt` helper that combines global and rule custom prompts based on the mode
- **RulesCommand.cs**: Added `--custom-prompt` and `--custom-prompt-mode` options to add/update subcommands with validation
- **ConfigCommand.cs**: Displays new rule properties
- **README.md**: Updated documentation for rules options, prompt templating, rule settings table, and prompt customization section

Closes #48