### PR TITLE
Add continue-on-error to attestation steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,7 @@ jobs:
 
       - name: Attest build provenance
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
+        continue-on-error: true
         with:
           subject-path: './artifacts/dev/*'
 
@@ -226,6 +227,7 @@ jobs:
 
       - name: Attest build provenance
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
+        continue-on-error: true
         with:
           subject-path: './artifacts/rc/*'
 


### PR DESCRIPTION
## Summary

Adds `continue-on-error: true` to both attestation steps in the CI workflow.

## Why

Artifact attestations are [not available for user-owned private repositories](https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations). The CI run from #53 failed across all 12 publish jobs with:

> Failed to persist attestation: Feature not available for user-owned private repositories.

## What this does

With `continue-on-error: true`, the build will succeed even when attestations can't be persisted. Once the repo is made public, attestations will start working automatically with no further changes needed.