### PR TITLE
Fix cleanup trap unbound variable error in install script

### DIFF
--- a/scripts/install/install-copilotd.sh
+++ b/scripts/install/install-copilotd.sh
@@ -668,17 +668,16 @@ install_copilotd() {
         fi
     fi
 
-    local temp_root
-    temp_root=$(mktemp -d "${TMPDIR:-/tmp}/copilotd-install-XXXXXX")
+    COPILOTD_INSTALL_TEMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/copilotd-install-XXXXXX")
+    local temp_root="$COPILOTD_INSTALL_TEMP_ROOT"
     local download_path="${temp_root}/${asset_name}"
     local extract_path="${temp_root}/extract"
 
     log_verbose "Using temporary workspace '$temp_root'."
 
     cleanup() {
-        if [[ -d "$temp_root" ]]; then
-            log_verbose "Cleaning up temporary workspace '$temp_root'."
-            rm -rf "$temp_root"
+        if [[ -d "${COPILOTD_INSTALL_TEMP_ROOT:-}" ]]; then
+            rm -rf "$COPILOTD_INSTALL_TEMP_ROOT"
         fi
     }
     trap cleanup EXIT


### PR DESCRIPTION
## Problem

The install script exits with `unbound variable` error after a successful install:

```
copilotd 0.0.4-pre.1.dev.4 is ready to use from '/home/user/.copilotd/bin'.
scripts/install/install-copilotd.sh: line 679: temp_root: unbound variable
```

## Root Cause

The EXIT trap's `cleanup` function references `temp_root`, which is declared `local` inside `install_copilotd()`. When the trap fires after the function returns, `set -u` (from `set -euo pipefail`) causes an unbound variable error since the local scope has ended.

## Fix

Use a global variable (`COPILOTD_INSTALL_TEMP_ROOT`) for the trap to reference, with `${VAR:-}` guard for `set -u` safety.

## Verified

Tested all three execution modes:
- Direct: `bash install-copilotd.sh --quality Dev --force --skip-provenance`
- Piped: `cat install-copilotd.sh | bash -s -- --quality Dev --force --skip-provenance`
- Re-install (version skip path)