### PR TITLE
Improve the init command with interactive wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,18 @@ gh release download install-scripts -R DamianEdwards/copilotd -p install.sh -O -
 
 ## Running
 
-Run `copilotd init` to configure watched repos then run `copilotd run` to start the daemon. Run `copilotd --help` for other commands.
+Run `copilotd init` to configure watched repos then run `copilotd run` to start the daemon.
+
+The `init` command is an interactive wizard that walks you through:
+1. **Dependency & auth checks** — verifies `gh` and `copilot` CLIs are installed (showing versions) and authenticated
+2. **Repo home** — where your repository clones live on disk
+3. **Global settings** — max concurrent sessions, default model
+4. **Default rule** — author filtering, required labels, tool permissions (yolo/allow-all-tools/allow-all-urls), model override
+5. **Repository selection** — pick which repos to watch (shows clone status)
+
+After setup, a configuration summary and concrete next-step commands are displayed.
+
+Run `copilotd --help` for other commands.
 
 ## Building from source
 
@@ -73,7 +84,7 @@ Convenience scripts `copilotd.sh` and `copilotd.cmd` in the repo root run the pr
 
 | Command | Description |
 |---------|-------------|
-| `copilotd init` | Interactive first-run setup (dependency checks, auth, repo selection, default rule) |
+| `copilotd init` | Interactive first-run wizard (dependency checks with versions, auth, global config, rule setup, repo selection) |
 | `copilotd run` | Start the polling daemon |
 | `copilotd status` | Show daemon health, watched repos, and session list |
 | `copilotd session` | List dispatched sessions (alias for `session list`) |

--- a/src/copilotd/Commands/InitCommand.cs
+++ b/src/copilotd/Commands/InitCommand.cs
@@ -170,6 +170,7 @@ public static class InitCommand
                         .Title("Who can create issues that copilotd will dispatch?")
                         .AddChoices(authorChoices)
                         .HighlightStyle(new Style(Color.Blue)));
+                AnsiConsole.MarkupLine($"  Issue authors: [blue]{Markup.Escape(authorChoice)}[/]");
 
                 AuthorMode authorMode;
                 List<string> authors = [];
@@ -200,12 +201,14 @@ public static class InitCommand
                     .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                     .Distinct(StringComparer.OrdinalIgnoreCase)
                     .ToList();
+                AnsiConsole.MarkupLine($"  Labels: [blue]{Markup.Escape(string.Join(", ", labels))}[/]");
                 AnsiConsole.WriteLine();
 
                 // Yolo / tool permissions
                 AnsiConsole.MarkupLine("[grey]Yolo mode skips all confirmation prompts (implies --allow-all-tools and --allow-all-urls).[/]");
                 var existingYolo = existingRule?.Yolo ?? false;
                 var yolo = AnsiConsole.Confirm("Enable yolo mode?", existingYolo);
+                AnsiConsole.MarkupLine($"  Yolo mode: [blue]{(yolo ? "yes" : "no")}[/]");
 
                 bool allowAllTools = true;
                 bool allowAllUrls = false;
@@ -213,8 +216,10 @@ public static class InitCommand
                 {
                     AnsiConsole.MarkupLine("[grey]Allow copilot to use all available tools without prompting.[/]");
                     allowAllTools = AnsiConsole.Confirm("Allow all tools?", existingRule?.AllowAllTools ?? true);
+                    AnsiConsole.MarkupLine($"  Allow all tools: [blue]{(allowAllTools ? "yes" : "no")}[/]");
                     AnsiConsole.MarkupLine("[grey]Allow copilot to access any URL without prompting.[/]");
                     allowAllUrls = AnsiConsole.Confirm("Allow all URLs?", existingRule?.AllowAllUrls ?? false);
+                    AnsiConsole.MarkupLine($"  Allow all URLs: [blue]{(allowAllUrls ? "yes" : "no")}[/]");
                 }
                 AnsiConsole.WriteLine();
 
@@ -226,6 +231,7 @@ public static class InitCommand
                         .DefaultValue(existingRuleModel)
                         .AllowEmpty());
                 var ruleModel = string.IsNullOrWhiteSpace(ruleModelInput) ? null : ruleModelInput.Trim();
+                AnsiConsole.MarkupLine($"  Model override: [blue]{Markup.Escape(ruleModel ?? "(inherit global)")}[/]");
                 AnsiConsole.WriteLine();
 
                 // Build the default rule

--- a/src/copilotd/Commands/InitCommand.cs
+++ b/src/copilotd/Commands/InitCommand.cs
@@ -1,4 +1,5 @@
 using System.CommandLine;
+using System.Reflection;
 using Copilotd.Infrastructure;
 using Copilotd.Models;
 using Copilotd.Services;
@@ -23,48 +24,73 @@ public static class InitCommand
                 var copilotCli = services.GetRequiredService<CopilotCliService>();
                 var stateStore = services.GetRequiredService<StateStore>();
 
-                // Check dependencies
-                if (!ghCli.IsAvailable())
+                // ── Phase 1: Dependencies & Auth ──────────────────────────
+                AnsiConsole.Write(new Rule("[bold blue]Dependencies & Authentication[/]").LeftJustified());
+                AnsiConsole.WriteLine();
+
+                var copilotdVersion = Assembly.GetExecutingAssembly()
+                    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+                    ?? Assembly.GetExecutingAssembly().GetName().Version?.ToString()
+                    ?? "unknown";
+                AnsiConsole.MarkupLine($"  [blue]copilotd[/] v{Markup.Escape(copilotdVersion)}");
+                AnsiConsole.WriteLine();
+
+                // gh CLI
+                var ghVersion = ghCli.GetVersion();
+                if (ghVersion is null)
                 {
-                    ConsoleOutput.Error("gh CLI is not installed or not on PATH.");
-                    ConsoleOutput.Info("Install it from: https://cli.github.com/");
+                    AnsiConsole.MarkupLine("  [red]✗[/] gh CLI — not found");
+                    ConsoleOutput.Info("  Install it from: https://cli.github.com/");
                     return 1;
                 }
+                AnsiConsole.MarkupLine($"  [green]✓[/] {Markup.Escape(ghVersion)}");
 
-                if (!copilotCli.IsAvailable())
+                // copilot CLI
+                var copilotVersion = copilotCli.GetVersion();
+                if (copilotVersion is null)
                 {
-                    ConsoleOutput.Error("copilot CLI is not installed or not on PATH.");
-                    ConsoleOutput.Info("Install it from: https://docs.github.com/copilot/how-tos/copilot-cli");
+                    AnsiConsole.MarkupLine("  [red]✗[/] copilot CLI — not found");
+                    ConsoleOutput.Info("  Install it from: https://docs.github.com/copilot/how-tos/copilot-cli");
                     return 1;
                 }
+                AnsiConsole.MarkupLine($"  [green]✓[/] {Markup.Escape(copilotVersion)}");
 
-                // Check auth
+                // Auth
                 var authResult = ghCli.CheckAuth();
                 if (!authResult.IsLoggedIn)
                 {
-                    ConsoleOutput.Error("gh CLI is not authenticated. Run 'gh auth login' first.");
+                    AnsiConsole.MarkupLine("  [red]✗[/] gh CLI — not authenticated");
+                    ConsoleOutput.Info("  Run 'gh auth login' first.");
                     return 1;
                 }
                 var username = authResult.Username;
+                AnsiConsole.MarkupLine($"  [green]✓[/] Authenticated as [bold]{Markup.Escape(username ?? "unknown")}[/]");
 
+                // copilot CLI uses gh auth — verify it's responsive (not a true auth check)
                 if (!copilotCli.IsLoggedIn())
                 {
-                    ConsoleOutput.Error("copilot CLI is not authenticated. Run 'copilot login' first.");
+                    AnsiConsole.MarkupLine("  [red]✗[/] copilot CLI — not responding");
+                    ConsoleOutput.Info("  Reinstall from: https://docs.github.com/copilot/how-tos/copilot-cli");
                     return 1;
                 }
+                AnsiConsole.MarkupLine("  [green]✓[/] copilot CLI ready (uses gh authentication)");
 
-                ConsoleOutput.Success($"Authenticated as: {username ?? "unknown"}");
+                AnsiConsole.WriteLine();
 
                 // Load existing config or start fresh
                 var config = stateStore.LoadConfig();
                 config.CurrentUser = username;
 
-                // Prompt for repo home directory
+                // ── Phase 2: Repo Home ────────────────────────────────────
+                AnsiConsole.Write(new Rule("[bold blue]Repository Home[/]").LeftJustified());
+                AnsiConsole.WriteLine();
+
                 var examplePath = OperatingSystem.IsWindows() ? @"C:\source" : "~/repos";
-                var prompt = $"Enter the directory where your repos are cloned (e.g., {examplePath}):";
-                var repoHome = config.RepoHome is not null
-                    ? AnsiConsole.Ask(prompt, config.RepoHome)
-                    : AnsiConsole.Ask<string>(prompt);
+                AnsiConsole.MarkupLine($"[grey]This is the root directory where your repos are cloned.[/]");
+                var repoHomePrompt = new TextPrompt<string>($"Enter repo home directory (e.g., {Markup.Escape(examplePath)}):");
+                if (config.RepoHome is not null)
+                    repoHomePrompt.DefaultValue(config.RepoHome);
+                var repoHome = AnsiConsole.Prompt(repoHomePrompt);
 
                 if (string.IsNullOrWhiteSpace(repoHome))
                 {
@@ -81,8 +107,143 @@ public static class InitCommand
                 }
 
                 config.RepoHome = Path.GetFullPath(repoHome);
+                AnsiConsole.WriteLine();
 
-                // List repos for selection
+                // ── Phase 3: Global Config ────────────────────────────────
+                AnsiConsole.Write(new Rule("[bold blue]Global Settings[/]").LeftJustified());
+                AnsiConsole.WriteLine();
+
+                // Max concurrent sessions
+                AnsiConsole.MarkupLine("[grey]Maximum number of copilot sessions running in parallel.[/]");
+                config.MaxInstances = AnsiConsole.Prompt(
+                    new TextPrompt<int>("Max concurrent sessions:")
+                        .DefaultValue(config.MaxInstances)
+                        .Validate(v => v > 0 ? ValidationResult.Success() : ValidationResult.Error("Must be a positive integer")));
+                AnsiConsole.WriteLine();
+
+                // Default model
+                AnsiConsole.MarkupLine("[grey]Optional default model for all sessions (e.g., claude-sonnet-4, o4-mini).[/]");
+                AnsiConsole.MarkupLine("[grey]Leave empty to use the copilot CLI default. Can be overridden per rule.[/]");
+                var modelInput = AnsiConsole.Prompt(
+                    new TextPrompt<string>("Default model:")
+                        .DefaultValue(config.DefaultModel ?? "")
+                        .AllowEmpty());
+                config.DefaultModel = string.IsNullOrWhiteSpace(modelInput) ? null : modelInput.Trim();
+                AnsiConsole.WriteLine();
+
+                // ── Phase 4: Default Rule Setup ───────────────────────────
+                AnsiConsole.Write(new Rule("[bold blue]Default Dispatch Rule[/]").LeftJustified());
+                AnsiConsole.WriteLine();
+                AnsiConsole.MarkupLine("[grey]The default rule controls which issues copilotd will pick up and dispatch.[/]");
+                AnsiConsole.WriteLine();
+
+                var existingRule = config.Rules.GetValueOrDefault(CopilotdConfig.DefaultRuleName);
+
+                // Author filtering
+                const string AuthorAny = "Any author";
+                const string AuthorWriteAccess = "Only authors with write access to the repo";
+                var authorOnlyMe = $"Only me ({Markup.Escape(username ?? "unknown")})";
+
+                // Determine existing selection for re-run and build choices with it first
+                var authorDefault = existingRule?.AuthorMode switch
+                {
+                    AuthorMode.Allowed when existingRule.Authors.Count == 1
+                        && string.Equals(existingRule.Authors[0], username, StringComparison.OrdinalIgnoreCase)
+                        => authorOnlyMe,
+                    AuthorMode.WriteAccess => AuthorWriteAccess,
+                    _ => AuthorAny
+                };
+
+                // Build choices with the current/default selection first so Spectre highlights it
+                var authorChoices = new List<string> { authorDefault };
+                foreach (var c in new[] { AuthorAny, authorOnlyMe, AuthorWriteAccess })
+                {
+                    if (c != authorDefault) authorChoices.Add(c);
+                }
+
+                // Don't offer "Only me" if username couldn't be determined
+                if (username is null)
+                    authorChoices.Remove(authorOnlyMe);
+
+                var authorChoice = AnsiConsole.Prompt(
+                    new SelectionPrompt<string>()
+                        .Title("Who can create issues that copilotd will dispatch?")
+                        .AddChoices(authorChoices)
+                        .HighlightStyle(new Style(Color.Blue)));
+
+                AuthorMode authorMode;
+                List<string> authors = [];
+                if (authorChoice == authorOnlyMe)
+                {
+                    authorMode = AuthorMode.Allowed;
+                    authors = [username!];
+                }
+                else if (authorChoice == AuthorWriteAccess)
+                {
+                    authorMode = AuthorMode.WriteAccess;
+                }
+                else
+                {
+                    authorMode = AuthorMode.Any;
+                }
+                AnsiConsole.WriteLine();
+
+                // Labels
+                AnsiConsole.MarkupLine("[grey]Issues must have ALL of these labels to be dispatched.[/]");
+                var existingLabels = existingRule?.Labels.Count > 0
+                    ? string.Join(", ", existingRule.Labels)
+                    : "copilotd";
+                var labelsInput = AnsiConsole.Prompt(
+                    new TextPrompt<string>("Required label(s) (comma-separated):")
+                        .DefaultValue(existingLabels));
+                var labels = labelsInput
+                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+                AnsiConsole.WriteLine();
+
+                // Yolo / tool permissions
+                AnsiConsole.MarkupLine("[grey]Yolo mode skips all confirmation prompts (implies --allow-all-tools and --allow-all-urls).[/]");
+                var existingYolo = existingRule?.Yolo ?? false;
+                var yolo = AnsiConsole.Confirm("Enable yolo mode?", existingYolo);
+
+                bool allowAllTools = true;
+                bool allowAllUrls = false;
+                if (!yolo)
+                {
+                    AnsiConsole.MarkupLine("[grey]Allow copilot to use all available tools without prompting.[/]");
+                    allowAllTools = AnsiConsole.Confirm("Allow all tools?", existingRule?.AllowAllTools ?? true);
+                    AnsiConsole.MarkupLine("[grey]Allow copilot to access any URL without prompting.[/]");
+                    allowAllUrls = AnsiConsole.Confirm("Allow all URLs?", existingRule?.AllowAllUrls ?? false);
+                }
+                AnsiConsole.WriteLine();
+
+                // Rule model override
+                AnsiConsole.MarkupLine("[grey]Optionally override the default model for sessions matching this rule.[/]");
+                var existingRuleModel = existingRule?.Model ?? "";
+                var ruleModelInput = AnsiConsole.Prompt(
+                    new TextPrompt<string>("Model override for default rule (empty to inherit global):")
+                        .DefaultValue(existingRuleModel)
+                        .AllowEmpty());
+                var ruleModel = string.IsNullOrWhiteSpace(ruleModelInput) ? null : ruleModelInput.Trim();
+                AnsiConsole.WriteLine();
+
+                // Build the default rule
+                var defaultRule = existingRule ?? new DispatchRule();
+                defaultRule.User = username;
+                defaultRule.Labels = labels;
+                defaultRule.AuthorMode = authorMode;
+                defaultRule.Authors = authors;
+                defaultRule.Yolo = yolo;
+                defaultRule.AllowAllTools = yolo || allowAllTools;
+                defaultRule.AllowAllUrls = yolo || allowAllUrls;
+                defaultRule.Model = ruleModel;
+                config.Rules[CopilotdConfig.DefaultRuleName] = defaultRule;
+
+                // ── Phase 5: Repo Selection ───────────────────────────────
+                AnsiConsole.Write(new Rule("[bold blue]Repository Selection[/]").LeftJustified());
+                AnsiConsole.WriteLine();
+
                 ConsoleOutput.Info("Fetching your repositories...");
                 var repos = ghCli.ListRepos();
 
@@ -101,8 +262,7 @@ public static class InitCommand
                     AnsiConsole.MarkupLine("[grey]Only cloned repos can be dispatched — repos are not auto-cloned.[/]");
                     AnsiConsole.WriteLine();
 
-                    var selected = AnsiConsole.Prompt(
-                        new MultiSelectionPrompt<string>()
+                    var repoPrompt = new MultiSelectionPrompt<string>()
                             .Title("Select repositories to watch ([green]cloned[/] repos will dispatch, [red]not cloned[/] repos will be skipped until cloned):")
                             .PageSize(15)
                             .MoreChoicesText("[grey](Move up/down, space to select, enter to confirm)[/]")
@@ -110,7 +270,16 @@ public static class InitCommand
                             .UseConverter(r => cloneStatus.GetValueOrDefault(r)
                                 ? $"{Markup.Escape(r)} [green](cloned)[/]"
                                 : $"{Markup.Escape(r)} [red](not cloned)[/]")
-                            .AddChoices(repos));
+                            .AddChoices(repos);
+
+                    // Pre-select previously chosen repos on re-run
+                    if (existingRule?.Repos is { Count: > 0 } existingRepos)
+                    {
+                        foreach (var repo in existingRepos.Where(r => repos.Contains(r, StringComparer.OrdinalIgnoreCase)))
+                            repoPrompt.Select(repo);
+                    }
+
+                    var selected = AnsiConsole.Prompt(repoPrompt);
 
                     var notClonedSelected = selected.Where(r => !cloneStatus.GetValueOrDefault(r)).ToList();
                     if (notClonedSelected.Count > 0)
@@ -127,43 +296,74 @@ public static class InitCommand
                         ConsoleOutput.Warning("No repos selected. You can add repos to rules later.");
                     }
 
-                    // Create or update default rule
-                    if (!config.Rules.TryGetValue(CopilotdConfig.DefaultRuleName, out var defaultRule))
-                    {
-                        defaultRule = new DispatchRule
-                        {
-                            User = username,
-                            Labels = ["copilotd"],
-                        };
-                        config.Rules[CopilotdConfig.DefaultRuleName] = defaultRule;
-                    }
-
                     defaultRule.Repos = selected;
                 }
-
-                // Ensure default rule exists even if no repos selected
-                if (!config.Rules.ContainsKey(CopilotdConfig.DefaultRuleName))
-                {
-                    config.Rules[CopilotdConfig.DefaultRuleName] = new DispatchRule
-                    {
-                        User = username,
-                        Labels = ["copilotd"],
-                    };
-                }
-
-                stateStore.SaveConfig(config);
-                ConsoleOutput.Success("Configuration saved successfully!");
-                ConsoleOutput.Info($"Config stored in: {stateStore.ConfigDir}");
-
                 AnsiConsole.WriteLine();
-                ConsoleOutput.Info("Next steps:");
-                AnsiConsole.MarkupLine("  Use [blue]copilotd rules[/] to manage dispatch rules and the repos they apply to.");
-                AnsiConsole.MarkupLine("  Run [blue]copilotd run[/] to start the monitoring loop.");
+
+                // ── Phase 6: Save & Summary ───────────────────────────────
+                stateStore.SaveConfig(config);
+
+                AnsiConsole.Write(new Rule("[bold green]Configuration Saved[/]").LeftJustified());
+                AnsiConsole.WriteLine();
+                AnsiConsole.MarkupLine($"[grey]Config stored in: {Markup.Escape(stateStore.ConfigDir)}[/]");
+                AnsiConsole.WriteLine();
+
+                // Summary table
+                var summaryTable = new Table().Border(TableBorder.Rounded).ShowRowSeparators();
+                summaryTable.AddColumn(new TableColumn("[bold]Setting[/]").NoWrap());
+                summaryTable.AddColumn(new TableColumn("[bold]Value[/]"));
+
+                summaryTable.AddRow("[blue]Repo home[/]", Markup.Escape(config.RepoHome));
+                summaryTable.AddRow("[blue]Max concurrent sessions[/]", Markup.Escape(config.MaxInstances.ToString()));
+                summaryTable.AddRow("[blue]Default model[/]", Markup.Escape(config.DefaultModel ?? "(copilot default)"));
+                summaryTable.AddRow("", "");
+                summaryTable.AddRow("[bold blue]Default Rule[/]", "");
+                summaryTable.AddRow("[blue]  Assignee[/]", Markup.Escape(defaultRule.User ?? "*"));
+                summaryTable.AddRow("[blue]  Author filter[/]", Markup.Escape(FormatAuthorMode(defaultRule)));
+                summaryTable.AddRow("[blue]  Labels[/]", Markup.Escape(string.Join(", ", defaultRule.Labels)));
+                summaryTable.AddRow("[blue]  Permissions[/]", Markup.Escape(FormatPermissions(defaultRule)));
+                summaryTable.AddRow("[blue]  Model override[/]", Markup.Escape(defaultRule.Model ?? "(inherit global)"));
+                summaryTable.AddRow("[blue]  Repos[/]", Markup.Escape(
+                    defaultRule.Repos.Count > 0 ? string.Join(", ", defaultRule.Repos) : "(none)"));
+
+                AnsiConsole.Write(summaryTable);
+                AnsiConsole.WriteLine();
+
+                // Next steps
+                AnsiConsole.Write(new Rule("[bold blue]Next Steps[/]").LeftJustified());
+                AnsiConsole.WriteLine();
+                AnsiConsole.MarkupLine("  [blue]copilotd run[/]                                           Start the daemon");
+                AnsiConsole.MarkupLine("  [blue]copilotd run --interval 15 --log-level debug[/]           Start with verbose logging");
+                AnsiConsole.MarkupLine("  [blue]copilotd rules update Default --add-repo org/repo[/]      Add another repo to the default rule");
+                AnsiConsole.MarkupLine("  [blue]copilotd rules add MyRule --label bug --yolo[/]           Create a new dispatch rule");
+                AnsiConsole.MarkupLine("  [blue]copilotd config --set max_instances=5[/]                  Change concurrency limit");
+                AnsiConsole.MarkupLine("  [blue]copilotd config --set default_model=claude-sonnet-4[/]    Set the default model");
+                AnsiConsole.MarkupLine("  [blue]copilotd status[/]                                        Check daemon health and sessions");
+                AnsiConsole.WriteLine();
 
                 return 0;
             }, logger);
         });
 
         return command;
+    }
+
+    private static string FormatAuthorMode(DispatchRule rule)
+    {
+        return rule.AuthorMode switch
+        {
+            AuthorMode.Allowed => string.Join(", ", rule.Authors),
+            AuthorMode.WriteAccess => "(write access only)",
+            _ => "(any)",
+        };
+    }
+
+    private static string FormatPermissions(DispatchRule rule)
+    {
+        if (rule.Yolo) return "--yolo";
+        var parts = new List<string>();
+        if (rule.AllowAllTools) parts.Add("--allow-all-tools");
+        if (rule.AllowAllUrls) parts.Add("--allow-all-urls");
+        return parts.Count > 0 ? string.Join(", ", parts) : "(defaults)";
     }
 }

--- a/src/copilotd/Services/CopilotCliService.cs
+++ b/src/copilotd/Services/CopilotCliService.cs
@@ -32,6 +32,26 @@ public sealed class CopilotCliService
     }
 
     /// <summary>
+    /// Returns the copilot CLI version string, or null if unavailable.
+    /// </summary>
+    public string? GetVersion()
+    {
+        try
+        {
+            var (exitCode, output) = RunCopilot("--version");
+            if (exitCode != 0) return null;
+
+            var trimmed = output.Trim();
+            var idx = trimmed.IndexOf('\n');
+            return idx > 0 ? trimmed[..idx].Trim() : trimmed;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
     /// Best-effort check for copilot login status.
     /// Since copilot CLI has no "login status" command, we attempt a lightweight
     /// operation and check if it fails with auth errors.

--- a/src/copilotd/Services/GhCliService.cs
+++ b/src/copilotd/Services/GhCliService.cs
@@ -39,6 +39,27 @@ public sealed class GhCliService
     }
 
     /// <summary>
+    /// Returns the gh CLI version string, or null if unavailable.
+    /// </summary>
+    public string? GetVersion()
+    {
+        try
+        {
+            var (exitCode, output) = RunGh("--version");
+            if (exitCode != 0) return null;
+
+            // Output is like "gh version 2.50.0 (2024-05-29)"
+            var trimmed = output.Trim();
+            var idx = trimmed.IndexOf('\n');
+            return idx > 0 ? trimmed[..idx].Trim() : trimmed;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
     /// Checks whether gh is authenticated and returns the current username.
     /// </summary>
     public (bool IsLoggedIn, string? Username) CheckAuth()


### PR DESCRIPTION
## Summary

Restructures \copilotd init\ into a polished 6-phase interactive wizard that better educates users on capabilities and makes first-run setup more thorough.

### Changes

**New features in the init wizard:**
- **Phase 1 — Dependencies & Auth:** Shows copilotd version, displays \gh\/\copilot\ CLI versions with ✓/✗ indicators, clarifies copilot uses gh authentication
- **Phase 3 — Global Settings (new):** Prompts for max concurrent sessions and optional default model
- **Phase 4 — Interactive Rule Setup (new):** Prompts for author filtering (any/only me/write access), required labels, yolo mode, allow-all-tools/urls, and model override
- **Phase 6 — Enhanced Summary:** Config summary table + concrete next-step command examples

**Re-run safety (from rubber duck review feedback):**
- Author mode selection preserves existing choice as the default on re-run
- Previously selected repos are pre-selected in the multi-select
- \GetVersion()\ replaces redundant \IsAvailable()\ + \GetVersion()\ double subprocess calls
- \Only me\ option is hidden when username can't be determined
- Copilot auth check text accurately describes what it verifies

**Service layer:**
- Added \GetVersion()\ to \GhCliService\ and \CopilotCliService\

**README:** Updated init command description and added detailed wizard phase breakdown.

Closes #74