### PR TITLE
Add cross-platform self-update support for Linux/macOS

### DIFF
--- a/src/copilotd/Commands/RunCommand.cs
+++ b/src/copilotd/Commands/RunCommand.cs
@@ -1,4 +1,5 @@
 using System.CommandLine;
+using System.Diagnostics;
 using Copilotd.Infrastructure;
 using Copilotd.Models;
 using Copilotd.Services;
@@ -87,44 +88,41 @@ public static class RunCommand
                             reconciliation.Reconcile(config, state);
 
                             // Self-update: check for staged update or fire background check
-                            if (OperatingSystem.IsWindows())
+                            var updateState = stateStore.LoadUpdateState();
+                            if (updateState.Status == UpdateStatus.Staged
+                                && !string.IsNullOrEmpty(updateState.StagedPath)
+                                && File.Exists(updateState.StagedPath))
                             {
-                                var updateState = stateStore.LoadUpdateState();
-                                if (updateState.Status == UpdateStatus.Staged
-                                    && !string.IsNullOrEmpty(updateState.StagedPath)
-                                    && File.Exists(updateState.StagedPath))
+                                // Staged update ready — spawn install process and exit daemon
+                                ConsoleOutput.Info($"Staged update {updateState.StagedVersion} detected, initiating install...");
+                                logger.LogInformation("Spawning update installer for staged version {Version}", updateState.StagedVersion);
+                                if (SpawnUpdateInstaller(logger))
                                 {
-                                    // Staged update ready — spawn install process and exit daemon
-                                    ConsoleOutput.Info($"Staged update {updateState.StagedVersion} detected, initiating install...");
-                                    logger.LogInformation("Spawning update installer for staged version {Version}", updateState.StagedVersion);
-                                    if (SpawnUpdateInstaller(logger))
-                                    {
-                                        cts.Cancel();
-                                        break;
-                                    }
-                                    else
-                                    {
-                                        ConsoleOutput.Warning("Failed to spawn update installer, will retry next cycle.");
-                                    }
+                                    cts.Cancel();
+                                    break;
                                 }
-
-                                // Fire non-blocking update check/stage (runs in background, result picked up next cycle)
-                                _ = Task.Run(async () =>
+                                else
                                 {
-                                    try
-                                    {
-                                        await updateService.CheckAndStageAsync(
-                                            allowPreRelease: false,
-                                            skipProvenance: false,
-                                            cts.Token);
-                                    }
-                                    catch (OperationCanceledException) { }
-                                    catch (Exception ex)
-                                    {
-                                        logger.LogDebug(ex, "Background update check failed");
-                                    }
-                                }, cts.Token);
+                                    ConsoleOutput.Warning("Failed to spawn update installer, will retry next cycle.");
+                                }
                             }
+
+                            // Fire non-blocking update check/stage (runs in background, result picked up next cycle)
+                            _ = Task.Run(async () =>
+                            {
+                                try
+                                {
+                                    await updateService.CheckAndStageAsync(
+                                        allowPreRelease: false,
+                                        skipProvenance: false,
+                                        cts.Token);
+                                }
+                                catch (OperationCanceledException) { }
+                                catch (Exception ex)
+                                {
+                                    logger.LogDebug(ex, "Background update check failed");
+                                }
+                            }, cts.Token);
                         }
                         catch (Exception ex)
                         {
@@ -167,7 +165,8 @@ public static class RunCommand
     /// <summary>
     /// Spawns a detached <c>copilotd update --install-staged</c> process
     /// that will wait for this daemon to exit, then perform the binary replacement.
-    /// Uses CreateProcessW on Windows for proper console isolation.
+    /// Windows: CreateProcessW with CREATE_NEW_CONSOLE for proper console isolation.
+    /// Unix: setsid for session detachment, with fallback to direct Process.Start.
     /// Returns true if the process was successfully spawned.
     /// </summary>
     private static bool SpawnUpdateInstaller(ILogger logger)
@@ -182,8 +181,15 @@ public static class RunCommand
         var commandLine = $"\"{exePath}\" update --install-staged";
         logger.LogDebug("Spawning update installer: {CommandLine}", commandLine);
 
-        if (!OperatingSystem.IsWindows())
-            return false;
+        if (OperatingSystem.IsWindows())
+            return SpawnUpdateInstallerWindows(exePath, logger);
+
+        return SpawnUpdateInstallerUnix(exePath, logger);
+    }
+
+    private static bool SpawnUpdateInstallerWindows(string exePath, ILogger logger)
+    {
+        var commandLine = $"\"{exePath}\" update --install-staged";
 
         var si = new NativeInterop.STARTUPINFO { cb = System.Runtime.InteropServices.Marshal.SizeOf<NativeInterop.STARTUPINFO>() };
         si.dwFlags = NativeInterop.STARTF_USESHOWWINDOW;
@@ -210,6 +216,70 @@ public static class RunCommand
         }
 
         logger.LogError("Failed to spawn update installer via CreateProcessW");
+        return false;
+    }
+
+    /// <summary>
+    /// Spawns the update installer as a detached process on Unix using setsid,
+    /// mirroring the pattern used by <see cref="StartCommand"/>.
+    /// </summary>
+    private static bool SpawnUpdateInstallerUnix(string exePath, ILogger logger)
+    {
+        // Try setsid first for full session detachment
+        var psi = new ProcessStartInfo
+        {
+            FileName = "setsid",
+            Arguments = $"\"{exePath}\" update --install-staged",
+            UseShellExecute = false,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+        };
+
+        try
+        {
+            var process = Process.Start(psi);
+            if (process is not null)
+            {
+                process.StandardInput.Close();
+                logger.LogInformation("Update installer spawned via setsid (PID {Pid})", process.Id);
+                return true;
+            }
+        }
+        catch
+        {
+            // setsid not available, fall back to direct launch
+            logger.LogDebug("setsid not available, falling back to direct launch");
+        }
+
+        // Fallback: direct process launch
+        var fallbackPsi = new ProcessStartInfo
+        {
+            FileName = exePath,
+            Arguments = "update --install-staged",
+            UseShellExecute = false,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+        };
+
+        try
+        {
+            var process = Process.Start(fallbackPsi);
+            if (process is not null)
+            {
+                process.StandardInput.Close();
+                logger.LogInformation("Update installer spawned (PID {Pid})", process.Id);
+                return true;
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to spawn update installer");
+        }
+
         return false;
     }
 }

--- a/src/copilotd/Commands/UpdateCommand.cs
+++ b/src/copilotd/Commands/UpdateCommand.cs
@@ -17,7 +17,7 @@ public static class UpdateCommand
 
     public static Command Create(IServiceProvider services)
     {
-        var command = new Command("update", "Check for and install updates (Windows only)");
+        var command = new Command("update", "Check for and install updates");
 
         var checkOption = new Option<bool>("--check")
         {
@@ -29,7 +29,7 @@ public static class UpdateCommand
         };
         var skipProvenanceOption = new Option<bool>("--skip-provenance-checks")
         {
-            Description = "Disable Authenticode signature verification"
+            Description = "Disable provenance verification (Authenticode on Windows, attestation on Linux/macOS)"
         };
         var dryRunOption = new Option<bool>("--dry-run")
         {
@@ -52,12 +52,6 @@ public static class UpdateCommand
             var logger = services.GetRequiredService<ILogger<Program>>();
             return await ConsoleOutput.RunWithErrorHandling(async () =>
             {
-                if (!OperatingSystem.IsWindows())
-                {
-                    ConsoleOutput.Warning("Self-updating is currently only supported on Windows.");
-                    return 1;
-                }
-
                 var updateService = services.GetRequiredService<UpdateService>();
                 var stateStore = services.GetRequiredService<StateStore>();
 
@@ -148,7 +142,7 @@ public static class UpdateCommand
         {
             ConsoleOutput.Info("[dry-run] Would download, verify, and install this update.");
             ConsoleOutput.Info($"[dry-run] Release tag: {update.ReleaseTag}, Dev build: {update.IsDevBuild}");
-            ConsoleOutput.Info($"[dry-run] Authenticode verification: {(update.IsDevBuild || skipProvenance ? "skipped" : "enabled")}");
+            ConsoleOutput.Info($"[dry-run] Provenance verification: {(update.IsDevBuild || skipProvenance ? "skipped" : "enabled")}");
             ConsoleOutput.Info($"[dry-run] Checksum verification: enabled");
             return 0;
         }

--- a/src/copilotd/Infrastructure/GitHubReleaseService.cs
+++ b/src/copilotd/Infrastructure/GitHubReleaseService.cs
@@ -334,11 +334,6 @@ public sealed class GitHubReleaseService
         throw new PlatformNotSupportedException("Unsupported operating system");
     }
 
-    /// <summary>
-    /// Gets the architecture-specific asset name for Windows.
-    /// </summary>
-    [Obsolete("Use GetPlatformAssetName() instead")]
-    public static string GetWindowsAssetName() => GetPlatformAssetName();
 
     private static bool ReleaseHasAsset(JsonElement release, string assetName)
     {

--- a/src/copilotd/Infrastructure/GitHubReleaseService.cs
+++ b/src/copilotd/Infrastructure/GitHubReleaseService.cs
@@ -259,16 +259,54 @@ public sealed class GitHubReleaseService
     }
 
     /// <summary>
-    /// Extracts a ZIP archive to a destination directory.
+    /// Extracts a release archive to a destination directory.
+    /// Handles ZIP (Windows) and tar.gz (Linux/macOS) formats.
     /// </summary>
     public static string ExtractReleaseArchive(string archivePath, string destinationDir)
     {
         Directory.CreateDirectory(destinationDir);
-        ZipFile.ExtractToDirectory(archivePath, destinationDir, overwriteFiles: true);
 
-        var binaryPath = Path.Combine(destinationDir, "copilotd.exe");
+        var binaryName = OperatingSystem.IsWindows() ? "copilotd.exe" : "copilotd";
+
+        if (archivePath.EndsWith(".tar.gz", StringComparison.OrdinalIgnoreCase))
+        {
+            // Use tar for extraction on Unix — preserves file permissions
+            var psi = new ProcessStartInfo
+            {
+                FileName = "tar",
+                Arguments = $"-xzf \"{archivePath}\" -C \"{destinationDir}\"",
+                UseShellExecute = false,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+            };
+
+            using var process = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start tar process");
+            var stderr = process.StandardError.ReadToEnd();
+
+            if (!process.WaitForExit(60_000))
+            {
+                process.Kill();
+                throw new TimeoutException("tar extraction timed out after 60 seconds");
+            }
+
+            if (process.ExitCode != 0)
+                throw new InvalidOperationException($"tar extraction failed (exit code {process.ExitCode}): {stderr}");
+        }
+        else
+        {
+            ZipFile.ExtractToDirectory(archivePath, destinationDir, overwriteFiles: true);
+        }
+
+        var binaryPath = Path.Combine(destinationDir, binaryName);
         if (!File.Exists(binaryPath))
-            throw new FileNotFoundException($"Archive did not contain copilotd.exe", binaryPath);
+            throw new FileNotFoundException($"Archive did not contain {binaryName}", binaryPath);
+
+        // Ensure the binary is executable on Unix
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(binaryPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+                | UnixFileMode.GroupRead | UnixFileMode.GroupExecute
+                | UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
 
         return binaryPath;
     }
@@ -276,17 +314,31 @@ public sealed class GitHubReleaseService
     /// <summary>
     /// Gets the architecture-specific asset name for the current platform.
     /// </summary>
-    public static string GetWindowsAssetName()
+    public static string GetPlatformAssetName()
     {
-        var arch = System.Runtime.InteropServices.RuntimeInformation.OSArchitecture;
+        var arch = System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture;
         var archStr = arch switch
         {
             System.Runtime.InteropServices.Architecture.X64 => "x64",
             System.Runtime.InteropServices.Architecture.Arm64 => "arm64",
             _ => throw new PlatformNotSupportedException($"Unsupported architecture: {arch}")
         };
-        return $"copilotd-win-{archStr}.zip";
+
+        if (OperatingSystem.IsWindows())
+            return $"copilotd-win-{archStr}.zip";
+        if (OperatingSystem.IsMacOS())
+            return $"copilotd-osx-{archStr}.tar.gz";
+        if (OperatingSystem.IsLinux())
+            return $"copilotd-linux-{archStr}.tar.gz";
+
+        throw new PlatformNotSupportedException("Unsupported operating system");
     }
+
+    /// <summary>
+    /// Gets the architecture-specific asset name for Windows.
+    /// </summary>
+    [Obsolete("Use GetPlatformAssetName() instead")]
+    public static string GetWindowsAssetName() => GetPlatformAssetName();
 
     private static bool ReleaseHasAsset(JsonElement release, string assetName)
     {

--- a/src/copilotd/Infrastructure/ProvenanceVerifier.cs
+++ b/src/copilotd/Infrastructure/ProvenanceVerifier.cs
@@ -40,15 +40,42 @@ public sealed class ProvenanceVerifier
     /// Verifies GitHub artifact attestation for a file using <c>gh attestation verify</c>.
     /// Used on Linux/macOS where Authenticode is not available.
     /// Mirrors the verification done by <c>install-copilotd.sh</c>.
+    /// Tries both the CI and bump-version workflows since either may have produced the release.
     /// </summary>
     public async Task<(bool Success, string? Error)> VerifyAttestationAsync(string filePath, CancellationToken ct)
     {
         _logger.LogInformation("Verifying artifact attestation for '{FilePath}'", filePath);
 
         var repo = GitHubReleaseService.Repository;
+
+        // Try each workflow that produces attested release assets
+        string[] signerWorkflows =
+        [
+            $"{repo}/.github/workflows/ci.yml",
+            $"{repo}/.github/workflows/bump-version.yml",
+        ];
+
+        string? lastError = null;
+        foreach (var workflow in signerWorkflows)
+        {
+            var (success, error) = await RunAttestationVerifyAsync(filePath, repo, workflow, ct);
+            if (success)
+                return (true, null);
+            lastError = error;
+            _logger.LogDebug("Attestation verification with workflow '{Workflow}' did not match, trying next", workflow);
+        }
+
+        _logger.LogWarning("Attestation verification failed for '{FilePath}': {Error}", filePath, lastError);
+        return (false, lastError ?? "Attestation verification failed");
+    }
+
+    private async Task<(bool Success, string? Error)> RunAttestationVerifyAsync(
+        string filePath, string repo, string signerWorkflow, CancellationToken ct)
+    {
         var args = $"attestation verify \"{filePath}\""
             + $" -R {repo}"
             + $" --signer-repo {repo}"
+            + $" --signer-workflow {signerWorkflow}"
             + " --source-ref refs/heads/main";
 
         var psi = new ProcessStartInfo
@@ -98,14 +125,12 @@ public sealed class ProvenanceVerifier
                 return (true, null);
             }
 
-            // gh attestation verify outputs errors to stderr
             var stderr = await stderrTask;
             var stdout = await stdoutTask;
             var error = !string.IsNullOrWhiteSpace(stderr) ? stderr.Trim()
                 : !string.IsNullOrWhiteSpace(stdout) ? stdout.Trim()
                 : "Attestation verification failed";
 
-            _logger.LogWarning("Attestation verification failed for '{FilePath}': {Error}", filePath, error);
             return (false, error);
         }
     }

--- a/src/copilotd/Infrastructure/ProvenanceVerifier.cs
+++ b/src/copilotd/Infrastructure/ProvenanceVerifier.cs
@@ -7,11 +7,10 @@ using Microsoft.Extensions.Logging;
 namespace Copilotd.Infrastructure;
 
 /// <summary>
-/// Verifies provenance (Authenticode signature + certificate chain) of downloaded binaries
-/// by writing the embedded PowerShell verification script to a temp file and executing it.
-/// The temp file uses a random name and is deleted immediately after use.
-/// Also handles SHA256 checksum and release-metadata.json validation.
-/// Windows-only; no-ops on other platforms.
+/// Verifies provenance of downloaded binaries.
+/// Windows: Authenticode signature + certificate chain via embedded PowerShell script.
+/// Linux/macOS: GitHub artifact attestations via <c>gh attestation verify</c>.
+/// Also handles SHA256 checksum and release-metadata.json validation (cross-platform).
 /// </summary>
 public sealed class ProvenanceVerifier
 {
@@ -24,23 +23,104 @@ public sealed class ProvenanceVerifier
     }
 
     /// <summary>
-    /// Verifies the Authenticode signature and certificate chain of a binary
-    /// by writing the embedded verify-provenance.ps1 to a temp file and executing it.
+    /// Verifies provenance of a binary file.
+    /// On Windows: Authenticode signature and certificate chain via embedded PowerShell script.
+    /// On Linux/macOS: GitHub artifact attestation via <c>gh attestation verify</c>.
     /// </summary>
     /// <returns>True if verification passed, false if it failed.</returns>
     public async Task<(bool Success, string? Error)> VerifyBinaryTrustAsync(string binaryPath, CancellationToken ct)
     {
-        if (!OperatingSystem.IsWindows())
+        if (OperatingSystem.IsWindows())
+            return await VerifyAuthenticodeAsync(binaryPath, ct);
+
+        return await VerifyAttestationAsync(binaryPath, ct);
+    }
+
+    /// <summary>
+    /// Verifies GitHub artifact attestation for a file using <c>gh attestation verify</c>.
+    /// Used on Linux/macOS where Authenticode is not available.
+    /// Mirrors the verification done by <c>install-copilotd.sh</c>.
+    /// </summary>
+    public async Task<(bool Success, string? Error)> VerifyAttestationAsync(string filePath, CancellationToken ct)
+    {
+        _logger.LogInformation("Verifying artifact attestation for '{FilePath}'", filePath);
+
+        var repo = GitHubReleaseService.Repository;
+        var args = $"attestation verify \"{filePath}\""
+            + $" -R {repo}"
+            + $" --signer-repo {repo}"
+            + " --source-ref refs/heads/main";
+
+        var psi = new ProcessStartInfo
         {
-            _logger.LogDebug("Skipping provenance verification on non-Windows platform");
-            return (true, null);
+            FileName = "gh",
+            Arguments = args,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(VerifyTimeout);
+
+        Process process;
+        try
+        {
+            process = Process.Start(psi) ?? throw new InvalidOperationException("Failed to start gh process");
+        }
+        catch (Exception ex)
+        {
+            var msg = $"Failed to start gh CLI for attestation verification: {ex.Message}";
+            _logger.LogWarning("{Message}", msg);
+            return (false, msg);
         }
 
+        using (process)
+        {
+            var stderrTask = process.StandardError.ReadToEndAsync(timeoutCts.Token);
+            var stdoutTask = process.StandardOutput.ReadToEndAsync(timeoutCts.Token);
+
+            try
+            {
+                await process.WaitForExitAsync(timeoutCts.Token);
+            }
+            catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+            {
+                _logger.LogWarning("Attestation verification timed out after {Timeout}s", VerifyTimeout.TotalSeconds);
+                process.Kill();
+                return (false, "Attestation verification timed out");
+            }
+
+            if (process.ExitCode == 0)
+            {
+                _logger.LogInformation("Artifact attestation verification passed for '{FilePath}'", filePath);
+                return (true, null);
+            }
+
+            // gh attestation verify outputs errors to stderr
+            var stderr = await stderrTask;
+            var stdout = await stdoutTask;
+            var error = !string.IsNullOrWhiteSpace(stderr) ? stderr.Trim()
+                : !string.IsNullOrWhiteSpace(stdout) ? stdout.Trim()
+                : "Attestation verification failed";
+
+            _logger.LogWarning("Attestation verification failed for '{FilePath}': {Error}", filePath, error);
+            return (false, error);
+        }
+    }
+
+    /// <summary>
+    /// Verifies the Authenticode signature and certificate chain of a binary (Windows only)
+    /// by writing the embedded verify-provenance.ps1 to a temp file and executing it.
+    /// </summary>
+    private async Task<(bool Success, string? Error)> VerifyAuthenticodeAsync(string binaryPath, CancellationToken ct)
+    {
         var scriptContent = GetEmbeddedScript();
         if (scriptContent is null)
             return (false, "Failed to load embedded verification script");
 
-        _logger.LogInformation("Verifying provenance of '{BinaryPath}'", binaryPath);
+        _logger.LogInformation("Verifying Authenticode provenance of '{BinaryPath}'", binaryPath);
 
         // Write the embedded script to a temp file for execution. We use a temp file
         // because -EncodedCommand exceeds the 32K command-line limit and -Command -
@@ -67,7 +147,7 @@ public sealed class ProvenanceVerifier
             var stderrTask = process.StandardError.ReadToEndAsync(timeoutCts.Token);
             var stdoutTask = process.StandardOutput.ReadToEndAsync(timeoutCts.Token);
 
-        try
+            try
             {
                 await process.WaitForExitAsync(timeoutCts.Token);
             }

--- a/src/copilotd/Services/UpdateService.cs
+++ b/src/copilotd/Services/UpdateService.cs
@@ -16,7 +16,6 @@ public sealed record UpdateCheckResult(
 
 /// <summary>
 /// Orchestrates the self-update lifecycle: check → download → verify → stage → install.
-/// Windows-only; no-ops on other platforms.
 /// </summary>
 public sealed class UpdateService
 {
@@ -51,12 +50,6 @@ public sealed class UpdateService
     /// </summary>
     public UpdateCheckResult? CheckForUpdate(bool allowPreRelease)
     {
-        if (!OperatingSystem.IsWindows())
-        {
-            _logger.LogDebug("Self-update is only supported on Windows");
-            return null;
-        }
-
         var currentVersionStr = VersionHelper.GetCurrentVersion();
         if (currentVersionStr is null || !VersionHelper.TryParse(currentVersionStr, out var currentVersion))
         {
@@ -69,7 +62,7 @@ public sealed class UpdateService
             : VersionHelper.IsStableBuild(currentVersion) && !allowPreRelease ? "Stable"
             : "PreRelease";
 
-        var assetName = GitHubReleaseService.GetWindowsAssetName();
+        var assetName = GitHubReleaseService.GetPlatformAssetName();
         var release = _releaseService.GetLatestRelease(quality, assetName);
         if (release is null)
         {
@@ -131,7 +124,7 @@ public sealed class UpdateService
         state.CurrentReleaseTag = update.ReleaseTag;
         _stateStore.SaveUpdateState(state);
 
-        var assetName = GitHubReleaseService.GetWindowsAssetName();
+        var assetName = GitHubReleaseService.GetPlatformAssetName();
         var tempRoot = Path.Combine(Path.GetTempPath(), $"copilotd-update-{Guid.NewGuid():N}");
 
         try
@@ -179,10 +172,21 @@ public sealed class UpdateService
                 }
             }
 
+            // Verify provenance of archive before extraction (skip for dev builds)
+            if (!update.IsDevBuild && !skipProvenance)
+            {
+                var (archiveTrustOk, archiveTrustErr) = await _provenanceVerifier.VerifyBinaryTrustAsync(archivePath, ct);
+                if (!archiveTrustOk)
+                {
+                    RecordFailure(state, archiveTrustErr ?? "Archive provenance verification failed");
+                    return false;
+                }
+            }
+
             // Extract archive
             var extractedBinary = GitHubReleaseService.ExtractReleaseArchive(archivePath, extractPath);
 
-            // Verify Authenticode provenance of extracted binary (skip for dev builds)
+            // Verify provenance of extracted binary (skip for dev builds)
             if (!update.IsDevBuild && !skipProvenance)
             {
                 var (trustOk, trustErr) = await _provenanceVerifier.VerifyBinaryTrustAsync(extractedBinary, ct);
@@ -197,9 +201,16 @@ public sealed class UpdateService
             var currentExePath = Environment.ProcessPath
                 ?? throw new InvalidOperationException("Cannot determine current executable path");
             var installDir = Path.GetDirectoryName(currentExePath)!;
-            var stagedPath = Path.Combine(installDir, "copilotd.exe.staged");
+            var binaryName = OperatingSystem.IsWindows() ? "copilotd.exe" : "copilotd";
+            var stagedPath = Path.Combine(installDir, $"{binaryName}.staged");
 
             File.Copy(extractedBinary, stagedPath, overwrite: true);
+
+            // Ensure the staged binary is executable on Unix
+            if (!OperatingSystem.IsWindows())
+                File.SetUnixFileMode(stagedPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+                    | UnixFileMode.GroupRead | UnixFileMode.GroupExecute
+                    | UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
 
             state.Status = UpdateStatus.Staged;
             state.StagedVersion = update.AvailableVersion;
@@ -289,7 +300,7 @@ public sealed class UpdateService
             _logger.LogInformation("Waiting for daemon (PID {Pid}) to exit...", daemonPid.Value.Pid);
             if (!await WaitForProcessExitAsync(daemonPid.Value.Pid, daemonPid.Value.StartTime, DaemonExitTimeout, ct))
             {
-                // Try graceful shutdown first via shutdown-instance helper
+                // Try graceful shutdown first
                 _logger.LogWarning("Daemon did not exit within timeout, attempting graceful shutdown");
                 if (!TryGracefulShutdown(daemonPid.Value.Pid))
                 {
@@ -313,15 +324,13 @@ public sealed class UpdateService
         var currentExePath = Environment.ProcessPath
             ?? throw new InvalidOperationException("Cannot determine current executable path");
         var installDir = Path.GetDirectoryName(currentExePath)!;
-        var targetPath = Path.Combine(installDir, "copilotd.exe");
-        var oldPath = Path.Combine(installDir, "copilotd.exe.old");
+        var binaryName = OperatingSystem.IsWindows() ? "copilotd.exe" : "copilotd";
+        var targetPath = Path.Combine(installDir, binaryName);
+        var oldPath = Path.Combine(installDir, $"{binaryName}.old");
 
-        // The install process itself is copilotd.exe, so we can't replace ourselves directly.
-        // But we CAN replace the target if we're running from a different path (the staged copy).
-        // However, if running as the target binary, Windows allows renaming the running executable.
         try
         {
-            // Rename current → old (Windows allows renaming running executables)
+            // Rename current → old
             if (File.Exists(targetPath))
             {
                 if (File.Exists(oldPath))
@@ -333,6 +342,12 @@ public sealed class UpdateService
             // Move staged → target
             File.Move(state.StagedPath, targetPath);
             _logger.LogDebug("Moved staged binary to '{Target}'", targetPath);
+
+            // Ensure the installed binary is executable on Unix
+            if (!OperatingSystem.IsWindows())
+                File.SetUnixFileMode(targetPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+                    | UnixFileMode.GroupRead | UnixFileMode.GroupExecute
+                    | UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
 
             // Success — clear update state
             _stateStore.ClearUpdateState();
@@ -433,7 +448,8 @@ public sealed class UpdateService
         var currentExePath = Environment.ProcessPath;
         if (currentExePath is null) return;
 
-        var oldPath = Path.Combine(Path.GetDirectoryName(currentExePath)!, "copilotd.exe.old");
+        var binaryName = OperatingSystem.IsWindows() ? "copilotd.exe" : "copilotd";
+        var oldPath = Path.Combine(Path.GetDirectoryName(currentExePath)!, $"{binaryName}.old");
         if (File.Exists(oldPath))
         {
             try
@@ -459,11 +475,15 @@ public sealed class UpdateService
     }
 
     /// <summary>
-    /// Attempts graceful shutdown of the daemon by spawning <c>copilotd shutdown-instance --pid</c>.
-    /// This mirrors the graceful shutdown logic used elsewhere in the codebase.
+    /// Attempts graceful shutdown of the daemon.
+    /// Windows: spawns <c>copilotd shutdown-instance --pid</c> (required for console attachment).
+    /// Unix: sends SIGINT directly via <c>libc kill()</c>.
     /// </summary>
     private bool TryGracefulShutdown(int pid)
     {
+        if (!OperatingSystem.IsWindows())
+            return TryGracefulShutdownUnix(pid);
+
         var copilotdPath = Environment.ProcessPath;
         if (copilotdPath is null)
         {
@@ -520,6 +540,68 @@ public sealed class UpdateService
         catch (Exception ex)
         {
             _logger.LogDebug(ex, "Graceful shutdown attempt failed");
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Sends SIGINT to the daemon process on Unix for graceful shutdown,
+    /// followed by SIGKILL if the process doesn't exit promptly.
+    /// </summary>
+    private bool TryGracefulShutdownUnix(int pid)
+    {
+        _logger.LogDebug("Sending SIGINT to daemon PID {Pid}", pid);
+        try
+        {
+            // Send SIGINT for graceful shutdown
+            if (NativeInterop.sys_kill(pid, NativeInterop.SIGINT) != 0)
+            {
+                _logger.LogDebug("SIGINT failed for PID {Pid}", pid);
+                return false;
+            }
+
+            // Wait up to 10 seconds for the process to exit
+            for (var i = 0; i < 20; i++)
+            {
+                Thread.Sleep(500);
+                try
+                {
+                    var proc = System.Diagnostics.Process.GetProcessById(pid);
+                    if (proc.HasExited)
+                    {
+                        _logger.LogInformation("Daemon PID {Pid} terminated via SIGINT", pid);
+                        return true;
+                    }
+                    proc.Dispose();
+                }
+                catch (ArgumentException)
+                {
+                    // Process not found = already exited
+                    _logger.LogInformation("Daemon PID {Pid} terminated via SIGINT", pid);
+                    return true;
+                }
+            }
+
+            // Fallback: SIGKILL
+            _logger.LogWarning("Daemon did not exit after SIGINT, sending SIGKILL to PID {Pid}", pid);
+            NativeInterop.sys_kill(pid, NativeInterop.SIGKILL);
+            Thread.Sleep(1000);
+
+            try
+            {
+                var proc = System.Diagnostics.Process.GetProcessById(pid);
+                if (proc.HasExited) return true;
+                proc.Dispose();
+            }
+            catch (ArgumentException)
+            {
+                return true;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Unix graceful shutdown attempt failed");
         }
 
         return false;


### PR DESCRIPTION
## Summary

Extends the self-update system to work on Linux and macOS, previously Windows-only.

Closes #44

## Changes

### Provenance Verification (ProvenanceVerifier.cs)
- **Non-Windows**: Uses \gh attestation verify\ with \--signer-repo\ and \--source-ref\ to verify GitHub artifact attestations (matching the pattern used by \install-copilotd.sh\)
- **Windows**: Authenticode verification remains unchanged
- Accepts attestations from both \ci.yml\ and \ump-version.yml\ workflows

### Asset Resolution (GitHubReleaseService.cs)
- New \GetPlatformAssetName()\ resolves the correct asset for the current OS/arch:
  - Linux: \copilotd-linux-{arch}.tar.gz\
  - macOS: \copilotd-osx-{arch}.tar.gz\  
  - Windows: \copilotd-win-{arch}.zip\
- Uses \ProcessArchitecture\ (not \OSArchitecture\) for Rosetta compatibility
- \ExtractReleaseArchive()\ handles tar.gz via \	ar -xzf\ with timeout handling, preserving Unix file permissions

### Update Service (UpdateService.cs)
- Removed Windows-only gates from \CheckForUpdate()\, \DownloadAndStageAsync()\, \InstallStagedAsync()\
- Platform-aware binary naming (\copilotd\ vs \copilotd.exe\)
- \chmod +x\ on staged and installed binaries
- Archive attestation verification **before** extraction (security improvement)
- Binary attestation verification after extraction
- Unix graceful shutdown via SIGINT/SIGKILL (vs Windows shutdown-instance helper)

### Daemon Loop (RunCommand.cs)
- Removed Windows-only gate on the self-update poll loop
- Unix \SpawnUpdateInstaller\ uses \setsid\ for session detachment (matching \StartCommand\ pattern), with fallback to direct \Process.Start\

### Update Command (UpdateCommand.cs)
- Removed Windows-only gate
- Updated descriptions to be platform-neutral