### PR TITLE
Support configurable default version phase after release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,17 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      default_post_release_phase:
+        description: "Phase for the next version after release (pre, rc, rtm). Defaults to repo variable DEFAULT_POST_RELEASE_PHASE or 'pre'."
+        required: false
+        default: ''
+        type: choice
+        options:
+          - ''
+          - pre
+          - rc
+          - rtm
 
 env:
   DOTNET_NOLOGO: true
@@ -281,6 +292,25 @@ jobs:
             exit 1
           fi
 
+      - name: Resolve post-release phase
+        id: post_release_phase
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          DEFAULT_PHASE='${{ github.event.inputs.default_post_release_phase }}'
+          if [ -z "$DEFAULT_PHASE" ]; then
+            DEFAULT_PHASE='${{ vars.DEFAULT_POST_RELEASE_PHASE }}'
+          fi
+
+          if [ -n "$DEFAULT_PHASE" ] && [[ ! "$DEFAULT_PHASE" =~ ^(pre|rc|rtm)$ ]]; then
+            echo "::error::Invalid post-release phase '${DEFAULT_PHASE}'. Must be pre, rc, or rtm."
+            exit 1
+          fi
+
+          echo "phase=${DEFAULT_PHASE}" >> "$GITHUB_OUTPUT"
+          echo "Resolved post-release phase: '${DEFAULT_PHASE:-<default: pre>}'"
+
       - name: Create GitHub release
         id: create_release
         env:
@@ -328,7 +358,15 @@ jobs:
           set -euo pipefail
 
           VERSION='${{ needs.prepare-release.outputs.version }}'
-          NEW_STATE_JSON=$(dotnet scripts/version.cs advance --state "$STATE_JSON" --shipped-version "$VERSION")
+
+          DEFAULT_PHASE='${{ steps.post_release_phase.outputs.phase }}'
+
+          PHASE_FLAG=()
+          if [ -n "$DEFAULT_PHASE" ]; then
+            PHASE_FLAG+=(--default-phase "$DEFAULT_PHASE")
+          fi
+
+          NEW_STATE_JSON=$(dotnet scripts/version.cs advance --state "$STATE_JSON" --shipped-version "$VERSION" "${PHASE_FLAG[@]}")
           VERSIONS_JSON=$(dotnet scripts/version.cs calculate --state "$NEW_STATE_JSON")
           NEXT_DEV_VERSION=$(echo "$VERSIONS_JSON" | jq -r '.devVersion')
           NEXT_RC_VERSION=$(echo "$VERSIONS_JSON" | jq -r '.rcVersion')

--- a/scripts/version.cs
+++ b/scripts/version.cs
@@ -62,16 +62,19 @@ rootCommand.Subcommands.Add(calculateCommand);
 var advanceCommand = new Command("advance", "Calculate the next state after a release is shipped.");
 var advanceStateOption = new Option<string>("--state") { Description = "Current version state as JSON.", Required = true };
 var shippedVersionOption = new Option<string>("--shipped-version") { Description = "The version that was just shipped.", Required = true };
+var defaultPhaseOption = new Option<string?>("--default-phase") { Description = "Default phase after an RTM release (pre, rc, rtm). Defaults to 'pre'." };
 advanceCommand.Options.Add(advanceStateOption);
 advanceCommand.Options.Add(shippedVersionOption);
+advanceCommand.Options.Add(defaultPhaseOption);
 advanceCommand.SetAction(parseResult => ExecuteHandled(() =>
 {
     var stateJson = parseResult.GetValue(advanceStateOption)!;
     var shippedVersion = parseResult.GetValue(shippedVersionOption)!;
+    var defaultPhase = parseResult.GetValue(defaultPhaseOption);
     var state = JsonSerializer.Deserialize<VersionState>(stateJson, jsonOptions)
         ?? throw new ArgumentException("Invalid state JSON.");
 
-    var newState = AdvanceState(state);
+    var newState = AdvanceState(state, defaultPhase);
     Console.WriteLine(JsonSerializer.Serialize(newState, jsonOptions));
 }));
 rootCommand.Subcommands.Add(advanceCommand);
@@ -227,13 +230,28 @@ static CalculatedVersions CalculateVersions(VersionState state)
     return new CalculatedVersions(devVersion, rcVersion, nextState);
 }
 
-static VersionState AdvanceState(VersionState state)
+static VersionState AdvanceState(VersionState state, string? defaultPhase = null)
 {
     return state.Phase switch
     {
         "pre" or "rc" => new VersionState(state.Base, state.Phase, state.PhaseNumber + 1, 0, "none"),
-        "rtm" => new VersionState(BumpBaseVersion(state.Base), "pre", 1, 0, "none"),
+        "rtm" => AdvanceFromRtm(state, defaultPhase ?? "pre"),
         _ => throw new ArgumentException($"Unknown phase: {state.Phase}")
+    };
+}
+
+static VersionState AdvanceFromRtm(VersionState state, string nextPhase)
+{
+    if (nextPhase is not ("pre" or "rc" or "rtm"))
+    {
+        throw new ArgumentException($"Invalid default phase: {nextPhase}. Must be pre, rc, or rtm.");
+    }
+
+    var newBase = BumpBaseVersion(state.Base);
+    return nextPhase switch
+    {
+        "rtm" => new VersionState(newBase, "rtm", 0, 0, "none"),
+        _ => new VersionState(newBase, nextPhase, 1, 0, "none"),
     };
 }
 


### PR DESCRIPTION
## Summary

Adds support for setting the default release phase to advance to after an RTM release, instead of always defaulting to `pre`.

### Changes

- **`scripts/version.cs`**: Added `--default-phase` optional parameter to the `advance` command. When advancing from RTM, uses this to determine the next phase (`pre`, `rc`, or `rtm`). Defaults to `pre` for backward compatibility.
- **`.github/workflows/release.yml`**:
  - Added `default_post_release_phase` workflow dispatch input (choice: blank/pre/rc/rtm)
  - Reads `DEFAULT_POST_RELEASE_PHASE` repo variable as fallback
  - Validates the phase **before** creating the GitHub release (fail-fast)
  - Precedence: workflow input → repo variable → hardcoded `pre`
- **Repo variable**: Set `DEFAULT_POST_RELEASE_PHASE=rtm` so future releases default to going straight to RTM.

Closes #80