### PR TITLE
Add support for specifying the model in a rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An orchestration daemon that watches configured GitHub repositories for issues m
 
 - **Issue watching** — polls GitHub repos for issues matching configurable rules (assigned user, labels, milestone, issue type)
 - **Automatic dispatch** — launches `copilot --remote` sessions with templated prompts derived from issue metadata
-- **Named dispatch rules** — flexible, composable rules with per-rule launch options (`--yolo`, `--allow-all-tools`, `--allow-all-urls`, extra prompts, repo assignments)
+- **Named dispatch rules** — flexible, composable rules with per-rule launch options (`--yolo`, `--allow-all-tools`, `--allow-all-urls`, `--model`, extra prompts, repo assignments)
 - **Session lifecycle** — full state machine with retry, backoff, orphan recovery, investigation feedback loops, and explicit completion signaling
 - **Self-healing state** — reconciles persisted state, live process status, and GitHub issue matches on every poll cycle and at startup
 - **Crash-resilient** — dispatched `copilot` sessions run as independent processes that survive daemon restarts; state is persisted atomically
@@ -64,7 +64,7 @@ Convenience scripts `copilotd.sh` and `copilotd.cmd` in the repo root run the pr
 | `copilotd session complete <issue>` | Mark a session as completed (callable from within a copilot session) |
 | `copilotd session reset <issue>` | Reset a completed/failed session to pending for re-dispatch |
 | `copilotd config` | Display current configuration |
-| `copilotd config --set key=value` | Set a config value (`repo_home`, `custom_prompt`, `max_instances`) |
+| `copilotd config --set key=value` | Set a config value (`repo_home`, `default_model`, `custom_prompt`, `max_instances`) |
 | `copilotd rules list` | List all dispatch rules |
 | `copilotd rules add <name>` | Add a new dispatch rule |
 | `copilotd rules update <name>` | Update an existing rule |
@@ -86,11 +86,14 @@ Convenience scripts `copilotd.sh` and `copilotd.cmd` in the repo root run the pr
 
 ### Rules options
 
-Rules support conditions (`--user`, `--label`, `--milestone`, `--type`) and launch options (`--yolo`, `--allow-all-tools`, `--allow-all-urls`, `--prompt`, `--custom-prompt`, `--custom-prompt-mode`, `--repo`). All conditions are logical AND.
+Rules support conditions (`--user`, `--label`, `--milestone`, `--type`) and launch options (`--yolo`, `--allow-all-tools`, `--allow-all-urls`, `--model`, `--prompt`, `--custom-prompt`, `--custom-prompt-mode`, `--repo`). All conditions are logical AND.
 
 ```bash
 # Add a rule
 copilotd rules add "Dashboard issues" --label area-dashboard --yolo --repo "org/repo"
+
+# Add a rule that uses a specific model
+copilotd rules add "Complex tasks" --label complexity-high --model "claude-sonnet-4"
 
 # Add a rule with a per-rule custom prompt that overrides the global custom prompt
 copilotd rules add "Backend" --label area-backend --custom-prompt "Focus on API design" --custom-prompt-mode override
@@ -228,6 +231,7 @@ Stored in `~/.copilotd/`:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `repo_home` | — | Root directory where repos are cloned (`<org>/<repo>` sub-folders expected) |
+| `default_model` | *(none)* | Default model passed to copilot via `--model` for all sessions (rule-specific `model` overrides) |
 | `prompt` | *(empty)* | Custom prompt text appended to the built-in prompt |
 | `max_instances` | `3` | Maximum concurrent copilot processes; excess sessions queue as Pending |
 
@@ -243,6 +247,7 @@ Stored in `~/.copilotd/`:
 | `yolo` | `false` | Pass `--yolo` to copilot (implies `allow_all_tools` and `allow_all_urls`) |
 | `allow_all_tools` | `true` | Pass `--allow-all-tools` to copilot |
 | `allow_all_urls` | `false` | Pass `--allow-all-urls` to copilot |
+| `model` | *(none)* | Model to use for sessions matching this rule (overrides global `default_model`) |
 | `extra_prompt` | *(none)* | Additional prompt text appended when this rule triggers |
 | `custom_prompt` | *(none)* | Per-rule custom prompt text (appended to or overrides global custom prompt) |
 | `custom_prompt_mode` | `append` | How rule custom prompt interacts with global: `append` or `override` |

--- a/src/copilotd/Commands/ConfigCommand.cs
+++ b/src/copilotd/Commands/ConfigCommand.cs
@@ -34,6 +34,7 @@ public static class ConfigCommand
                     table.AddColumn(new TableColumn("[bold]Value[/]"));
 
                     table.AddRow("repo_home", Markup.Escape(config.RepoHome ?? "(not set)"));
+                    table.AddRow("default_model", Markup.Escape(config.DefaultModel ?? "(not set)"));
                     table.AddRow("custom_prompt", Markup.Escape(string.IsNullOrEmpty(config.Prompt) ? "(not set)" : config.Prompt));
                     table.AddRow("current_user", Markup.Escape(config.CurrentUser ?? "(not set)"));
                     table.AddRow("max_instances", Markup.Escape(config.MaxInstances.ToString()));
@@ -55,6 +56,7 @@ public static class ConfigCommand
                                 if (rule.AllowAllTools) details.Add("allow_all_tools=true");
                                 if (rule.AllowAllUrls) details.Add("allow_all_urls=true");
                             }
+                            if (rule.Model is not null) details.Add($"model={rule.Model}");
                             if (rule.ExtraPrompt is not null) details.Add($"extra_prompt={rule.ExtraPrompt}");
                             if (rule.CustomPrompt is not null) details.Add($"custom_prompt={rule.CustomPrompt}");
                             if (rule.CustomPrompt is not null) details.Add($"custom_prompt_mode={rule.CustomPromptMode.ToString().ToLowerInvariant()}");
@@ -99,6 +101,14 @@ public static class ConfigCommand
                         ConsoleOutput.Success("custom_prompt updated.");
                         break;
 
+                    case "default_model":
+                    case "model": // convenience alias
+                        cfg.DefaultModel = string.IsNullOrWhiteSpace(value) ? null : value;
+                        ConsoleOutput.Success(cfg.DefaultModel is not null
+                            ? $"default_model set to: {cfg.DefaultModel}"
+                            : "default_model cleared.");
+                        break;
+
                     case "max_instances":
                         if (int.TryParse(value, out var maxInst) && maxInst > 0)
                         {
@@ -114,7 +124,7 @@ public static class ConfigCommand
 
                     default:
                         ConsoleOutput.Error($"Unknown config key: {key}");
-                        ConsoleOutput.Info("Valid keys: repo_home, custom_prompt, max_instances");
+                        ConsoleOutput.Info("Valid keys: repo_home, default_model, custom_prompt, max_instances");
                         return 1;
                 }
 

--- a/src/copilotd/Commands/RulesCommand.cs
+++ b/src/copilotd/Commands/RulesCommand.cs
@@ -87,15 +87,14 @@ public static class RulesCommand
         }
 
         var table = new Table();
-        table.AddColumn("Name");
-        table.AddColumn("User");
-        table.AddColumn("Labels");
-        table.AddColumn("Milestone");
-        table.AddColumn("Type");
-        table.AddColumn("Repos");
-        table.AddColumn("Yolo");
-        table.AddColumn("Tools");
-        table.AddColumn("URLs");
+        table.ShowRowSeparators = true;
+        table.AddColumn(new TableColumn("[bold]Name[/]"));
+        table.AddColumn(new TableColumn("[bold]Assignee[/]"));
+        table.AddColumn(new TableColumn("[bold]Labels[/]"));
+        table.AddColumn(new TableColumn("[bold]Milestone[/]"));
+        table.AddColumn(new TableColumn("[bold]Type[/]"));
+        table.AddColumn(new TableColumn("[bold]Repos[/]"));
+        table.AddColumn(new TableColumn("[bold]Launch Options[/]"));
 
         foreach (var kvp in rules)
         {
@@ -108,13 +107,31 @@ public static class RulesCommand
                 Markup.Escape(rule.Milestone ?? "*"),
                 Markup.Escape(rule.Type ?? "*"),
                 Markup.Escape(string.Join(", ", rule.Repos)),
-                rule.Yolo ? "yes" : "no",
-                rule.Yolo || rule.AllowAllTools ? "yes" : "no",
-                rule.Yolo || rule.AllowAllUrls ? "yes" : "no");
+                Markup.Escape(FormatLaunchOptions(rule)));
         }
 
         AnsiConsole.Write(table);
         return 0;
+    }
+
+    private static string FormatLaunchOptions(DispatchRule rule)
+    {
+        var parts = new List<string>();
+
+        if (rule.Yolo)
+        {
+            parts.Add("--yolo");
+        }
+        else
+        {
+            if (rule.AllowAllTools) parts.Add("--allow-all-tools");
+            if (rule.AllowAllUrls) parts.Add("--allow-all-urls");
+        }
+
+        if (rule.Model is not null)
+            parts.Add($"--model={rule.Model}");
+
+        return parts.Count > 0 ? string.Join(", ", parts) : "(defaults)";
     }
 
     private static Command CreateAdd(IServiceProvider services)
@@ -129,6 +146,7 @@ public static class RulesCommand
         var allowAllToolsOption = new Option<bool?>("--allow-all-tools") { Description = "Pass --allow-all-tools to copilot (default: true)" };
         var allowAllUrlsOption = new Option<bool?>("--allow-all-urls") { Description = "Pass --allow-all-urls to copilot (default: false)" };
         var promptOption = new Option<string?>("--prompt") { Description = "Extra prompt for this rule" };
+        var modelOption = new Option<string?>("--model") { Description = "Model to use for sessions triggered by this rule (overrides global default_model)" };
         var customPromptOption = new Option<string?>("--custom-prompt") { Description = "Per-rule custom prompt (appended to or overrides global custom prompt)" };
         var customPromptModeOption = new Option<string?>("--custom-prompt-mode") { Description = "How rule custom prompt interacts with global: 'append' (default) or 'override'" };
         var repoOption = new Option<string[]>("--repo") { Description = "Repository to add (can be specified multiple times)", AllowMultipleArgumentsPerToken = true };
@@ -142,6 +160,7 @@ public static class RulesCommand
         command.Options.Add(allowAllToolsOption);
         command.Options.Add(allowAllUrlsOption);
         command.Options.Add(promptOption);
+        command.Options.Add(modelOption);
         command.Options.Add(customPromptOption);
         command.Options.Add(customPromptModeOption);
         command.Options.Add(repoOption);
@@ -171,6 +190,7 @@ public static class RulesCommand
                     Yolo = parseResult.GetValue(yoloOption),
                     AllowAllTools = parseResult.GetValue(allowAllToolsOption) ?? true,
                     AllowAllUrls = parseResult.GetValue(allowAllUrlsOption) ?? false,
+                    Model = string.IsNullOrWhiteSpace(parseResult.GetValue(modelOption)) ? null : parseResult.GetValue(modelOption),
                     ExtraPrompt = parseResult.GetValue(promptOption),
                     CustomPrompt = parseResult.GetValue(customPromptOption),
                     Repos = [.. parseResult.GetValue(repoOption) ?? []],
@@ -210,6 +230,7 @@ public static class RulesCommand
         var allowAllToolsOption = new Option<bool?>("--allow-all-tools") { Description = "Update allow-all-tools setting" };
         var allowAllUrlsOption = new Option<bool?>("--allow-all-urls") { Description = "Update allow-all-urls setting" };
         var promptOption = new Option<string?>("--prompt") { Description = "Update extra prompt" };
+        var modelOption = new Option<string?>("--model") { Description = "Update model (overrides global default_model)" };
         var customPromptOption = new Option<string?>("--custom-prompt") { Description = "Update per-rule custom prompt" };
         var customPromptModeOption = new Option<string?>("--custom-prompt-mode") { Description = "Update custom prompt mode: 'append' or 'override'" };
         var addRepoOption = new Option<string[]>("--add-repo") { Description = "Add a repository", AllowMultipleArgumentsPerToken = true };
@@ -225,6 +246,7 @@ public static class RulesCommand
         command.Options.Add(allowAllToolsOption);
         command.Options.Add(allowAllUrlsOption);
         command.Options.Add(promptOption);
+        command.Options.Add(modelOption);
         command.Options.Add(customPromptOption);
         command.Options.Add(customPromptModeOption);
         command.Options.Add(addRepoOption);
@@ -276,6 +298,12 @@ public static class RulesCommand
 
                 if (parseResult.GetResult(promptOption) is not null)
                     rule.ExtraPrompt = parseResult.GetValue(promptOption);
+
+                if (parseResult.GetResult(modelOption) is not null)
+                {
+                    var modelValue = parseResult.GetValue(modelOption);
+                    rule.Model = string.IsNullOrWhiteSpace(modelValue) ? null : modelValue;
+                }
 
                 if (parseResult.GetResult(customPromptOption) is not null)
                     rule.CustomPrompt = parseResult.GetValue(customPromptOption);

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -42,7 +42,7 @@ public sealed partial class ProcessManager
 
         var customPrompt = _stateStore.LoadCustomPrompt(config);
         var prompt = BuildPrompt(customPrompt, issue, session, config);
-        var args = BuildArguments(session, prompt, config.Rules.GetValueOrDefault(session.RuleName), repoPath);
+        var args = BuildArguments(session, prompt, config.Rules.GetValueOrDefault(session.RuleName), repoPath, config.DefaultModel);
 
         _logger.LogInformation("Launching copilot for {IssueKey} with session {SessionId}", session.IssueKey, session.CopilotSessionId);
         _logger.LogDebug("copilot {Args}", args);
@@ -407,7 +407,7 @@ public sealed partial class ProcessManager
         };
     }
 
-    private static string BuildArguments(DispatchSession session, string prompt, DispatchRule? rule, string repoPath)
+    private static string BuildArguments(DispatchSession session, string prompt, DispatchRule? rule, string repoPath, string? defaultModel)
     {
         var args = new List<string>
         {
@@ -415,6 +415,14 @@ public sealed partial class ProcessManager
             $"--resume={session.CopilotSessionId}",
             "-i", $"\"{EscapeArg(prompt)}\"",
         };
+
+        // Model: rule-specific overrides global default
+        var model = rule?.Model ?? defaultModel;
+        if (!string.IsNullOrWhiteSpace(model))
+        {
+            args.Add("--model");
+            args.Add($"\"{EscapeArg(model)}\"");
+        }
 
         var yolo = rule?.Yolo == true;
 

--- a/src/copilotd/Models/CopilotdConfig.cs
+++ b/src/copilotd/Models/CopilotdConfig.cs
@@ -42,6 +42,12 @@ public sealed class CopilotdConfig
     public int MaxInstances { get; set; } = 3;
 
     /// <summary>
+    /// Default model to use for all copilot sessions. When set, <c>--model</c> is
+    /// passed to the copilot CLI unless a rule specifies its own model override.
+    /// </summary>
+    public string? DefaultModel { get; set; }
+
+    /// <summary>
     /// Named dispatch rules. Key is the rule name.
     /// </summary>
     public Dictionary<string, DispatchRule> Rules { get; set; } = new(StringComparer.OrdinalIgnoreCase);
@@ -95,6 +101,12 @@ public sealed class DispatchRule
 
     /// <summary>Whether to pass --allow-all-urls to copilot. Defaults to false. Implied by Yolo.</summary>
     public bool AllowAllUrls { get; set; }
+
+    /// <summary>
+    /// Model to use for sessions triggered by this rule. Overrides the global
+    /// <see cref="CopilotdConfig.DefaultModel"/> when set.
+    /// </summary>
+    public string? Model { get; set; }
 
     /// <summary>Extra prompt text appended when this rule triggers.</summary>
     public string? ExtraPrompt { get; set; }


### PR DESCRIPTION
Adds support for specifying the model used by copilot sessions, at both the global config level and per-rule level.

## Changes

- **\CopilotdConfig.DefaultModel\** — new global config property. When set, \--model\ is passed to the copilot CLI for all sessions.
- **\DispatchRule.Model\** — new per-rule property. Overrides the global default when set.
- **\ProcessManager.BuildArguments\** — passes \--model <model>\ when launching sessions (rule model takes precedence over global default).
- **\ules add --model\ / \ules update --model\** — CLI support for setting model on rules.
- **\config --set default_model=<model>\** — CLI support for setting the global default model (with \model\ alias).
- **Config & rules display** — model shown in \config\ output and \ules list\ table.
- Empty/whitespace model values are normalized to \
ull\ to ensure proper fallback to the global default.

## Precedence

\\\
rule.Model > config.DefaultModel > (no --model flag)
\\\

Closes #51