### PR TITLE
Add granular redispatch trust levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,17 @@ enforces trust boundaries on comment-triggered re-dispatches:
 - **`trust_level: collaborators`** (default) — only comments from users with write/maintain/admin
   access to the repository trigger re-dispatch. Comments from other users are logged and ignored.
 - **`trust_level: all`** — any non-bot comment triggers re-dispatch (less secure, opt-in).
+- **`trust_level: issueAuthor`** — only comments from the original issue author trigger re-dispatch.
+  Useful for community-filed issues where the reporter may need to provide follow-up clarification.
+- **`trust_level: assignees`** — only comments from current issue assignees trigger re-dispatch.
+  Assignees are checked live (not cached) so changes to assignees take effect on the next poll.
+- **`trust_level: issueAuthorAndCollaborators`** — comments from the original issue author or any
+  user with write/maintain/admin access trigger re-dispatch. Combines community author feedback
+  with maintainer oversight.
+- **`trust_level: matchDispatchRule`** — the commenter must pass the same author filtering conditions
+  used by the dispatch rule (e.g., if the rule uses `author_mode: writeAccess`, only write-access
+  users can trigger re-dispatch; if the rule uses `author_mode: allowed` with a specific author list,
+  only those authors can trigger re-dispatch).
 - **Re-dispatch rate limit** — sessions are limited to `max_redispatches` (default: 10)
   comment-triggered re-dispatches. Use `copilotd session reset` to re-enable after hitting the limit.
 - **Security prompt** — when re-dispatching in response to comments, a security context is
@@ -335,7 +346,7 @@ Stored in `~/.copilotd/`:
 | `extra_prompt` | *(none)* | Additional prompt text appended when this rule triggers |
 | `custom_prompt` | *(none)* | Per-rule custom prompt text (appended to or overrides global custom prompt) |
 | `custom_prompt_mode` | `append` | How rule custom prompt interacts with global: `append` or `override` |
-| `trust_level` | `collaborators` | Which comment authors can trigger session re-dispatch: `collaborators` (write access required) or `all` |
+| `trust_level` | `collaborators` | Which comment authors can trigger session re-dispatch: `collaborators` (write access required), `all`, `issueAuthor`, `assignees`, `issueAuthorAndCollaborators`, or `matchDispatchRule` |
 
 Log files are written to `$TEMP/copilotd/logs/` with daily rollover.
 

--- a/src/copilotd/Models/CopilotdConfig.cs
+++ b/src/copilotd/Models/CopilotdConfig.cs
@@ -153,6 +153,10 @@ public sealed class DispatchRule
     /// Controls which comment authors can trigger session re-dispatch.
     /// <see cref="CommentTrustLevel.Collaborators"/>: only repo collaborators with write access (default).
     /// <see cref="CommentTrustLevel.All"/>: any commenter can trigger re-dispatch.
+    /// <see cref="CommentTrustLevel.IssueAuthor"/>: only the original issue author.
+    /// <see cref="CommentTrustLevel.Assignees"/>: only current issue assignees.
+    /// <see cref="CommentTrustLevel.IssueAuthorAndCollaborators"/>: issue author or write-access collaborators.
+    /// <see cref="CommentTrustLevel.MatchDispatchRule"/>: commenter must pass the rule's author filtering.
     /// </summary>
     public CommentTrustLevel TrustLevel { get; set; } = CommentTrustLevel.Collaborators;
 
@@ -242,6 +246,21 @@ public enum CommentTrustLevel
 
     /// <summary>Any commenter can trigger re-dispatch (less secure, opt-in).</summary>
     All,
+
+    /// <summary>Only the original issue author can trigger re-dispatch.</summary>
+    IssueAuthor,
+
+    /// <summary>Only current issue assignees can trigger re-dispatch.</summary>
+    Assignees,
+
+    /// <summary>The original issue author or repository collaborators with write access can trigger re-dispatch.</summary>
+    IssueAuthorAndCollaborators,
+
+    /// <summary>
+    /// The commenter must pass the same author filtering conditions as the original dispatch rule
+    /// (e.g., if the rule uses <see cref="AuthorMode.WriteAccess"/>, only write-access users can trigger re-dispatch).
+    /// </summary>
+    MatchDispatchRule,
 }
 
 /// <summary>

--- a/src/copilotd/Models/SessionState.cs
+++ b/src/copilotd/Models/SessionState.cs
@@ -79,6 +79,13 @@ public sealed class DispatchSession
     /// <summary>Name of the rule that triggered this dispatch.</summary>
     public string RuleName { get; set; } = "";
 
+    /// <summary>
+    /// The GitHub login of the issue author at the time of dispatch.
+    /// Used by <see cref="CommentTrustLevel.IssueAuthor"/> and
+    /// <see cref="CommentTrustLevel.IssueAuthorAndCollaborators"/> trust checks.
+    /// </summary>
+    public string? IssueAuthor { get; set; }
+
     /// <summary>Generated UUID used with copilot --resume=&lt;id&gt;.</summary>
     public string CopilotSessionId { get; set; } = "";
 

--- a/src/copilotd/Services/GhCliService.cs
+++ b/src/copilotd/Services/GhCliService.cs
@@ -390,6 +390,46 @@ public sealed class GhCliService
     }
 
     /// <summary>
+    /// Returns the current assignee logins for an issue by querying the GitHub API.
+    /// Returns an empty list if there are no assignees, or null on API failure (so callers
+    /// can distinguish "no assignees" from "couldn't check").
+    /// </summary>
+    public List<string>? GetIssueAssignees(string repo, int issueNumber)
+    {
+        var args = $"issue view {issueNumber} --repo {repo} --json assignees";
+        var (exitCode, output) = RunGh(args);
+        if (exitCode != 0)
+        {
+            _logger.LogWarning("Failed to query assignees on {Repo}#{Issue}: {Output}", repo, issueNumber, output);
+            return null;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(output);
+            if (!doc.RootElement.TryGetProperty("assignees", out var assignees))
+                return [];
+
+            var result = new List<string>();
+            foreach (var assignee in assignees.EnumerateArray())
+            {
+                if (assignee.TryGetProperty("login", out var login))
+                {
+                    var loginStr = login.GetString();
+                    if (loginStr is not null)
+                        result.Add(loginStr);
+                }
+            }
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse assignees JSON for {Repo}#{Issue}", repo, issueNumber);
+            return null;
+        }
+    }
+
+    /// <summary>
     /// Checks whether there are new review comments on a pull request since the given timestamp,
     /// excluding comments posted by copilotd itself (identified by <see cref="CommentMarker"/>).
     /// Checks both PR review comments (from formal reviews) and regular PR comments.

--- a/src/copilotd/Services/ReconciliationEngine.cs
+++ b/src/copilotd/Services/ReconciliationEngine.cs
@@ -303,6 +303,13 @@ public sealed class ReconciliationEngine
         {
             if (state.Sessions.TryGetValue(issueKey, out var existing))
             {
+                // Backfill IssueAuthor for sessions created before this field existed
+                if (existing.IssueAuthor is null && issue.Author is not null)
+                {
+                    existing.IssueAuthor = issue.Author;
+                    existing.UpdatedAt = DateTimeOffset.UtcNow;
+                }
+
                 switch (existing.Status)
                 {
                     case SessionStatus.Running:
@@ -329,14 +336,19 @@ public sealed class ReconciliationEngine
                                 }
 
                                 // Check author trust level
-                                var rule = config.Rules.GetValueOrDefault(existing.RuleName);
-                                var trustLevel = rule?.TrustLevel ?? CommentTrustLevel.Collaborators;
+                                var trusted = IsCommentTrusted(existing, commentInfo.Author, config, out var trustLevel);
 
-                                if (trustLevel == CommentTrustLevel.Collaborators
-                                    && !_ghCli.HasWriteAccess(existing.Repo, commentInfo.Author))
+                                if (trusted is null)
                                 {
-                                    _logger.LogInformation("Ignoring comment from non-collaborator {Author} on {Key} (trust_level=collaborators)",
-                                        commentInfo.Author, issueKey);
+                                    _logger.LogWarning("Could not evaluate trust for {Author} on {Key} (trust_level={TrustLevel}), will retry next cycle",
+                                        commentInfo.Author, issueKey, trustLevel);
+                                    continue;
+                                }
+
+                                if (trusted == false)
+                                {
+                                    _logger.LogInformation("Ignoring comment from untrusted author {Author} on {Key} (trust_level={TrustLevel})",
+                                        commentInfo.Author, issueKey, trustLevel);
                                     // Advance WaitingSince past this comment so the next poll can find later trusted comments
                                     existing.WaitingSince = commentInfo.CreatedAt;
                                     existing.UpdatedAt = DateTimeOffset.UtcNow;
@@ -395,14 +407,19 @@ public sealed class ReconciliationEngine
                                     }
 
                                     // Check author trust level
-                                    var rule = config.Rules.GetValueOrDefault(existing.RuleName);
-                                    var trustLevel = rule?.TrustLevel ?? CommentTrustLevel.Collaborators;
+                                    var trusted = IsCommentTrusted(existing, reviewInfo.Author, config, out var trustLevel);
 
-                                    if (trustLevel == CommentTrustLevel.Collaborators
-                                        && !_ghCli.HasWriteAccess(existing.Repo, reviewInfo.Author))
+                                    if (trusted is null)
                                     {
-                                        _logger.LogInformation("Ignoring PR review from non-collaborator {Author} on {Key} (trust_level=collaborators)",
-                                            reviewInfo.Author, issueKey);
+                                        _logger.LogWarning("Could not evaluate trust for {Author} on {Key} (trust_level={TrustLevel}), will retry next cycle",
+                                            reviewInfo.Author, issueKey, trustLevel);
+                                        continue;
+                                    }
+
+                                    if (trusted == false)
+                                    {
+                                        _logger.LogInformation("Ignoring PR review from untrusted author {Author} on {Key} (trust_level={TrustLevel})",
+                                            reviewInfo.Author, issueKey, trustLevel);
                                         // Advance WaitingSince past this review so the next poll can find later trusted reviews
                                         existing.WaitingSince = reviewInfo.CreatedAt;
                                         existing.UpdatedAt = DateTimeOffset.UtcNow;
@@ -439,14 +456,19 @@ public sealed class ReconciliationEngine
                                 }
 
                                 // Check author trust level
-                                var rule = config.Rules.GetValueOrDefault(existing.RuleName);
-                                var trustLevel = rule?.TrustLevel ?? CommentTrustLevel.Collaborators;
+                                var trusted = IsCommentTrusted(existing, issueCommentInfo.Author, config, out var trustLevel);
 
-                                if (trustLevel == CommentTrustLevel.Collaborators
-                                    && !_ghCli.HasWriteAccess(existing.Repo, issueCommentInfo.Author))
+                                if (trusted is null)
                                 {
-                                    _logger.LogInformation("Ignoring issue comment from non-collaborator {Author} on {Key} while waiting for PR review (trust_level=collaborators)",
-                                        issueCommentInfo.Author, issueKey);
+                                    _logger.LogWarning("Could not evaluate trust for {Author} on {Key} (trust_level={TrustLevel}), will retry next cycle",
+                                        issueCommentInfo.Author, issueKey, trustLevel);
+                                    continue;
+                                }
+
+                                if (trusted == false)
+                                {
+                                    _logger.LogInformation("Ignoring issue comment from untrusted author {Author} on {Key} while waiting for PR review (trust_level={TrustLevel})",
+                                        issueCommentInfo.Author, issueKey, trustLevel);
                                     // Advance WaitingSince past this comment so the next poll can find later trusted comments
                                     existing.WaitingSince = issueCommentInfo.CreatedAt;
                                     existing.UpdatedAt = DateTimeOffset.UtcNow;
@@ -525,6 +547,7 @@ public sealed class ReconciliationEngine
                     Repo = issue.Repo,
                     IssueNumber = issue.Number,
                     RuleName = ruleName,
+                    IssueAuthor = issue.Author,
                     CopilotSessionId = Guid.NewGuid().ToString(),
                     Status = SessionStatus.Pending,
                     CreatedAt = DateTimeOffset.UtcNow,
@@ -602,6 +625,64 @@ public sealed class ReconciliationEngine
         if (skippedByLimit > 0)
         {
             _logger.LogInformation("{Count} session(s) still queued, waiting for instance slots", skippedByLimit);
+        }
+    }
+
+    /// <summary>
+    /// Checks whether a comment author is trusted for re-dispatch based on the rule's trust level.
+    /// Returns true if the comment should trigger re-dispatch, false if it should be ignored,
+    /// null if trust could not be determined (e.g., transient API failure) and the comment should
+    /// be retried on the next poll cycle rather than skipped.
+    /// </summary>
+    private bool? IsCommentTrusted(
+        DispatchSession session,
+        string commentAuthor,
+        CopilotdConfig config,
+        out CommentTrustLevel effectiveTrustLevel)
+    {
+        var rule = config.Rules.GetValueOrDefault(session.RuleName);
+        effectiveTrustLevel = rule?.TrustLevel ?? CommentTrustLevel.Collaborators;
+
+        switch (effectiveTrustLevel)
+        {
+            case CommentTrustLevel.All:
+                return true;
+
+            case CommentTrustLevel.Collaborators:
+                return _ghCli.HasWriteAccess(session.Repo, commentAuthor);
+
+            case CommentTrustLevel.IssueAuthor:
+                return session.IssueAuthor is not null
+                    && string.Equals(session.IssueAuthor, commentAuthor, StringComparison.OrdinalIgnoreCase);
+
+            case CommentTrustLevel.Assignees:
+                var assignees = _ghCli.GetIssueAssignees(session.Repo, session.IssueNumber);
+                if (assignees is null)
+                    return null; // API failure — retry next cycle
+                return assignees.Exists(a => string.Equals(a, commentAuthor, StringComparison.OrdinalIgnoreCase));
+
+            case CommentTrustLevel.IssueAuthorAndCollaborators:
+                if (session.IssueAuthor is not null
+                    && string.Equals(session.IssueAuthor, commentAuthor, StringComparison.OrdinalIgnoreCase))
+                    return true;
+                return _ghCli.HasWriteAccess(session.Repo, commentAuthor);
+
+            case CommentTrustLevel.MatchDispatchRule:
+                if (rule is null)
+                    return _ghCli.HasWriteAccess(session.Repo, commentAuthor);
+                return rule.AuthorMode switch
+                {
+                    // AuthorMode.Any means "no author filtering on dispatch" — but for re-dispatch
+                    // trust, allowing anyone would be a security risk. Fall back to collaborators.
+                    AuthorMode.Any => _ghCli.HasWriteAccess(session.Repo, commentAuthor),
+                    AuthorMode.Allowed => rule.Authors.Contains(commentAuthor, StringComparer.OrdinalIgnoreCase),
+                    AuthorMode.WriteAccess => _ghCli.HasWriteAccess(session.Repo, commentAuthor),
+                    _ => _ghCli.HasWriteAccess(session.Repo, commentAuthor),
+                };
+
+            default:
+                // Unknown trust level — fail-closed to collaborators
+                return _ghCli.HasWriteAccess(session.Repo, commentAuthor);
         }
     }
 


### PR DESCRIPTION
Closes #73

## Summary

Adds more granular control over which comment authors can trigger session re-dispatch, extending the existing \	rust_level\ rule setting with 4 new options beyond \collaborators\ and \ll\:

| Trust Level | Behavior |
|---|---|
| \collaborators\ | *(existing, default)* Write-access users only |
| \ll\ | *(existing)* Any commenter |
| **\issueAuthor\** | Only the original issue author |
| **\ssignees\** | Only current issue assignees (live-queried) |
| **\issueAuthorAndCollaborators\** | Issue author OR write-access collaborators |
| **\matchDispatchRule\** | Commenter must pass the rule's \uthor_mode\ filter |

## Key design decisions

- **\IssueAuthor\ stored on \DispatchSession\** — avoids an API round-trip per poll cycle. Pre-existing sessions are backfilled during reconciliation from the issue query results.
- **\Assignees\ queried live** — assignees may change after dispatch, so caching them at creation time would be incorrect.
- **\MatchDispatchRule\ + \AuthorMode.Any\ falls back to \Collaborators\** — \AuthorMode.Any\ means 'no author filtering for dispatch' which is a benign default, but using it for re-dispatch trust would silently allow anyone to inject instructions. Instead we fail-closed to collaborators.
- **Tri-state trust evaluation** — \IsCommentTrusted\ returns \
ull\ when trust can't be determined (e.g., \GetIssueAssignees\ API failure). The caller retries next cycle instead of permanently skipping the comment.
- **Extracted shared \IsCommentTrusted\ method** — replaces 3× duplicated trust-check logic.

## Changes

- \CopilotdConfig.cs\ — 4 new \CommentTrustLevel\ enum values, updated doc comments
- \SessionState.cs\ — new \IssueAuthor\ property on \DispatchSession\
- \GhCliService.cs\ — new \GetIssueAssignees()\ method (returns \
ull\ on API failure)
- \ReconciliationEngine.cs\ — \IsCommentTrusted()\ extraction, backfill logic, tri-state handling
- \README.md\ — documented all trust levels

## Follow-up

- CLI support (\--trust-level\ on \ules add/update\) can be added separately