### PR TITLE
Add auto-generated PR-based release notes to releases

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,8 @@
+changelog:
+  categories:
+    - title: "🚀 Features"
+      labels: [enhancement]
+    - title: "🐛 Bug Fixes"
+      labels: [bug]
+    - title: "Other Changes"
+      labels: ["*"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -340,6 +340,7 @@ jobs:
             --target "${{ github.sha }}" \
             "${PRERELEASE_FLAG[@]}" \
             --title "v${VERSION}" \
+            --generate-notes \
             --notes "## copilotd ${VERSION}
 
           Native release assets for Windows, Linux, and macOS.


### PR DESCRIPTION
Adds auto-generated release notes based on merged PRs to GitHub releases created by the Release workflow.

## Changes

- **\.github/workflows/release.yml\**: Added \--generate-notes\ flag to the \gh release create\ command so GitHub automatically appends a changelog of merged PRs after the existing custom notes.
- **\.github/release.yml\**: New changelog configuration that groups PRs into categories by label:
  - 🚀 **Features** (\nhancement\)
  - 🐛 **Bug Fixes** (\ug\)
  - **Other Changes** (everything else)