### PR TITLE
Add E2E test section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,3 +298,8 @@ full combined prompt at dispatch time. Per-rule extra prompts (`--prompt`) are a
 ## License
 
 MIT
+
+
+## E2E Test
+
+This section was added by an automated E2E test and can be safely removed.


### PR DESCRIPTION
Closes #57

This PR adds an E2E test section to the README as requested in the issue.