### PR TITLE
Add build provenance attestations to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,11 @@ jobs:
 
     runs-on: ${{ matrix.runner }}
 
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -152,6 +157,11 @@ jobs:
         shell: pwsh
         run: ./scripts/Publish-NativeAsset.ps1 -RuntimeIdentifier '${{ matrix.rid }}' -Version '${{ needs.version.outputs.version }}' -ArtifactsDirectory './artifacts/dev'
 
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
+        with:
+          subject-path: './artifacts/dev/*'
+
       - name: Upload dev artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
@@ -179,6 +189,11 @@ jobs:
             rid: osx-arm64
 
     runs-on: ${{ matrix.runner }}
+
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
 
     steps:
       - name: Checkout
@@ -208,6 +223,11 @@ jobs:
       - name: Publish native asset
         shell: pwsh
         run: ./scripts/Publish-NativeAsset.ps1 -RuntimeIdentifier '${{ matrix.rid }}' -Version '${{ needs.version.outputs.rc_version }}' -ArtifactsDirectory './artifacts/rc'
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
+        with:
+          subject-path: './artifacts/rc/*'
 
       - name: Upload RC artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
         run: ./scripts/Publish-NativeAsset.ps1 -RuntimeIdentifier '${{ matrix.rid }}' -Version '${{ needs.version.outputs.version }}' -ArtifactsDirectory './artifacts/dev'
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
         with:
           subject-path: './artifacts/dev/*'
 
@@ -225,7 +225,7 @@ jobs:
         run: ./scripts/Publish-NativeAsset.ps1 -RuntimeIdentifier '${{ matrix.rid }}' -Version '${{ needs.version.outputs.rc_version }}' -ArtifactsDirectory './artifacts/rc'
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
         with:
           subject-path: './artifacts/rc/*'
 


### PR DESCRIPTION
## Summary

Adds GitHub artifact attestations to the CI workflow for all platforms (Windows, Linux, macOS) in both dev and RC publish jobs.

## Changes

- Added `permissions` block (`id-token: write`, `attestations: write`, `contents: read`) to `publish-dev` and `publish-rc` jobs
- Added `actions/attest-build-provenance@v4.1.0` step after the native asset publish step in both jobs
- Attestations cover all build artifacts (archives, checksums, and metadata files)
- PR builds are **not** affected — attestations only run on CI pushes to main

## Context

This uses GitHub's Sigstore-based artifact attestation system. While the repo is private, attestations use GitHub's Sigstore instance. Once the repo goes public, they'll automatically use the Sigstore public good instance.

This lays the groundwork for a bash install script (#43) and self-updating on Linux/macOS (#44).

Closes #42