### PR TITLE
Fix gh attestation verify using mutually exclusive flags

### DIFF
--- a/scripts/install/install-copilotd.sh
+++ b/scripts/install/install-copilotd.sh
@@ -375,7 +375,6 @@ assert_artifact_attestation() {
     local exit_code=0
     output=$(gh attestation verify "$file_path" \
         -R "$repo" \
-        --signer-repo "$repo" \
         --signer-workflow "${repo}/.github/workflows/ci.yml" \
         --source-ref "refs/heads/main" \
         2>&1) || exit_code=$?

--- a/src/copilotd/Infrastructure/ProvenanceVerifier.cs
+++ b/src/copilotd/Infrastructure/ProvenanceVerifier.cs
@@ -74,7 +74,6 @@ public sealed class ProvenanceVerifier
     {
         var args = $"attestation verify \"{filePath}\""
             + $" -R {repo}"
-            + $" --signer-repo {repo}"
             + $" --signer-workflow {signerWorkflow}"
             + " --source-ref refs/heads/main";
 


### PR DESCRIPTION
## Problem

`gh attestation verify` was invoked with both `--signer-repo` and `--signer-workflow` flags, which are mutually exclusive in the gh CLI (v2.89.0+). This caused attestation verification to **always fail** with:

```
if any flags in the group [cert-identity cert-identity-regex signer-repo signer-workflow] are set
none of the others can be; [signer-repo signer-workflow] were all set
```

This affected both:
- **`ProvenanceVerifier.cs`** — the self-update provenance check on Linux/macOS
- **`install-copilotd.sh`** — the install script's attestation verification

## Fix

Remove `--signer-repo` and keep `--signer-workflow`, which is more specific — it constrains both the repository and the exact workflow file, providing stronger provenance guarantees.

## Verification

Tested on Linux (gh 2.89.0):
- `gh attestation verify` with `--signer-workflow` alone: ✅ passes
- `gh attestation verify` with `--signer-repo` alone: ✅ passes  
- `gh attestation verify` with both: ❌ fails (the bug)