### PR TITLE
Use native arm64 runners for linux-arm64 builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
             rid: win-arm64
           - runner: ubuntu-22.04
             rid: linux-x64
-          - runner: ubuntu-22.04
+          - runner: ubuntu-22.04-arm
             rid: linux-arm64
           - runner: macos-latest
             rid: osx-x64
@@ -147,22 +147,6 @@ jobs:
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
         with:
           dotnet-version: '10.0.x'
-
-      - name: Install linux-arm64 prerequisites
-        if: matrix.rid == 'linux-arm64'
-        shell: bash
-        run: |
-          set -euo pipefail
-          sudo dpkg --add-architecture arm64
-          sudo bash -c 'cat > /etc/apt/sources.list.d/arm64.list <<EOF
-          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy main restricted universe
-          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main restricted universe
-          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-security main restricted universe
-          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-backports main restricted universe multiverse
-          EOF'
-          sudo sed -i -e 's/^deb /deb [arch=amd64] /g' /etc/apt/sources.list
-          sudo apt update
-          sudo apt install -y clang llvm binutils-aarch64-linux-gnu gcc-aarch64-linux-gnu zlib1g-dev:arm64
 
       - name: Publish native asset
         shell: pwsh
@@ -197,7 +181,7 @@ jobs:
             rid: win-arm64
           - runner: ubuntu-22.04
             rid: linux-x64
-          - runner: ubuntu-22.04
+          - runner: ubuntu-22.04-arm
             rid: linux-arm64
           - runner: macos-latest
             rid: osx-x64
@@ -219,22 +203,6 @@ jobs:
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
         with:
           dotnet-version: '10.0.x'
-
-      - name: Install linux-arm64 prerequisites
-        if: matrix.rid == 'linux-arm64'
-        shell: bash
-        run: |
-          set -euo pipefail
-          sudo dpkg --add-architecture arm64
-          sudo bash -c 'cat > /etc/apt/sources.list.d/arm64.list <<EOF
-          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy main restricted universe
-          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main restricted universe
-          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-security main restricted universe
-          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-backports main restricted universe multiverse
-          EOF'
-          sudo sed -i -e 's/^deb /deb [arch=amd64] /g' /etc/apt/sources.list
-          sudo apt update
-          sudo apt install -y clang llvm binutils-aarch64-linux-gnu gcc-aarch64-linux-gnu zlib1g-dev:arm64
 
       - name: Publish native asset
         shell: pwsh

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,7 +55,7 @@ jobs:
             rid: win-x64
           - runner: ubuntu-22.04
             rid: linux-x64
-          - runner: ubuntu-22.04
+          - runner: ubuntu-22.04-arm
             rid: linux-arm64
           - runner: macos-latest
             rid: osx-arm64
@@ -65,22 +65,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-
-      - name: Install linux-arm64 prerequisites
-        if: matrix.rid == 'linux-arm64'
-        shell: bash
-        run: |
-          set -euo pipefail
-          sudo dpkg --add-architecture arm64
-          sudo bash -c 'cat > /etc/apt/sources.list.d/arm64.list <<EOF
-          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy main restricted universe
-          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main restricted universe
-          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-security main restricted universe
-          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-backports main restricted universe multiverse
-          EOF'
-          sudo sed -i -e 's/^deb /deb [arch=amd64] /g' /etc/apt/sources.list
-          sudo apt update
-          sudo apt install -y clang llvm binutils-aarch64-linux-gnu gcc-aarch64-linux-gnu zlib1g-dev:arm64
 
       - name: Build and validate NativeAOT publish
         uses: ./.github/actions/build


### PR DESCRIPTION
## Summary

Switches linux-arm64 matrix entries from `ubuntu-22.04` (x64 cross-compilation) to `ubuntu-22.04-arm` (native arm64) in both CI and PR workflows.

## Problem

The `Install linux-arm64 prerequisites` step downloads ~60MB of cross-compilation toolchain packages (`clang`, `llvm`, `binutils-aarch64-linux-gnu`, `gcc-aarch64-linux-gnu`, `zlib1g-dev:arm64`) via `apt install` on every run. This is intermittently extremely slow depending on runner network conditions — in [run 24261778059](https://github.com/DamianEdwards/copilotd/actions/runs/24261778059), the RC job downloaded at 42 kB/s (25 min) while the dev job hit 25 MB/s (2 sec). This happened again in [run 24263359106](https://github.com/DamianEdwards/copilotd/actions/runs/24263359106/job/70852621463).

## Changes

- **`ci.yml`**: Changed `runner` from `ubuntu-22.04` to `ubuntu-22.04-arm` for both `publish-dev` and `publish-rc` `linux-arm64` matrix entries. Removed the `Install linux-arm64 prerequisites` step from both jobs.
- **`pr.yml`**: Same change for the `publish-aot` `linux-arm64` matrix entry.

Net result: **3 lines changed, 51 lines removed** across 2 files.

## Why this works

Native arm64 runners compile for `linux-arm64` directly — no cross-compilation toolchain needed. The .NET SDK handles native AOT compilation natively on the target architecture.

Fixes #68