### PR TITLE
Support addressing PR review comments from issue-based sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,11 @@ When a copilot session creates a pull request, it can enter a review monitoring 
 
 The default prompt instructs copilot sessions to use `session pr` after creating a pull request. Multiple review rounds are supported — the session resumes with `--resume` for full conversation context continuity.
 
+When re-dispatched for PR review, copilot is instructed to interact with the PR directly:
+- **General comments** — posted to the PR via `gh pr comment`
+- **Thread replies** — reply to specific review comment threads via the GitHub GraphQL API
+- **Suggested changes** — applied directly to the relevant files when a review comment includes a `suggestion` block
+
 ### Interactive takeover
 
 Use `copilotd session join <issue>` to take over any tracked session:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ An orchestration daemon that watches configured GitHub repositories for issues m
 - **Issue watching** — polls GitHub repos for issues matching configurable rules (assigned user, labels, milestone, issue type)
 - **Automatic dispatch** — launches `copilot --remote` sessions with templated prompts derived from issue metadata
 - **Named dispatch rules** — flexible, composable rules with per-rule launch options (`--yolo`, `--allow-all-tools`, `--allow-all-urls`, `--model`, extra prompts, repo assignments)
-- **Session lifecycle** — full state machine with retry, backoff, orphan recovery, investigation feedback loops, and explicit completion signaling
+- **Session lifecycle** — full state machine with retry, backoff, orphan recovery, investigation feedback loops, PR review monitoring, and explicit completion signaling
+- **PR review feedback** — sessions that create PRs can wait for review comments and automatically re-dispatch to address feedback
 - **Self-healing state** — reconciles persisted state, live process status, and GitHub issue matches on every poll cycle and at startup
 - **Crash-resilient** — dispatched `copilot` sessions run as independent processes that survive daemon restarts; state is persisted atomically
 - **Interactive takeover** — join any orchestrated session interactively with `copilotd session join`, then hand it back automatically
@@ -62,6 +63,7 @@ Convenience scripts `copilotd.sh` and `copilotd.cmd` in the repo root run the pr
 | `copilotd session join <issue>` | Take over a session interactively |
 | `copilotd session comment <issue>` | Post a comment on the issue and wait for feedback (callable from within a copilot session) |
 | `copilotd session complete <issue>` | Mark a session as completed (callable from within a copilot session) |
+| `copilotd session pr <pr-number> <issue>` | Associate a PR with a session and wait for review feedback (callable from within a copilot session) |
 | `copilotd session reset <issue>` | Reset a completed/failed session to pending for re-dispatch |
 | `copilotd config` | Display current configuration |
 | `copilotd config --set key=value` | Set a config value (`repo_home`, `default_model`, `custom_prompt`, `max_instances`) |
@@ -80,7 +82,7 @@ Convenience scripts `copilotd.sh` and `copilotd.cmd` in the repo root run the pr
 ### Status & session options
 
 ```
---filter <status>   Filter by status (pending, running, joined, waitingforfeedback, completed, failed, orphaned)
+--filter <status>   Filter by status (pending, running, joined, waitingforfeedback, waitingforreview, completed, failed, orphaned)
 --all               Include ended (completed/failed) sessions
 ```
 
@@ -115,6 +117,7 @@ The built-in prompt supports token replacement:
 | `$(issue.id)` | Issue number |
 | `$(issue.type)` | Issue type (e.g., `bug`) |
 | `$(issue.milestone)` | Milestone title |
+| `$(pr.id)` | Pull request number (available in PR review re-dispatch prompts) |
 
 Custom prompt text (configured via `custom_prompt` or `~/.copilotd/prompt.md`) is appended after
 the built-in prompt with a trailer. Rules can also specify a `custom_prompt` that either appends
@@ -154,6 +157,17 @@ Each dispatched copilot session follows a state machine:
                       ▼          │
                     Pending ─────┘
                  │
+                 │                   copilot calls
+                 │                   session pr
+                 │◄── WaitingForReview ◄─────────────────────────┘
+                      │          ▲
+      review comment  │          │ no new reviews
+      detected        │          │ (keeps waiting)
+                      ▼          │
+                    Pending ─────┘
+                      │
+                PR merged/closed → Completed (auto)
+                 │
           re-opened / re-matched
           (only if not explicitly completed)
 ```
@@ -168,6 +182,7 @@ Each dispatched copilot session follows a state machine:
 | **Dispatching** | **Failed** | Process launch failed (increments retry count) |
 | **Running** | **Completed** | Issue no longer matches rules (closed, relabeled, etc.) — process gracefully terminated |
 | **Running** | **WaitingForFeedback** | Copilot calls `copilotd session comment` — process exits, session waits for new issue comments |
+| **Running** | **WaitingForReview** | Copilot calls `copilotd session pr <pr-number>` — process exits, session waits for PR review feedback |
 | **Running** | **Orphaned** | Process died unexpectedly (PID gone or reused) |
 | **Running** | **Joined** | User runs `copilotd session join` — process terminated, user takes over |
 | **Orphaned** | **Pending** | Retry eligible (retry count < 3) — exponential backoff: 2^n minutes, capped at 30m |
@@ -176,6 +191,8 @@ Each dispatched copilot session follows a state machine:
 | **Joined** | **Pending** | User exits interactive session — automatically re-queued for dispatch |
 | **WaitingForFeedback** | **Pending** | New comment detected on the issue (not posted by copilotd) — re-dispatched with same session ID for `--resume` context continuity |
 | **WaitingForFeedback** | **Completed** | Issue no longer matches rules while waiting |
+| **WaitingForReview** | **Pending** | New review comment or changes-requested review detected on the PR — re-dispatched with PR review prompt |
+| **WaitingForReview** | **Completed** | PR is merged or closed, or issue no longer matches rules |
 | **Completed** | **Pending** | Issue re-matches rules (e.g., reopened) — only if not explicitly completed by copilot |
 | Any non-terminal | **Completed** | Copilot calls `copilotd session complete` — sets `CompletedBySession` flag, prevents re-dispatch |
 
@@ -202,6 +219,20 @@ When a copilot session encounters an issue that needs more information before wo
 
 The default prompt instructs copilot sessions to use this flow when they need clarification.
 
+### PR review feedback
+
+When a copilot session creates a pull request, it can enter a review monitoring loop:
+
+1. The session calls `copilotd session pr <pr-number> <issue>` after pushing a PR
+2. The session transitions to **WaitingForReview** — the copilot process exits, no instance slot is consumed
+3. On each poll cycle, the reconciler checks for new PR review comments, formal reviews (`CHANGES_REQUESTED` or `COMMENTED`), and falls back to checking issue comments
+4. When review feedback is detected, the session is re-dispatched with a PR-specific prompt that instructs copilot to address the feedback
+5. The existing worktree is refreshed (`git fetch` + `git pull --ff-only`) rather than recreated, preserving any local state
+6. Copilot addresses the feedback, pushes changes to the existing PR, and calls `session pr` again to continue the loop
+7. If the PR is merged or closed, the session is automatically completed
+
+The default prompt instructs copilot sessions to use `session pr` after creating a pull request. Multiple review rounds are supported — the session resumes with `--resume` for full conversation context continuity.
+
 ### Interactive takeover
 
 Use `copilotd session join <issue>` to take over any tracked session:
@@ -214,7 +245,7 @@ Use `copilotd session join <issue>` to take over any tracked session:
 ### Terminal states and pruning
 
 - **Completed** and **Failed** are terminal states
-- **WaitingForFeedback** is *not* terminal — the session is paused, not finished
+- **WaitingForFeedback** and **WaitingForReview** are *not* terminal — the session is paused, not finished
 - Terminal sessions are automatically pruned from state after 7 days
 - All running sessions are gracefully terminated when the daemon shuts down
 

--- a/src/copilotd/Commands/SessionCommand.cs
+++ b/src/copilotd/Commands/SessionCommand.cs
@@ -21,6 +21,7 @@ public static class SessionCommand
         command.Subcommands.Add(CreateJoinCommand(services));
         command.Subcommands.Add(CreateCommentCommand(services));
         command.Subcommands.Add(CreateCompleteCommand(services));
+        command.Subcommands.Add(CreatePrCommand(services));
         command.Subcommands.Add(CreateResetCommand(services));
 
         // Default to list behavior when no subcommand is specified
@@ -333,6 +334,63 @@ public static class SessionCommand
         return command;
     }
 
+    // ---- pr subcommand ----
+
+    private static Command CreatePrCommand(IServiceProvider services)
+    {
+        var command = new Command("pr", "Associate a pull request with a session and wait for review feedback (can be called from within a copilot session)");
+
+        var prNumberArg = new Argument<int>("pr-number") { Description = "Pull request number" };
+        command.Arguments.Add(prNumberArg);
+
+        var issueArg = new Argument<string>("issue") { Description = "Issue key (e.g., owner/repo#123)" };
+        command.Arguments.Add(issueArg);
+
+        command.SetAction(async (ParseResult parseResult, CancellationToken ct) =>
+        {
+            var logger = services.GetRequiredService<ILogger<Program>>();
+            return await ConsoleOutput.RunWithErrorHandling(async () =>
+            {
+                var stateStore = services.GetRequiredService<StateStore>();
+                var state = stateStore.LoadState();
+
+                var prNumber = parseResult.GetValue(prNumberArg);
+                var issueKey = parseResult.GetValue(issueArg)!;
+
+                if (!state.Sessions.TryGetValue(issueKey, out var session))
+                {
+                    ConsoleOutput.Error($"No session found for '{issueKey}'.");
+                    return 1;
+                }
+
+                if (session.IsTerminal)
+                {
+                    ConsoleOutput.Error($"Session for '{issueKey}' is already {session.Status.ToString().ToLowerInvariant()}.");
+                    return 1;
+                }
+
+                if (prNumber <= 0)
+                {
+                    ConsoleOutput.Error("Pull request number must be a positive integer.");
+                    return 1;
+                }
+
+                session.PullRequestNumber = prNumber;
+                session.Status = SessionStatus.WaitingForReview;
+                session.WaitingSince = DateTimeOffset.UtcNow;
+                session.ProcessId = null;
+                session.ProcessStartTime = null;
+                session.UpdatedAt = DateTimeOffset.UtcNow;
+                stateStore.SaveState(state);
+
+                ConsoleOutput.Success($"PR #{prNumber} associated with session for {issueKey}. Session is now waiting for review feedback.");
+                return 0;
+            }, logger);
+        });
+
+        return command;
+    }
+
     // ---- reset subcommand ----
 
     private static Command CreateResetCommand(IServiceProvider services)
@@ -371,11 +429,13 @@ public static class SessionCommand
 
                 session.Status = SessionStatus.Pending;
                 session.CompletedBySession = false;
+                session.PullRequestNumber = null;
                 session.CopilotSessionId = Guid.NewGuid().ToString();
                 session.ProcessId = null;
                 session.ProcessStartTime = null;
                 session.RetryCount = 0;
                 session.LastFailureAt = null;
+                session.WaitingSince = null;
                 session.UpdatedAt = DateTimeOffset.UtcNow;
                 stateStore.SaveState(state);
 
@@ -496,6 +556,7 @@ public static class SessionCommand
                 SessionStatus.Running => $"[green]{s.Status}[/]",
                 SessionStatus.Joined => $"[blue]{s.Status}[/]",
                 SessionStatus.WaitingForFeedback => $"[cyan]{s.Status}[/]",
+                SessionStatus.WaitingForReview => $"[magenta]{s.Status}[/]",
                 SessionStatus.Pending or SessionStatus.Dispatching => $"[yellow]{s.Status}[/]",
                 SessionStatus.Failed or SessionStatus.Orphaned => $"[red]{s.Status}[/]",
                 SessionStatus.Completed => $"[grey]{s.Status}[/]",

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -357,7 +357,10 @@ public sealed partial class ProcessManager
 
     private static string BuildPrompt(string globalCustomPrompt, GitHubIssue issue, DispatchSession session, CopilotdConfig config)
     {
-        var prompt = CopilotdConfig.DefaultPrompt;
+        // Use a PR-specific prompt when re-dispatching for review feedback
+        var prompt = session.PullRequestNumber is not null
+            ? BuildPrReviewPrompt(issue, session)
+            : CopilotdConfig.DefaultPrompt;
 
         var rule = config.Rules.GetValueOrDefault(session.RuleName);
 
@@ -379,9 +382,31 @@ public sealed partial class ProcessManager
             .Replace("$(issue.repo)", issue.Repo)
             .Replace("$(issue.id)", issue.Number.ToString())
             .Replace("$(issue.type)", issue.Type ?? "issue")
-            .Replace("$(issue.milestone)", issue.Milestone ?? "none");
+            .Replace("$(issue.milestone)", issue.Milestone ?? "none")
+            .Replace("$(pr.id)", session.PullRequestNumber?.ToString() ?? "");
 
         return prompt;
+    }
+
+    /// <summary>
+    /// Builds a prompt for re-dispatching a session to address PR review feedback.
+    /// </summary>
+    private static string BuildPrReviewPrompt(GitHubIssue issue, DispatchSession session)
+    {
+        return $$"""
+            You are addressing review feedback on pull request #$(pr.id) in the $(issue.repo) repository.
+            This PR was created for issue #$(issue.id). Read the PR review comments carefully and address all feedback.
+
+            Important:
+            - You are on the same branch that was used to create the PR. Your changes will be pushed to the existing PR.
+            - Address each review comment by making the requested changes.
+            - After addressing all review feedback, push your changes to update the PR.
+            - Then run `copilotd session pr $(pr.id) $(issue.repo)#$(issue.id)` to continue monitoring for further review feedback.
+            - If the changes are complete and no more reviews are expected, run `copilotd session complete $(issue.repo)#$(issue.id)` instead.
+
+            If you need more information or clarification before proceeding:
+            - Run `copilotd session comment $(issue.repo)#$(issue.id) --message "Your question or findings here"` to post a comment on the issue.
+            """;
     }
 
     /// <summary>
@@ -469,9 +494,15 @@ public sealed partial class ProcessManager
     /// <summary>
     /// Creates a git worktree for the session on a new branch from the latest default branch.
     /// Layout: &lt;repo_home&gt;/org/repo_sessions/issue-N/
+    /// If the session already has a worktree (e.g., re-dispatching for PR review), refreshes it instead.
     /// </summary>
     public bool PrepareWorktree(DispatchSession session, CopilotdConfig config, DaemonState state)
     {
+        // If the session already has a worktree (PR review re-dispatch), refresh it
+        if (!string.IsNullOrEmpty(session.WorktreePath) && Directory.Exists(session.WorktreePath))
+        {
+            return RefreshWorktree(session);
+        }
         var mainRepoPath = _repoResolver.ResolveRepoPath(session.Repo, config, state);
         if (mainRepoPath is null || !Directory.Exists(mainRepoPath))
         {
@@ -545,6 +576,33 @@ public sealed partial class ProcessManager
 
         session.WorktreePath = worktreePath;
         _logger.LogInformation("Worktree ready for {Key} at {Path}", session.IssueKey, worktreePath);
+        return true;
+    }
+
+    /// <summary>
+    /// Refreshes an existing worktree by pulling the latest changes from origin.
+    /// Used when re-dispatching a session for PR review feedback.
+    /// </summary>
+    private bool RefreshWorktree(DispatchSession session)
+    {
+        var worktreePath = session.WorktreePath!;
+        _logger.LogInformation("Refreshing existing worktree for {Key} at {Path}", session.IssueKey, worktreePath);
+
+        // Fetch latest from origin
+        if (!RunGit(worktreePath, "fetch origin"))
+        {
+            _logger.LogWarning("Failed to fetch origin in worktree for {Key}", session.IssueKey);
+            return false;
+        }
+
+        // Pull latest changes (the branch may have been updated by the PR)
+        if (!RunGit(worktreePath, "pull --ff-only"))
+        {
+            _logger.LogWarning("Failed to pull latest changes in worktree for {Key}, continuing anyway", session.IssueKey);
+            // Non-fatal: the worktree may have local changes that prevent ff-only
+        }
+
+        _logger.LogInformation("Worktree refreshed for {Key} at {Path}", session.IssueKey, worktreePath);
         return true;
     }
 

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -400,12 +400,19 @@ public sealed partial class ProcessManager
             Important:
             - You are on the same branch that was used to create the PR. Your changes will be pushed to the existing PR.
             - Address each review comment by making the requested changes.
+            - If a review comment includes a suggested change (```suggestion block), apply it directly to the relevant file.
             - After addressing all review feedback, push your changes to update the PR.
             - Then run `copilotd session pr $(pr.id) $(issue.repo)#$(issue.id)` to continue monitoring for further review feedback.
             - If the changes are complete and no more reviews are expected, run `copilotd session complete $(issue.repo)#$(issue.id)` instead.
 
-            If you need more information or clarification before proceeding:
-            - Run `copilotd session comment $(issue.repo)#$(issue.id) --message "Your question or findings here"` to post a comment on the issue.
+            Interacting with the PR:
+            - To post a general comment on the PR: `gh pr comment $(pr.id) --repo $(issue.repo) --body "Your comment"`
+            - To reply to a specific review thread, use `gh api graphql` with the addPullRequestReviewThreadReply mutation:
+              ```
+              gh api graphql -f query='mutation { addPullRequestReviewThreadReply(input: { pullRequestReviewThreadId: "THREAD_ID", body: "Your reply" }) { comment { id } } }'
+              ```
+              You can find thread IDs by querying: `gh api graphql -f query='{ repository(owner: "OWNER", name: "REPO") { pullRequest(number: $(pr.id)) { reviewThreads(last: 20) { nodes { id isResolved comments(last: 5) { nodes { body author { login } } } } } } } }'`
+            - Do NOT use `copilotd session comment` to post to the issue when in PR review mode. All communication should happen on the PR itself.
             """;
     }
 

--- a/src/copilotd/Models/CopilotdConfig.cs
+++ b/src/copilotd/Models/CopilotdConfig.cs
@@ -63,7 +63,7 @@ public sealed class CopilotdConfig
         If you have enough information to implement the requested changes:
         - You are already on a new branch created for this issue. Commit your changes here.
         - When your work is complete, push the branch and create a pull request that references the issue (e.g., "Closes #$(issue.id)").
-        - After the pull request is created, run `copilotd session complete $(issue.repo)#$(issue.id)` to mark this session as done.
+        - After the pull request is created, run `copilotd session pr <pr-number> $(issue.repo)#$(issue.id)` to enable automatic review feedback handling (replace <pr-number> with the actual PR number).
 
         If you need more information or clarification before proceeding:
         - Run `copilotd session comment $(issue.repo)#$(issue.id) --message "Your question or findings here"` to post a comment on the issue.

--- a/src/copilotd/Models/SessionState.cs
+++ b/src/copilotd/Models/SessionState.cs
@@ -53,7 +53,13 @@ public enum SessionStatus
     /// Session posted a comment on the issue and is waiting for a response.
     /// No process is running; the reconciler monitors for new comments.
     /// </summary>
-    WaitingForFeedback
+    WaitingForFeedback,
+
+    /// <summary>
+    /// Session created a pull request and is waiting for review feedback.
+    /// No process is running; the reconciler monitors for new PR review comments.
+    /// </summary>
+    WaitingForReview
 }
 
 /// <summary>
@@ -112,6 +118,12 @@ public sealed class DispatchSession
     /// Used to detect new comments on the issue since the session started waiting.
     /// </summary>
     public DateTimeOffset? WaitingSince { get; set; }
+
+    /// <summary>
+    /// The pull request number associated with this session, if one was created.
+    /// Set via 'copilotd session pr' and used to monitor for review comments.
+    /// </summary>
+    public int? PullRequestNumber { get; set; }
 
     /// <summary>
     /// Path to the git worktree directory for this session. Null if using the main repo checkout.

--- a/src/copilotd/Services/GhCliService.cs
+++ b/src/copilotd/Services/GhCliService.cs
@@ -309,6 +309,134 @@ public sealed class GhCliService
         }
     }
 
+    /// <summary>
+    /// Checks whether there are new review comments on a pull request since the given timestamp,
+    /// excluding comments posted by copilotd itself (identified by <see cref="CommentMarker"/>).
+    /// Checks both PR review comments (from formal reviews) and regular PR comments.
+    /// </summary>
+    public bool HasNewPrReviewCommentsSince(string repo, int prNumber, DateTimeOffset since)
+    {
+        var args = $"pr view {prNumber} --repo {repo} --json comments,reviews";
+        var (exitCode, output) = RunGh(args);
+        if (exitCode != 0)
+        {
+            _logger.LogWarning("Failed to query PR comments on {Repo}#{Pr}: {Output}", repo, prNumber, output);
+            return false;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(output);
+
+            // Check regular PR comments
+            if (doc.RootElement.TryGetProperty("comments", out var comments))
+            {
+                foreach (var comment in comments.EnumerateArray())
+                {
+                    if (IsNewNonBotComment(comment, since))
+                    {
+                        _logger.LogDebug("Found new PR comment on {Repo}!{Pr}", repo, prNumber);
+                        return true;
+                    }
+                }
+            }
+
+            // Check formal review submissions (requested changes, comments)
+            if (doc.RootElement.TryGetProperty("reviews", out var reviews))
+            {
+                foreach (var review in reviews.EnumerateArray())
+                {
+                    if (!review.TryGetProperty("submittedAt", out var submittedAtEl))
+                        continue;
+
+                    var submittedAtStr = submittedAtEl.GetString();
+                    if (submittedAtStr is null || !DateTimeOffset.TryParse(submittedAtStr, out var submittedAt))
+                        continue;
+
+                    if (submittedAt <= since)
+                        continue;
+
+                    // Skip empty/approved-only reviews with no body
+                    if (review.TryGetProperty("body", out var bodyEl))
+                    {
+                        var body = bodyEl.GetString();
+                        if (body is not null && body.Contains(CommentMarker, StringComparison.Ordinal))
+                            continue;
+                    }
+
+                    // Check review state — we care about CHANGES_REQUESTED and COMMENTED
+                    if (review.TryGetProperty("state", out var stateEl))
+                    {
+                        var reviewState = stateEl.GetString();
+                        if (reviewState is "CHANGES_REQUESTED" or "COMMENTED")
+                        {
+                            _logger.LogDebug("Found new review ({State}) on {Repo}!{Pr}", reviewState, repo, prNumber);
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse PR comments JSON for {Repo}!{Pr}", repo, prNumber);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Gets the current state of a pull request (e.g., OPEN, CLOSED, MERGED).
+    /// Returns null if the PR state cannot be determined.
+    /// </summary>
+    public string? GetPullRequestState(string repo, int prNumber)
+    {
+        var args = $"pr view {prNumber} --repo {repo} --json state";
+        var (exitCode, output) = RunGh(args);
+        if (exitCode != 0)
+        {
+            _logger.LogWarning("Failed to query PR state for {Repo}!{Pr}: {Output}", repo, prNumber, output);
+            return null;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(output);
+            if (doc.RootElement.TryGetProperty("state", out var stateEl))
+                return stateEl.GetString();
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse PR state JSON for {Repo}!{Pr}", repo, prNumber);
+            return null;
+        }
+    }
+
+    private bool IsNewNonBotComment(JsonElement comment, DateTimeOffset since)
+    {
+        if (!comment.TryGetProperty("createdAt", out var createdAtEl))
+            return false;
+
+        var createdAtStr = createdAtEl.GetString();
+        if (createdAtStr is null || !DateTimeOffset.TryParse(createdAtStr, out var createdAt))
+            return false;
+
+        if (createdAt <= since)
+            return false;
+
+        // Skip comments posted by copilotd
+        if (comment.TryGetProperty("body", out var bodyEl))
+        {
+            var body = bodyEl.GetString();
+            if (body is not null && body.Contains(CommentMarker, StringComparison.Ordinal))
+                return false;
+        }
+
+        return true;
+    }
+
     private static readonly TimeSpan GhTimeout = TimeSpan.FromSeconds(30);
 
     private (int ExitCode, string Output) RunGh(string arguments)

--- a/src/copilotd/Services/GhCliService.cs
+++ b/src/copilotd/Services/GhCliService.cs
@@ -379,6 +379,8 @@ public sealed class GhCliService
     /// <summary>
     /// Returns info about the first new non-bot review comment or PR comment since the given timestamp,
     /// or null if no new comments exist. Checks both regular PR comments and formal review submissions.
+    /// Note: Does not detect individual review-thread replies (only top-level comments and formal
+    /// review submissions). Detecting thread replies would require GraphQL queries against reviewThreads.
     /// </summary>
     public NewCommentInfo? GetNewPrReviewCommentSince(string repo, int prNumber, DateTimeOffset since)
     {

--- a/src/copilotd/Services/ReconciliationEngine.cs
+++ b/src/copilotd/Services/ReconciliationEngine.cs
@@ -337,6 +337,9 @@ public sealed class ReconciliationEngine
                                 {
                                     _logger.LogInformation("Ignoring comment from non-collaborator {Author} on {Key} (trust_level=collaborators)",
                                         commentInfo.Author, issueKey);
+                                    // Advance WaitingSince past this comment so the next poll can find later trusted comments
+                                    existing.WaitingSince = commentInfo.CreatedAt;
+                                    existing.UpdatedAt = DateTimeOffset.UtcNow;
                                     continue;
                                 }
 
@@ -372,6 +375,7 @@ public sealed class ReconciliationEngine
                                 existing.ProcessId = null;
                                 existing.ProcessStartTime = null;
                                 existing.UpdatedAt = DateTimeOffset.UtcNow;
+                                _processManager.CleanupWorktree(existing, config, state);
                                 continue;
                             }
 
@@ -399,6 +403,9 @@ public sealed class ReconciliationEngine
                                     {
                                         _logger.LogInformation("Ignoring PR review from non-collaborator {Author} on {Key} (trust_level=collaborators)",
                                             reviewInfo.Author, issueKey);
+                                        // Advance WaitingSince past this review so the next poll can find later trusted reviews
+                                        existing.WaitingSince = reviewInfo.CreatedAt;
+                                        existing.UpdatedAt = DateTimeOffset.UtcNow;
                                         continue;
                                     }
 
@@ -440,6 +447,9 @@ public sealed class ReconciliationEngine
                                 {
                                     _logger.LogInformation("Ignoring issue comment from non-collaborator {Author} on {Key} while waiting for PR review (trust_level=collaborators)",
                                         issueCommentInfo.Author, issueKey);
+                                    // Advance WaitingSince past this comment so the next poll can find later trusted comments
+                                    existing.WaitingSince = issueCommentInfo.CreatedAt;
+                                    existing.UpdatedAt = DateTimeOffset.UtcNow;
                                     continue;
                                 }
 

--- a/src/copilotd/Services/ReconciliationEngine.cs
+++ b/src/copilotd/Services/ReconciliationEngine.cs
@@ -59,10 +59,11 @@ public sealed class ReconciliationEngine
         state.LastPollTime = DateTimeOffset.UtcNow;
         _stateStore.SaveState(state);
 
-        _logger.LogInformation("Reconciliation complete: {Active} active, {Pending} pending, {Waiting} waiting, {Terminal} terminal sessions",
+        _logger.LogInformation("Reconciliation complete: {Active} active, {Pending} pending, {Waiting} waiting, {WaitingForReview} waiting for review, {Terminal} terminal sessions",
             state.Sessions.Values.Count(s => s.Status == SessionStatus.Running),
             state.Sessions.Values.Count(s => s.Status == SessionStatus.Pending),
             state.Sessions.Values.Count(s => s.Status == SessionStatus.WaitingForFeedback),
+            state.Sessions.Values.Count(s => s.Status == SessionStatus.WaitingForReview),
             state.Sessions.Values.Count(s => s.IsTerminal));
     }
 
@@ -107,8 +108,8 @@ public sealed class ReconciliationEngine
             if (session.Status is SessionStatus.Pending)
                 continue;
 
-            // WaitingForFeedback sessions have no running process — skip liveness check
-            if (session.Status is SessionStatus.WaitingForFeedback)
+            // WaitingForFeedback and WaitingForReview sessions have no running process — skip liveness check
+            if (session.Status is SessionStatus.WaitingForFeedback or SessionStatus.WaitingForReview)
                 continue;
 
             // For Joined sessions, check if the interactive process is still alive.
@@ -264,6 +265,17 @@ public sealed class ReconciliationEngine
                     continue;
                 }
 
+                // WaitingForReview sessions have no process to terminate
+                if (session.Status is SessionStatus.WaitingForReview)
+                {
+                    _logger.LogInformation("Issue {Key} no longer matches rules, completing PR review session", key);
+                    session.Status = SessionStatus.Completed;
+                    session.WaitingSince = null;
+                    session.UpdatedAt = DateTimeOffset.UtcNow;
+                    _processManager.CleanupWorktree(session, config, state);
+                    continue;
+                }
+
                 _logger.LogInformation("Issue {Key} no longer matches rules, terminating session", key);
                 toTerminate.Add(session);
             }
@@ -318,12 +330,64 @@ public sealed class ReconciliationEngine
                         }
                         continue;
 
+                    case SessionStatus.WaitingForReview:
+                        if (existing.PullRequestNumber is not null)
+                        {
+                            // Check if the PR has been merged or closed — auto-complete the session
+                            var prState = _ghCli.GetPullRequestState(existing.Repo, existing.PullRequestNumber.Value);
+                            if (prState is "MERGED" or "CLOSED")
+                            {
+                                _logger.LogInformation("PR #{Pr} for {Key} is {State}, completing session",
+                                    existing.PullRequestNumber, issueKey, prState);
+                                existing.Status = SessionStatus.Completed;
+                                existing.CompletedBySession = true;
+                                existing.WaitingSince = null;
+                                existing.ProcessId = null;
+                                existing.ProcessStartTime = null;
+                                existing.UpdatedAt = DateTimeOffset.UtcNow;
+                                continue;
+                            }
+
+                            // Check for new review comments on the PR
+                            if (existing.WaitingSince is not null
+                                && _ghCli.HasNewPrReviewCommentsSince(existing.Repo, existing.PullRequestNumber.Value, existing.WaitingSince.Value))
+                            {
+                                _logger.LogInformation("New review comment detected on PR #{Pr} for {Key}, re-dispatching session",
+                                    existing.PullRequestNumber, issueKey);
+                                // Keep same CopilotSessionId so --resume preserves context
+                                existing.Status = SessionStatus.Pending;
+                                existing.WaitingSince = null;
+                                existing.ProcessId = null;
+                                existing.ProcessStartTime = null;
+                                existing.UpdatedAt = DateTimeOffset.UtcNow;
+                                continue;
+                            }
+                        }
+
+                        // Also check for new issue comments (maintainer may respond on the issue)
+                        if (existing.WaitingSince is not null
+                            && _ghCli.HasNewCommentsSince(existing.Repo, existing.IssueNumber, existing.WaitingSince.Value))
+                        {
+                            _logger.LogInformation("New issue comment detected on {Key} while waiting for PR review, re-dispatching session", issueKey);
+                            existing.Status = SessionStatus.Pending;
+                            existing.WaitingSince = null;
+                            existing.ProcessId = null;
+                            existing.ProcessStartTime = null;
+                            existing.UpdatedAt = DateTimeOffset.UtcNow;
+                        }
+                        else
+                        {
+                            _logger.LogDebug("Session {Key} still waiting for PR review feedback", issueKey);
+                        }
+                        continue;
+
                     case SessionStatus.Orphaned when existing.CanRetry:
                         _logger.LogInformation("Re-dispatching orphaned session {Key} (retry {N}/{Max})",
                             issueKey, existing.RetryCount + 1, DispatchSession.MaxRetries);
                         _processManager.CleanupWorktree(existing, config, state);
                         existing.Status = SessionStatus.Pending;
                         existing.RetryCount++;
+                        existing.PullRequestNumber = null;
                         existing.CopilotSessionId = Guid.NewGuid().ToString();
                         existing.ProcessId = null;
                         existing.ProcessStartTime = null;
@@ -353,6 +417,7 @@ public sealed class ReconciliationEngine
                         _logger.LogInformation("Issue {Key} re-matched after completion, re-dispatching", issueKey);
                         _processManager.CleanupWorktree(existing, config, state);
                         existing.Status = SessionStatus.Pending;
+                        existing.PullRequestNumber = null;
                         existing.CopilotSessionId = Guid.NewGuid().ToString();
                         existing.ProcessId = null;
                         existing.ProcessStartTime = null;


### PR DESCRIPTION
## Summary

Adds support for copilotd to monitor PR review comments and re-dispatch copilot sessions to address feedback, implementing the flow described in #18.

## Changes

### New `session pr` command
- `copilotd session pr <pr-number> <issue>` — Associates a PR with a session and transitions it to `WaitingForReview` status
- Mirrors the existing `session comment` / `WaitingForFeedback` pattern

### PR review comment polling
- Reconciliation engine monitors PRs in `WaitingForReview` state
- Checks both regular PR comments and formal review submissions (`CHANGES_REQUESTED` or `COMMENTED`)
- Falls back to issue comment detection (same as `WaitingForFeedback`)
- Auto-completes sessions when PR is merged or closed

### PR-aware re-dispatch
- When review feedback is detected, session is re-dispatched with a PR-specific prompt
- Prompt instructs copilot to read PR review comments, address feedback, push changes, and call `session pr` again
- Reuses the existing worktree (refreshes with `git fetch` + `git pull --ff-only`) instead of creating a new one
- Resumes the same copilot session to preserve conversation history

### Updated default prompt
- Default prompt now instructs copilot to use `session pr <pr-number>` after creating a PR

## Flow

1. Issue dispatched → copilot works on it → creates PR → calls `session pr 123 owner/repo#N`
2. Session enters `WaitingForReview` state, monitoring PR #123
3. Reviewer posts feedback → copilotd detects it → re-dispatches with PR review prompt
4. Copilot addresses feedback → pushes changes → calls `session pr` again
5. Loop continues until PR is merged/closed (auto-completes) or copilot calls `session complete`

## Testing

E2E verified:
- [x] `session pr` command correctly sets `WaitingForReview` status and `PullRequestNumber`
- [x] Daemon detects `WaitingForReview` sessions and polls PR for comments/reviews
- [x] Review comment detection triggers re-dispatch with correct PR-specific prompt
- [x] Worktree reuse works (refresh instead of recreate)
- [x] Session resumes with same session ID
- [x] PR close auto-completes the session
- [x] Code reviewed by Goldeneye and Opus 4.6; all findings addressed

Closes #18
