### PR TITLE
Add control remote session for remote daemon management

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ An orchestration daemon that watches configured GitHub repositories for issues m
 - **Self-healing state** — reconciles persisted state, live process status, and GitHub issue matches on every poll cycle and at startup
 - **Crash-resilient** — dispatched `copilot` sessions run as independent processes that survive daemon restarts; state is persisted atomically
 - **Interactive takeover** — join any orchestrated session interactively with `copilotd session join`, then hand it back automatically
+- **Remote control session** — hosts a `copilot --remote` session for remotely managing copilotd via the GitHub remote sessions UI (web & mobile)
 - **Cross-platform** — works on Windows, macOS, and Linux; publishes as native AOT
 
 ## Getting started
@@ -303,6 +304,35 @@ Use `copilotd session join <issue>` to take over any tracked session:
 3. An interactive `copilot --resume=<session_id>` is launched with full terminal access
 4. When you exit, the session is automatically re-queued as **Pending** for orchestrated dispatch
 
+### Control remote session
+
+When the daemon starts, it launches a special `copilot --remote` session that lets you remotely
+monitor and manage copilotd from the [GitHub remote sessions UI](https://docs.github.com/copilot)
+on web and mobile. Through this session you can check daemon status, list sessions, reset stuck
+sessions, and more — all via natural language.
+
+**How it works:**
+
+- The control session is launched automatically on `copilotd run` startup (when `enable_control_session` is `true`)
+- It runs in the context of a clone of the copilotd repo at `<repo_home>/DamianEdwards/copilotd` (cloned automatically if not already present)
+- Tool access is restricted to `copilotd`, `gh`, and `git` commands only — no general shell access
+- If the control session process dies, the daemon automatically relaunches it on the next poll cycle
+- It does not count against the `max_instances` limit
+- It is tracked separately from dispatch sessions and shown in the `copilotd status` output
+
+**Available commands in the control session:**
+
+| Command | Description |
+|---------|-------------|
+| `copilotd status` | Show daemon health, watched repos, and session summary |
+| `copilotd session list [--all]` | List active sessions (use `--all` to include completed/failed) |
+| `copilotd session reset <issue>` | Reset a session for re-dispatch |
+| `copilotd session complete <issue>` | Mark a session as completed |
+| `copilotd rules list` | Show configured dispatch rules |
+| `copilotd config` | Show current configuration |
+
+To disable the control session, set `enable_control_session` to `false` in `~/.copilotd/config.json`.
+
 ### Terminal states and pruning
 
 - **Completed** and **Failed** are terminal states
@@ -327,6 +357,7 @@ Stored in `~/.copilotd/`:
 | `prompt` | *(empty)* | Custom prompt text appended to the built-in prompt |
 | `max_instances` | `3` | Maximum concurrent copilot processes; excess sessions queue as Pending |
 | `max_redispatches` | `10` | Maximum re-dispatches per session via comment/review feedback loops before requiring manual reset |
+| `enable_control_session` | `true` | Launch a control remote session when the daemon starts for remote management via the GitHub remote sessions UI |
 
 ### Rule settings
 

--- a/src/copilotd/Commands/RunCommand.cs
+++ b/src/copilotd/Commands/RunCommand.cs
@@ -59,6 +59,43 @@ public static class RunCommand
                     reconciliation.Reconcile(config, state);
                     ConsoleOutput.Success("Startup reconciliation complete.");
 
+                    // Launch control session if enabled
+                    if (config.EnableControlSession)
+                    {
+                        state = stateStore.LoadState();
+
+                        // Check if a control session from a prior daemon run is still alive
+                        var existingAlive = state.ControlSession is not null
+                            && state.ControlSession.Status == ControlSessionStatus.Running
+                            && processManager.CheckControlSession(state.ControlSession) == ProcessLivenessResult.Alive;
+
+                        if (existingAlive)
+                        {
+                            ConsoleOutput.Success($"Control session already running (PID {state.ControlSession!.ProcessId}).");
+                        }
+                        else
+                        {
+                            // Terminate stale process if needed
+                            if (state.ControlSession?.ProcessId is not null)
+                                processManager.TerminateControlSession(state.ControlSession);
+
+                            ConsoleOutput.Info("Launching control remote session...");
+                            var controlSession = processManager.LaunchControlSession(config);
+                            if (controlSession is not null)
+                            {
+                                state.ControlSession = controlSession;
+                                stateStore.SaveState(state);
+                                ConsoleOutput.Success($"Control session launched (PID {controlSession.ProcessId}).");
+                            }
+                            else
+                            {
+                                state.ControlSession = new ControlSessionInfo { Status = ControlSessionStatus.Failed };
+                                stateStore.SaveState(state);
+                                ConsoleOutput.Warning("Failed to launch control session. Will retry next cycle.");
+                            }
+                        }
+                    }
+
                     // Main poll loop
                     using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
                     Console.CancelKeyPress += (_, e) =>
@@ -86,6 +123,46 @@ public static class RunCommand
                             state = stateStore.LoadState();
 
                             reconciliation.Reconcile(config, state);
+
+                            // Control session health check
+                            state = stateStore.LoadState();
+                            if (config.EnableControlSession)
+                            {
+                                var controlAlive = state.ControlSession is not null
+                                    && state.ControlSession.Status == ControlSessionStatus.Running
+                                    && processManager.CheckControlSession(state.ControlSession) == ProcessLivenessResult.Alive;
+
+                                if (!controlAlive)
+                                {
+                                    // Terminate stale process if needed
+                                    if (state.ControlSession?.ProcessId is not null)
+                                        processManager.TerminateControlSession(state.ControlSession);
+
+                                    logger.LogInformation("Relaunching control session...");
+                                    var controlSession = processManager.LaunchControlSession(config);
+                                    if (controlSession is not null)
+                                    {
+                                        state.ControlSession = controlSession;
+                                        logger.LogInformation("Control session relaunched (PID {Pid})", controlSession.ProcessId);
+                                    }
+                                    else
+                                    {
+                                        state.ControlSession = new ControlSessionInfo { Status = ControlSessionStatus.Failed };
+                                        logger.LogWarning("Failed to relaunch control session");
+                                    }
+                                    stateStore.SaveState(state);
+                                }
+                            }
+                            else if (state.ControlSession is not null
+                                     && state.ControlSession.Status == ControlSessionStatus.Running)
+                            {
+                                // Config toggled off — terminate control session
+                                logger.LogInformation("Control session disabled, terminating...");
+                                processManager.TerminateControlSession(state.ControlSession);
+                                state.ControlSession.Status = ControlSessionStatus.Stopped;
+                                state.ControlSession.ProcessId = null;
+                                stateStore.SaveState(state);
+                            }
 
                             // Self-update: check for staged update or fire background check
                             var updateState = stateStore.LoadUpdateState();
@@ -134,6 +211,17 @@ public static class RunCommand
 
                     // Gracefully terminate running sessions before exit
                     state = stateStore.LoadState();
+
+                    // Terminate control session
+                    if (state.ControlSession is not null
+                        && state.ControlSession.Status == ControlSessionStatus.Running)
+                    {
+                        ConsoleOutput.Info("Shutting down control session...");
+                        processManager.TerminateControlSession(state.ControlSession);
+                        state.ControlSession.Status = ControlSessionStatus.Stopped;
+                        state.ControlSession.ProcessId = null;
+                    }
+
                     var runningSessions = state.Sessions.Values
                         .Where(s => s.Status == SessionStatus.Running)
                         .ToList();
@@ -146,8 +234,10 @@ public static class RunCommand
                             session.Status = SessionStatus.Completed;
                             session.UpdatedAt = DateTimeOffset.UtcNow;
                         }
-                        stateStore.SaveState(state);
                     }
+
+                    // Always save state on shutdown to persist control session and dispatch session changes
+                    stateStore.SaveState(state);
 
                     ConsoleOutput.Info("copilotd daemon stopped.");
                     return 0;

--- a/src/copilotd/Commands/RunCommand.cs
+++ b/src/copilotd/Commands/RunCommand.cs
@@ -80,7 +80,7 @@ public static class RunCommand
                                 processManager.TerminateControlSession(state.ControlSession);
 
                             ConsoleOutput.Info("Launching control remote session...");
-                            var controlSession = processManager.LaunchControlSession(config, state);
+                            var controlSession = processManager.LaunchControlSession(config);
                             if (controlSession is not null)
                             {
                                 state.ControlSession = controlSession;
@@ -139,7 +139,7 @@ public static class RunCommand
                                         processManager.TerminateControlSession(state.ControlSession);
 
                                     logger.LogInformation("Relaunching control session...");
-                                    var controlSession = processManager.LaunchControlSession(config, state);
+                                    var controlSession = processManager.LaunchControlSession(config);
                                     if (controlSession is not null)
                                     {
                                         state.ControlSession = controlSession;

--- a/src/copilotd/Commands/RunCommand.cs
+++ b/src/copilotd/Commands/RunCommand.cs
@@ -80,7 +80,7 @@ public static class RunCommand
                                 processManager.TerminateControlSession(state.ControlSession);
 
                             ConsoleOutput.Info("Launching control remote session...");
-                            var controlSession = processManager.LaunchControlSession(config);
+                            var controlSession = processManager.LaunchControlSession(config, state);
                             if (controlSession is not null)
                             {
                                 state.ControlSession = controlSession;
@@ -139,7 +139,7 @@ public static class RunCommand
                                         processManager.TerminateControlSession(state.ControlSession);
 
                                     logger.LogInformation("Relaunching control session...");
-                                    var controlSession = processManager.LaunchControlSession(config);
+                                    var controlSession = processManager.LaunchControlSession(config, state);
                                     if (controlSession is not null)
                                     {
                                         state.ControlSession = controlSession;

--- a/src/copilotd/Commands/StatusCommand.cs
+++ b/src/copilotd/Commands/StatusCommand.cs
@@ -58,6 +58,25 @@ public static class StatusCommand
                 }
 
                 ConsoleOutput.Info($"  Rules:     {config.Rules.Count}");
+
+                // Control session status
+                if (state.ControlSession is not null)
+                {
+                    var controlStatus = state.ControlSession.Status switch
+                    {
+                        ControlSessionStatus.Running => "[green]● Running[/]",
+                        ControlSessionStatus.Starting => "[yellow]◐ Starting[/]",
+                        ControlSessionStatus.Failed => "[red]✕ Failed[/]",
+                        _ => "[grey]○ Stopped[/]",
+                    };
+                    var controlPid = state.ControlSession.ProcessId is { } pid ? $" (PID {pid})" : "";
+                    AnsiConsole.MarkupLine($"  Control:   {controlStatus}{Markup.Escape(controlPid)}");
+                }
+                else if (config.EnableControlSession)
+                {
+                    AnsiConsole.MarkupLine("  Control:   [grey]○ Not started[/]");
+                }
+
                 AnsiConsole.WriteLine();
 
                 // Delegate session list rendering to the shared helper

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -355,6 +355,217 @@ public sealed partial class ProcessManager
         return true;
     }
 
+    /// <summary>
+    /// Checks if the control session process is still alive.
+    /// </summary>
+    public ProcessLivenessResult CheckControlSession(ControlSessionInfo session)
+    {
+        if (session.ProcessId is not { } pid)
+            return ProcessLivenessResult.Dead;
+
+        try
+        {
+            var process = Process.GetProcessById(pid);
+
+            if (session.ProcessStartTime is { } expectedStart)
+            {
+                var actualStart = GetProcessStartTime(process);
+                if (actualStart is not null && Math.Abs((actualStart.Value - expectedStart).TotalSeconds) > 5)
+                {
+                    _logger.LogDebug("Control session PID {Pid} start time mismatch", pid);
+                    process.Dispose();
+                    return ProcessLivenessResult.PidReused;
+                }
+            }
+
+            var alive = !process.HasExited;
+            process.Dispose();
+            return alive ? ProcessLivenessResult.Alive : ProcessLivenessResult.Dead;
+        }
+        catch (ArgumentException)
+        {
+            return ProcessLivenessResult.Dead;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Error checking control session process {Pid}", pid);
+            return ProcessLivenessResult.Dead;
+        }
+    }
+
+    /// <summary>
+    /// Launches the control remote session — a special <c>copilot --remote</c> session that
+    /// allows remote management of copilotd via the GitHub remote sessions UI.
+    /// Returns a populated <see cref="ControlSessionInfo"/> on success, or null on failure.
+    /// </summary>
+    public ControlSessionInfo? LaunchControlSession(CopilotdConfig config)
+    {
+        // Use ~/.copilotd as the working directory to keep the control session scoped
+        var workingDir = _stateStore.ConfigDir;
+        if (!Directory.Exists(workingDir))
+            workingDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+        var session = new ControlSessionInfo
+        {
+            CopilotSessionId = Guid.NewGuid().ToString("D"),
+            Status = ControlSessionStatus.Starting,
+            StartedAt = DateTimeOffset.UtcNow,
+        };
+
+        var args = BuildControlSessionArguments(CopilotdConfig.ControlSessionPrompt, config.DefaultModel);
+        _logger.LogInformation("Launching control session {SessionId}", session.CopilotSessionId);
+        _logger.LogDebug("copilot {Args}", args);
+
+        try
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                var si = new STARTUPINFO { cb = Marshal.SizeOf<STARTUPINFO>() };
+                si.dwFlags = STARTF_USESHOWWINDOW;
+                si.wShowWindow = SW_HIDE;
+
+                var cmdLine = $"copilot {args}";
+                var flags = CREATE_NEW_CONSOLE | CREATE_NEW_PROCESS_GROUP;
+
+                if (!CreateProcessW(null, cmdLine, IntPtr.Zero, IntPtr.Zero, false,
+                    flags, IntPtr.Zero, workingDir, ref si, out var pi))
+                {
+                    _logger.LogError("CreateProcessW failed for control session (error: {Error})",
+                        Marshal.GetLastWin32Error());
+                    return null;
+                }
+
+                session.ProcessId = pi.dwProcessId;
+                CloseHandle(pi.hProcess);
+                CloseHandle(pi.hThread);
+
+                try
+                {
+                    using var proc = Process.GetProcessById(pi.dwProcessId);
+                    session.ProcessStartTime = GetProcessStartTime(proc);
+                }
+                catch
+                {
+                    session.ProcessStartTime = DateTimeOffset.UtcNow;
+                }
+            }
+            else
+            {
+                var psi = new ProcessStartInfo
+                {
+                    FileName = "copilot",
+                    Arguments = args,
+                    WorkingDirectory = workingDir,
+                    UseShellExecute = false,
+                    RedirectStandardOutput = false,
+                    RedirectStandardError = false,
+                    RedirectStandardInput = false,
+                    CreateNoWindow = true,
+                };
+
+                var process = Process.Start(psi);
+                if (process is null)
+                {
+                    _logger.LogError("Failed to start copilot process for control session");
+                    return null;
+                }
+
+                session.ProcessId = process.Id;
+                session.ProcessStartTime = GetProcessStartTime(process);
+                process.Dispose();
+            }
+
+            session.Status = ControlSessionStatus.Running;
+            _logger.LogInformation("Control session launched: PID={Pid}", session.ProcessId);
+            return session;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception launching control session");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Gracefully terminates the control session process.
+    /// </summary>
+    public bool TerminateControlSession(ControlSessionInfo session)
+    {
+        if (session.ProcessId is not { } pid)
+        {
+            _logger.LogDebug("No PID tracked for control session, nothing to terminate");
+            return true;
+        }
+
+        Process process;
+        try
+        {
+            process = Process.GetProcessById(pid);
+        }
+        catch (ArgumentException)
+        {
+            _logger.LogDebug("Control session process {Pid} not found, already exited", pid);
+            return true;
+        }
+
+        try
+        {
+            if (session.ProcessStartTime is { } expectedStart)
+            {
+                var actualStart = GetProcessStartTime(process);
+                if (actualStart is not null && Math.Abs((actualStart.Value - expectedStart).TotalSeconds) > 5)
+                {
+                    _logger.LogWarning("Control session PID {Pid} was reused by another process, skipping termination", pid);
+                    return true;
+                }
+            }
+
+            if (process.HasExited)
+            {
+                _logger.LogDebug("Control session process {Pid} already exited", pid);
+                return true;
+            }
+
+            _logger.LogInformation("Gracefully terminating control session process {Pid}", pid);
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return TerminateViaShutdownInstance(process, pid);
+            }
+            else
+            {
+                return TerminateViaSignals(process, pid);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to terminate control session process {Pid}", pid);
+            return false;
+        }
+        finally
+        {
+            process.Dispose();
+        }
+    }
+
+    private static string BuildControlSessionArguments(string prompt, string? defaultModel)
+    {
+        var args = new List<string>
+        {
+            "--remote",
+            "-i", $"\"{EscapeArg(prompt)}\"",
+            "--allow-all-tools",
+        };
+
+        if (!string.IsNullOrWhiteSpace(defaultModel))
+        {
+            args.Add("--model");
+            args.Add($"\"{EscapeArg(defaultModel)}\"");
+        }
+
+        return string.Join(' ', args);
+    }
+
     private static string BuildPrompt(string globalCustomPrompt, GitHubIssue issue, DispatchSession session, CopilotdConfig config)
     {
         // Use a PR-specific prompt when re-dispatching for review feedback

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -398,12 +398,16 @@ public sealed partial class ProcessManager
     /// allows remote management of copilotd via the GitHub remote sessions UI.
     /// Returns a populated <see cref="ControlSessionInfo"/> on success, or null on failure.
     /// </summary>
-    public ControlSessionInfo? LaunchControlSession(CopilotdConfig config)
+    public ControlSessionInfo? LaunchControlSession(CopilotdConfig config, DaemonState state)
     {
-        // Use ~/.copilotd as the working directory to keep the control session scoped
-        var workingDir = _stateStore.ConfigDir;
-        if (!Directory.Exists(workingDir))
-            workingDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        // copilot --remote requires a cloned GitHub repo as the working directory.
+        // Use the first resolved repo path, or try to resolve one from configured rules.
+        var workingDir = ResolveControlSessionWorkingDir(config, state);
+        if (workingDir is null)
+        {
+            _logger.LogError("No cloned GitHub repo found for control session. Configure RepoHome and at least one rule with a repo.");
+            return null;
+        }
 
         var session = new ControlSessionInfo
         {
@@ -564,6 +568,34 @@ public sealed partial class ProcessManager
         }
 
         return string.Join(' ', args);
+    }
+
+    /// <summary>
+    /// Finds a cloned GitHub repo to use as the control session's working directory.
+    /// Prefers cached resolved paths, falls back to resolving from configured rule repos.
+    /// </summary>
+    private string? ResolveControlSessionWorkingDir(CopilotdConfig config, DaemonState state)
+    {
+        // Try cached resolved repo paths first
+        foreach (var path in state.ResolvedRepoPaths.Values)
+        {
+            if (Directory.Exists(path))
+                return path;
+        }
+
+        // Fall back to resolving from configured rules
+        var repoSlugs = config.Rules.Values
+            .SelectMany(r => r.Repos)
+            .Distinct(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var slug in repoSlugs)
+        {
+            var path = _repoResolver.ResolveRepoPath(slug, config, state);
+            if (path is not null && Directory.Exists(path))
+                return path;
+        }
+
+        return null;
     }
 
     private static string BuildPrompt(string globalCustomPrompt, GitHubIssue issue, DispatchSession session, CopilotdConfig config)

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -398,14 +398,14 @@ public sealed partial class ProcessManager
     /// allows remote management of copilotd via the GitHub remote sessions UI.
     /// Returns a populated <see cref="ControlSessionInfo"/> on success, or null on failure.
     /// </summary>
-    public ControlSessionInfo? LaunchControlSession(CopilotdConfig config, DaemonState state)
+    public ControlSessionInfo? LaunchControlSession(CopilotdConfig config)
     {
+        // Clone the copilotd repo to <RepoHome>/DamianEdwards/copilotd if needed.
         // copilot --remote requires a cloned GitHub repo as the working directory.
-        // Use the first resolved repo path, or try to resolve one from configured rules.
-        var workingDir = ResolveControlSessionWorkingDir(config, state);
+        var workingDir = EnsureControlSessionRepo(config);
         if (workingDir is null)
         {
-            _logger.LogError("No cloned GitHub repo found for control session. Configure RepoHome and at least one rule with a repo.");
+            _logger.LogError("Cannot launch control session: failed to set up copilotd repo clone");
             return null;
         }
 
@@ -558,7 +558,10 @@ public sealed partial class ProcessManager
         {
             "--remote",
             "-i", $"\"{EscapeArg(prompt)}\"",
-            "--allow-all-tools",
+            // Only allow copilotd, gh, and git commands — no general shell access
+            "--allow-tool=shell(copilotd:*)",
+            "--allow-tool=shell(gh:*)",
+            "--allow-tool=shell(git:*)",
         };
 
         if (!string.IsNullOrWhiteSpace(defaultModel))
@@ -571,31 +574,77 @@ public sealed partial class ProcessManager
     }
 
     /// <summary>
-    /// Finds a cloned GitHub repo to use as the control session's working directory.
-    /// Prefers cached resolved paths, falls back to resolving from configured rule repos.
+    /// The copilotd repo to clone for the control session's working directory.
     /// </summary>
-    private string? ResolveControlSessionWorkingDir(CopilotdConfig config, DaemonState state)
+    private const string ControlSessionRepo = "DamianEdwards/copilotd";
+
+    /// <summary>
+    /// Ensures the copilotd repo is cloned to <c>&lt;RepoHome&gt;/DamianEdwards/copilotd</c>
+    /// for use as the control session's working directory. Clones it if not already present.
+    /// </summary>
+    private string? EnsureControlSessionRepo(CopilotdConfig config)
     {
-        // Try cached resolved repo paths first
-        foreach (var path in state.ResolvedRepoPaths.Values)
+        if (string.IsNullOrEmpty(config.RepoHome))
         {
-            if (Directory.Exists(path))
-                return path;
+            _logger.LogError("RepoHome is not configured; cannot set up control session repo");
+            return null;
         }
 
-        // Fall back to resolving from configured rules
-        var repoSlugs = config.Rules.Values
-            .SelectMany(r => r.Repos)
-            .Distinct(StringComparer.OrdinalIgnoreCase);
+        var repoPath = Path.Combine(config.RepoHome, "DamianEdwards", "copilotd");
 
-        foreach (var slug in repoSlugs)
+        if (Directory.Exists(Path.Combine(repoPath, ".git")))
         {
-            var path = _repoResolver.ResolveRepoPath(slug, config, state);
-            if (path is not null && Directory.Exists(path))
-                return path;
+            _logger.LogDebug("Control session repo already exists at {Path}", repoPath);
+            return repoPath;
         }
 
-        return null;
+        _logger.LogInformation("Cloning {Repo} for control session...", ControlSessionRepo);
+
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(repoPath)!);
+
+            var psi = new ProcessStartInfo
+            {
+                FileName = "gh",
+                Arguments = $"repo clone {ControlSessionRepo} \"{repoPath}\"",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+            };
+
+            using var process = Process.Start(psi);
+            if (process is null)
+            {
+                _logger.LogError("Failed to start gh repo clone for control session");
+                return null;
+            }
+
+            process.WaitForExit(TimeSpan.FromSeconds(60));
+
+            if (!process.HasExited)
+            {
+                _logger.LogWarning("gh repo clone timed out for control session");
+                process.Kill(entireProcessTree: true);
+                return null;
+            }
+
+            if (process.ExitCode != 0)
+            {
+                var stderr = process.StandardError.ReadToEnd();
+                _logger.LogError("gh repo clone failed (exit {Code}): {Stderr}", process.ExitCode, stderr);
+                return null;
+            }
+
+            _logger.LogInformation("Cloned {Repo} to {Path}", ControlSessionRepo, repoPath);
+            return repoPath;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception cloning {Repo} for control session", ControlSessionRepo);
+            return null;
+        }
     }
 
     private static string BuildPrompt(string globalCustomPrompt, GitHubIssue issue, DispatchSession session, CopilotdConfig config)

--- a/src/copilotd/Models/CopilotdConfig.cs
+++ b/src/copilotd/Models/CopilotdConfig.cs
@@ -106,7 +106,7 @@ public sealed class CopilotdConfig
     public const string ControlSessionPrompt =
         """
         You are the copilotd control session — a remote management interface for the copilotd daemon.
-        copilotd is a daemon that automatically dispatches GitHub Copilot coding sessions for GitHub issues
+        copilotd is a daemon that automatically dispatches GitHub Copilot CLI coding sessions for GitHub issues
         matching configured rules. You help the user monitor and manage copilotd remotely.
 
         AVAILABLE COMMANDS (run these in the terminal):

--- a/src/copilotd/Models/CopilotdConfig.cs
+++ b/src/copilotd/Models/CopilotdConfig.cs
@@ -54,6 +54,13 @@ public sealed class CopilotdConfig
     public int MaxRedispatches { get; set; } = 10;
 
     /// <summary>
+    /// Whether to launch a control remote session when the daemon starts.
+    /// The control session allows remote management of copilotd via the GitHub remote sessions UI.
+    /// Default is true.
+    /// </summary>
+    public bool EnableControlSession { get; set; } = true;
+
+    /// <summary>
     /// Named dispatch rules. Key is the rule name.
     /// </summary>
     public Dictionary<string, DispatchRule> Rules { get; set; } = new(StringComparer.OrdinalIgnoreCase);
@@ -94,6 +101,43 @@ public sealed class CopilotdConfig
         If you need more information or clarification before proceeding:
         - Run `copilotd session comment $(issue.repo)#$(issue.id) --message "Your question or findings here"` to post a comment on the issue.
         - This will pause your session until a response is posted on the issue, at which point your session will automatically resume.
+        """;
+
+    public const string ControlSessionPrompt =
+        """
+        You are the copilotd control session — a remote management interface for the copilotd daemon.
+        copilotd is a daemon that automatically dispatches GitHub Copilot coding sessions for GitHub issues
+        matching configured rules. You help the user monitor and manage copilotd remotely.
+
+        AVAILABLE COMMANDS (run these in the terminal):
+        - `copilotd status`                          — Show daemon health, watched repos, and session summary
+        - `copilotd session list [--all]`             — List active sessions (--all includes completed/failed)
+        - `copilotd session list --filter <status>`   — Filter by status: pending, running, completed, failed, orphaned, joined, waitingforfeedback, waitingforreview
+        - `copilotd session reset <issue>`            — Reset a session for re-dispatch (e.g., "org/repo#42")
+        - `copilotd session complete <issue>`         — Mark a session as completed
+        - `copilotd session comment <issue> --message "text"` — Post a comment on the issue and pause the session
+        - `copilotd session pr <pr-number> <issue>`   — Associate a PR with a session for review monitoring
+        - `copilotd rules list`                       — Show configured dispatch rules
+        - `copilotd config`                           — Show current configuration
+
+        FORBIDDEN COMMANDS (do NOT run these — they would disrupt the daemon):
+        - `copilotd run` / `copilotd start` / `copilotd stop` — Would interfere with the running daemon
+        - `copilotd update` — Could replace the running binary
+        - `copilotd init` — Interactive setup, not appropriate for remote sessions
+        - `copilotd shutdown-instance` — Internal command, never run directly
+
+        SESSION LIFECYCLE:
+        Issues matching rules are dispatched as copilot sessions that progress through:
+        Pending → Dispatching → Running → Completed/Failed
+        Sessions can also be: Orphaned (process died), Joined (user took over),
+        WaitingForFeedback (paused for issue comments), or WaitingForReview (monitoring PR reviews).
+
+        GUIDELINES:
+        - Always start by running `copilotd status` to understand the current state
+        - When the user asks about sessions, run `copilotd session list` to get fresh data
+        - Present information clearly and concisely
+        - If a session is stuck or failed, suggest `copilotd session reset <issue>` to retry it
+        - Issue keys use the format "org/repo#number"
         """;
 }
 

--- a/src/copilotd/Models/JsonContext.cs
+++ b/src/copilotd/Models/JsonContext.cs
@@ -186,17 +186,53 @@ public sealed class TolerantAuthorModeConverter : JsonConverter<AuthorMode>
 }
 
 /// <summary>
+/// AOT-compatible JSON converter for <see cref="ControlSessionStatus"/> that gracefully handles
+/// unknown enum values by falling back to <see cref="ControlSessionStatus.Stopped"/>.
+/// </summary>
+public sealed class TolerantControlSessionStatusConverter : JsonConverter<ControlSessionStatus>
+{
+    public override ControlSessionStatus Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            var value = reader.GetString();
+            if (Enum.TryParse<ControlSessionStatus>(value, ignoreCase: true, out var status))
+                return status;
+
+            return ControlSessionStatus.Stopped;
+        }
+
+        if (reader.TokenType == JsonTokenType.Number)
+        {
+            var intValue = reader.GetInt32();
+            if (Enum.IsDefined(typeof(ControlSessionStatus), intValue))
+                return (ControlSessionStatus)intValue;
+
+            return ControlSessionStatus.Stopped;
+        }
+
+        return ControlSessionStatus.Stopped;
+    }
+
+    public override void Write(Utf8JsonWriter writer, ControlSessionStatus value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToString());
+    }
+}
+
+/// <summary>
 /// AOT-safe JSON serialization metadata for all persisted models.
 /// </summary>
 [JsonSourceGenerationOptions(
     WriteIndented = true,
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-    Converters = [typeof(TolerantSessionStatusConverter), typeof(TolerantUpdateStatusConverter), typeof(TolerantPromptModeConverter), typeof(TolerantCommentTrustLevelConverter), typeof(TolerantAuthorModeConverter)])]
+    Converters = [typeof(TolerantSessionStatusConverter), typeof(TolerantUpdateStatusConverter), typeof(TolerantPromptModeConverter), typeof(TolerantCommentTrustLevelConverter), typeof(TolerantAuthorModeConverter), typeof(TolerantControlSessionStatusConverter)])]
 [JsonSerializable(typeof(CopilotdConfig))]
 [JsonSerializable(typeof(DaemonState))]
 [JsonSerializable(typeof(DispatchRule))]
 [JsonSerializable(typeof(DispatchSession))]
+[JsonSerializable(typeof(ControlSessionInfo))]
 [JsonSerializable(typeof(GitHubIssue))]
 [JsonSerializable(typeof(List<GitHubIssue>))]
 [JsonSerializable(typeof(List<GhRepo>))]

--- a/src/copilotd/Models/SessionState.cs
+++ b/src/copilotd/Models/SessionState.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Copilotd.Models;
 
 /// <summary>
@@ -21,6 +23,13 @@ public sealed class DaemonState
     /// Populated by <see cref="Infrastructure.RepoPathResolver"/> and validated on each use.
     /// </summary>
     public Dictionary<string, string> ResolvedRepoPaths { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// The control remote session that allows remote management of copilotd.
+    /// Null when no control session has been started. Tracked separately from
+    /// dispatch sessions to avoid interference with reconciliation and pruning.
+    /// </summary>
+    public ControlSessionInfo? ControlSession { get; set; }
 }
 
 /// <summary>
@@ -158,4 +167,46 @@ public sealed class DispatchSession
     /// <summary>Whether this session can be re-dispatched.</summary>
     public bool CanRetry => Status is SessionStatus.Orphaned or SessionStatus.Failed
                             && RetryCount < MaxRetries;
+}
+
+/// <summary>
+/// Lifecycle status of the control remote session.
+/// </summary>
+[JsonConverter(typeof(TolerantControlSessionStatusConverter))]
+public enum ControlSessionStatus
+{
+    /// <summary>Control session is not running.</summary>
+    Stopped,
+
+    /// <summary>Control session process is being launched.</summary>
+    Starting,
+
+    /// <summary>Control session process is alive.</summary>
+    Running,
+
+    /// <summary>Control session process exited abnormally.</summary>
+    Failed,
+}
+
+/// <summary>
+/// Tracks the daemon's control remote session — a special <c>copilot --remote</c> session
+/// that allows remote management of copilotd via the GitHub remote sessions UI.
+/// Tracked separately from dispatch sessions to avoid interference with reconciliation.
+/// </summary>
+public sealed class ControlSessionInfo
+{
+    /// <summary>Generated UUID for the copilot remote session.</summary>
+    public string CopilotSessionId { get; set; } = "";
+
+    /// <summary>OS process ID of the copilot process.</summary>
+    public int? ProcessId { get; set; }
+
+    /// <summary>Process start time, used alongside PID to detect PID reuse.</summary>
+    public DateTimeOffset? ProcessStartTime { get; set; }
+
+    /// <summary>Current lifecycle status.</summary>
+    public ControlSessionStatus Status { get; set; } = ControlSessionStatus.Stopped;
+
+    /// <summary>When the control session was last started.</summary>
+    public DateTimeOffset? StartedAt { get; set; }
 }


### PR DESCRIPTION
## Summary

Implements #56 — `copilotd run` now hosts its own `copilot --remote` session that allows remote viewing and management of copilotd through the GitHub remote sessions UI (web/mobile).

## What's new

- **ControlSessionInfo model** tracked separately on `DaemonState` (not in `Sessions` dict) to avoid interference with reconciliation, pruning, and user commands
- **EnableControlSession** config flag (default: `true`) on `CopilotdConfig`
- **LaunchControlSession / TerminateControlSession / CheckControlSession** methods on `ProcessManager` with full Windows/Unix platform support (CreateProcessW on Windows, Process.Start on Unix)
- **RunCommand integration**: launches on startup (reusing existing if alive), health-checks each poll cycle with auto-restart, graceful termination on shutdown
- **StatusCommand** displays control session status in the daemon header
- **ControlSessionPrompt** constant with available commands (`status`, `session list`, `session reset`, etc.) and explicit blocklist of dangerous commands (`run`, `start`, `stop`, `update`)
- Does **not** count against `MaxInstances`
- Fresh session each daemon start (no `--resume` — stale context from prior runs is unhelpful)

## Design decisions

| Decision | Rationale |
|---|---|
| Separate `ControlSession` field on `DaemonState` | Avoids pollution of `Sessions` dict, prevents reconciliation/pruning interference |
| Working directory: `~/.copilotd` | Scoped safely; avoids starting in overly broad locations |
| Default enabled | Feature is opt-in-disabled via `EnableControlSession: false` in config |
| Prompt-based (not `--agent`) | Simpler initial approach; `--agent` is a natural follow-up enhancement |
| Auto-restart on crash | Each poll cycle checks liveness and relaunches if dead |

## Files changed

- `src/copilotd/Models/SessionState.cs` — `ControlSessionInfo` class, `ControlSessionStatus` enum
- `src/copilotd/Models/CopilotdConfig.cs` — `EnableControlSession` flag, `ControlSessionPrompt` constant
- `src/copilotd/Models/JsonContext.cs` — AOT serialization registration, tolerant converter
- `src/copilotd/Infrastructure/ProcessManager.cs` — Launch/terminate/check methods
- `src/copilotd/Commands/RunCommand.cs` — Startup, poll loop, shutdown integration
- `src/copilotd/Commands/StatusCommand.cs` — Control session status display

Closes #56
