### PR TITLE
Enable asset attestation now that repo is public

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -127,6 +127,11 @@ jobs:
 
     runs-on: ${{ matrix.runner }}
 
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -139,6 +144,15 @@ jobs:
       - name: Publish native asset
         shell: pwsh
         run: ./scripts/Publish-NativeAsset.ps1 -RuntimeIdentifier '${{ matrix.rid }}' -Version '${{ needs.version.outputs.version }}' -ArtifactsDirectory './artifacts/dev'
+
+      - name: Attest build provenance
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
+        with:
+          subject-path: './artifacts/dev/*'
+
+      - name: Remove attestation-only binaries
+        shell: bash
+        run: rm -f ./artifacts/dev/copilotd-${{ matrix.rid }} ./artifacts/dev/copilotd-${{ matrix.rid }}.exe
 
       - name: Upload dev artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
@@ -168,6 +182,11 @@ jobs:
 
     runs-on: ${{ matrix.runner }}
 
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -180,6 +199,15 @@ jobs:
       - name: Publish native asset
         shell: pwsh
         run: ./scripts/Publish-NativeAsset.ps1 -RuntimeIdentifier '${{ matrix.rid }}' -Version '${{ needs.version.outputs.rc_version }}' -ArtifactsDirectory './artifacts/rc'
+
+      - name: Attest build provenance
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
+        with:
+          subject-path: './artifacts/rc/*'
+
+      - name: Remove attestation-only binaries
+        shell: bash
+        run: rm -f ./artifacts/rc/copilotd-${{ matrix.rid }} ./artifacts/rc/copilotd-${{ matrix.rid }}.exe
 
       - name: Upload RC artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,6 @@ jobs:
 
       - name: Attest build provenance
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
-        continue-on-error: true
         with:
           subject-path: './artifacts/dev/*'
 
@@ -210,7 +209,6 @@ jobs:
 
       - name: Attest build provenance
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
-        continue-on-error: true
         with:
           subject-path: './artifacts/rc/*'
 


### PR DESCRIPTION
## Summary

Enables build provenance attestation across all publish workflows now that the repository is public.

## Problem

The last CI run (April 10) showed attestation errors:
> Failed to persist attestation: Feature not available for user-owned private repositories.

The \continue-on-error: true\ flag on CI attestation steps silenced these failures. Additionally, the \ump-version.yml\ workflow was missing attestation entirely.

## Changes

- **\ci.yml\**: Removed \continue-on-error: true\ from both \publish-dev\ and \publish-rc\ attestation steps so failures are now visible
- **\ump-version.yml\**: Added attestation steps (with permissions and attestation-only binary cleanup) to both \publish-dev\ and \publish-rc\ jobs, matching the CI workflow pattern