### PR TITLE
Fix leaked copilot session cleanup

### DIFF
--- a/src/copilotd/Commands/RunCommand.cs
+++ b/src/copilotd/Commands/RunCommand.cs
@@ -54,45 +54,64 @@ public static class RunCommand
 
                     // Startup reconciliation pass
                     var config = stateStore.LoadConfig();
-                    var state = stateStore.LoadState();
                     ConsoleOutput.Info("Running startup reconciliation...");
-                    reconciliation.Reconcile(config, state);
+                    stateStore.WithStateLock(() =>
+                    {
+                        var state = stateStore.LoadState();
+                        reconciliation.Reconcile(config, state);
+                    }, ct);
                     ConsoleOutput.Success("Startup reconciliation complete.");
 
                     // Launch control session if enabled
                     if (config.EnableControlSession)
                     {
-                        state = stateStore.LoadState();
+                        var existingControlPid = default(int?);
+                        var launchedControlPid = default(int?);
+                        var launchFailed = false;
 
-                        // Check if a control session from a prior daemon run is still alive
-                        var existingAlive = state.ControlSession is not null
-                            && state.ControlSession.Status == ControlSessionStatus.Running
-                            && processManager.CheckControlSession(state.ControlSession) == ProcessLivenessResult.Alive;
+                        stateStore.WithStateLock(() =>
+                        {
+                            var state = stateStore.LoadState();
 
-                        if (existingAlive)
-                        {
-                            ConsoleOutput.Success($"Control session already running (PID {state.ControlSession!.ProcessId}).");
-                        }
-                        else
-                        {
-                            // Terminate stale process if needed
+                            var existingAlive = state.ControlSession is not null
+                                && state.ControlSession.Status == ControlSessionStatus.Running
+                                && processManager.CheckControlSession(state.ControlSession) == ProcessLivenessResult.Alive;
+
+                            if (existingAlive)
+                            {
+                                existingControlPid = state.ControlSession!.ProcessId;
+                                return;
+                            }
+
                             if (state.ControlSession?.ProcessId is not null)
                                 processManager.TerminateControlSession(state.ControlSession);
 
-                            ConsoleOutput.Info("Launching control remote session...");
                             var controlSession = processManager.LaunchControlSession(config);
                             if (controlSession is not null)
                             {
                                 state.ControlSession = controlSession;
-                                stateStore.SaveState(state);
-                                ConsoleOutput.Success($"Control session launched (PID {controlSession.ProcessId}).");
+                                launchedControlPid = controlSession.ProcessId;
                             }
                             else
                             {
                                 state.ControlSession = new ControlSessionInfo { Status = ControlSessionStatus.Failed };
-                                stateStore.SaveState(state);
-                                ConsoleOutput.Warning("Failed to launch control session. Will retry next cycle.");
+                                launchFailed = true;
                             }
+
+                            stateStore.SaveState(state);
+                        }, ct);
+
+                        if (existingControlPid is not null)
+                        {
+                            ConsoleOutput.Success($"Control session already running (PID {existingControlPid}).");
+                        }
+                        else if (launchedControlPid is not null)
+                        {
+                            ConsoleOutput.Success($"Control session launched (PID {launchedControlPid}).");
+                        }
+                        else if (launchFailed)
+                        {
+                            ConsoleOutput.Warning("Failed to launch control session. Will retry next cycle.");
                         }
                     }
 
@@ -120,49 +139,50 @@ public static class RunCommand
                         {
                             // Reload config each cycle for live editing support
                             config = stateStore.LoadConfig();
-                            state = stateStore.LoadState();
-
-                            reconciliation.Reconcile(config, state);
-
-                            // Control session health check
-                            state = stateStore.LoadState();
-                            if (config.EnableControlSession)
+                            stateStore.WithStateLock(() =>
                             {
-                                var controlAlive = state.ControlSession is not null
-                                    && state.ControlSession.Status == ControlSessionStatus.Running
-                                    && processManager.CheckControlSession(state.ControlSession) == ProcessLivenessResult.Alive;
+                                var state = stateStore.LoadState();
 
-                                if (!controlAlive)
+                                reconciliation.Reconcile(config, state);
+
+                                if (config.EnableControlSession)
                                 {
-                                    // Terminate stale process if needed
-                                    if (state.ControlSession?.ProcessId is not null)
-                                        processManager.TerminateControlSession(state.ControlSession);
+                                    var controlAlive = state.ControlSession is not null
+                                        && state.ControlSession.Status == ControlSessionStatus.Running
+                                        && processManager.CheckControlSession(state.ControlSession) == ProcessLivenessResult.Alive;
 
-                                    logger.LogInformation("Relaunching control session...");
-                                    var controlSession = processManager.LaunchControlSession(config);
-                                    if (controlSession is not null)
+                                    if (!controlAlive)
                                     {
-                                        state.ControlSession = controlSession;
-                                        logger.LogInformation("Control session relaunched (PID {Pid})", controlSession.ProcessId);
+                                        if (state.ControlSession?.ProcessId is not null)
+                                            processManager.TerminateControlSession(state.ControlSession);
+
+                                        logger.LogInformation("Relaunching control session...");
+                                        var controlSession = processManager.LaunchControlSession(config);
+                                        if (controlSession is not null)
+                                        {
+                                            state.ControlSession = controlSession;
+                                            logger.LogInformation("Control session relaunched (PID {Pid})", controlSession.ProcessId);
+                                        }
+                                        else
+                                        {
+                                            state.ControlSession = new ControlSessionInfo { Status = ControlSessionStatus.Failed };
+                                            logger.LogWarning("Failed to relaunch control session");
+                                        }
+
+                                        stateStore.SaveState(state);
                                     }
-                                    else
-                                    {
-                                        state.ControlSession = new ControlSessionInfo { Status = ControlSessionStatus.Failed };
-                                        logger.LogWarning("Failed to relaunch control session");
-                                    }
+                                }
+                                else if (state.ControlSession is not null
+                                         && state.ControlSession.Status == ControlSessionStatus.Running)
+                                {
+                                    logger.LogInformation("Control session disabled, terminating...");
+                                    processManager.TerminateControlSession(state.ControlSession);
+                                    state.ControlSession.Status = ControlSessionStatus.Stopped;
+                                    state.ControlSession.ProcessId = null;
+                                    state.ControlSession.ProcessStartTime = null;
                                     stateStore.SaveState(state);
                                 }
-                            }
-                            else if (state.ControlSession is not null
-                                     && state.ControlSession.Status == ControlSessionStatus.Running)
-                            {
-                                // Config toggled off — terminate control session
-                                logger.LogInformation("Control session disabled, terminating...");
-                                processManager.TerminateControlSession(state.ControlSession);
-                                state.ControlSession.Status = ControlSessionStatus.Stopped;
-                                state.ControlSession.ProcessId = null;
-                                stateStore.SaveState(state);
-                            }
+                            }, cts.Token);
 
                             // Self-update: check for staged update or fire background check
                             var updateState = stateStore.LoadUpdateState();
@@ -210,34 +230,38 @@ public static class RunCommand
                     }
 
                     // Gracefully terminate running sessions before exit
-                    state = stateStore.LoadState();
-
-                    // Terminate control session
-                    if (state.ControlSession is not null
-                        && state.ControlSession.Status == ControlSessionStatus.Running)
+                    stateStore.WithStateLock(() =>
                     {
-                        ConsoleOutput.Info("Shutting down control session...");
-                        processManager.TerminateControlSession(state.ControlSession);
-                        state.ControlSession.Status = ControlSessionStatus.Stopped;
-                        state.ControlSession.ProcessId = null;
-                    }
+                        var state = stateStore.LoadState();
 
-                    var runningSessions = state.Sessions.Values
-                        .Where(s => s.Status == SessionStatus.Running)
-                        .ToList();
-                    if (runningSessions.Count > 0)
-                    {
-                        ConsoleOutput.Info($"Shutting down {runningSessions.Count} active copilot session(s)...");
-                        foreach (var session in runningSessions)
+                        if (state.ControlSession is not null
+                            && state.ControlSession.Status == ControlSessionStatus.Running)
                         {
-                            processManager.TerminateProcess(session);
-                            session.Status = SessionStatus.Completed;
-                            session.UpdatedAt = DateTimeOffset.UtcNow;
+                            ConsoleOutput.Info("Shutting down control session...");
+                            processManager.TerminateControlSession(state.ControlSession);
+                            state.ControlSession.Status = ControlSessionStatus.Stopped;
+                            state.ControlSession.ProcessId = null;
+                            state.ControlSession.ProcessStartTime = null;
                         }
-                    }
 
-                    // Always save state on shutdown to persist control session and dispatch session changes
-                    stateStore.SaveState(state);
+                        var runningSessions = state.Sessions.Values
+                            .Where(s => s.Status == SessionStatus.Running)
+                            .ToList();
+                        if (runningSessions.Count > 0)
+                        {
+                            ConsoleOutput.Info($"Shutting down {runningSessions.Count} active copilot session(s)...");
+                            foreach (var session in runningSessions)
+                            {
+                                processManager.TerminateProcess(session);
+                                session.Status = SessionStatus.Completed;
+                                session.ProcessId = null;
+                                session.ProcessStartTime = null;
+                                session.UpdatedAt = DateTimeOffset.UtcNow;
+                            }
+                        }
+
+                        stateStore.SaveState(state);
+                    }, ct);
 
                     ConsoleOutput.Info("copilotd daemon stopped.");
                     return 0;

--- a/src/copilotd/Commands/SessionCommand.cs
+++ b/src/copilotd/Commands/SessionCommand.cs
@@ -110,54 +110,73 @@ public static class SessionCommand
             {
                 var stateStore = services.GetRequiredService<StateStore>();
                 var processManager = services.GetRequiredService<ProcessManager>();
-                var state = stateStore.LoadState();
                 var config = stateStore.LoadConfig();
+                var repoResolver = services.GetRequiredService<RepoPathResolver>();
 
                 var issueKey = parseResult.GetValue(issueArg)!;
+                string? sessionId = null;
+                string? worktreePath = null;
+                string? workingDir = null;
+                var priorProcess = default(TrackedProcessRef);
+                var priorStatus = SessionStatus.Pending;
+                string? errorMessage = null;
 
-                if (!state.Sessions.TryGetValue(issueKey, out var session))
+                stateStore.WithStateLock(() =>
                 {
-                    ConsoleOutput.Error($"No session found for '{issueKey}'.");
-                    ConsoleOutput.Info("Use 'copilotd session list --all' to see all tracked sessions.");
+                    var state = stateStore.LoadState();
+
+                    if (!state.Sessions.TryGetValue(issueKey, out var session))
+                    {
+                        errorMessage = $"No session found for '{issueKey}'.";
+                        return;
+                    }
+
+                    if (string.IsNullOrEmpty(session.CopilotSessionId))
+                    {
+                        errorMessage = $"Session for '{issueKey}' has no copilot session ID.";
+                        return;
+                    }
+
+                    workingDir = session.WorktreePath ?? repoResolver.ResolveRepoPath(session.Repo, config, state);
+                    if (workingDir is null || !Directory.Exists(workingDir))
+                    {
+                        errorMessage = $"Working directory not found for {session.Repo}. Ensure the repository is cloned under the configured RepoHome directory.";
+                        return;
+                    }
+
+                    sessionId = session.CopilotSessionId;
+                    worktreePath = session.WorktreePath;
+                    priorStatus = session.Status;
+
+                    if (session.Status is SessionStatus.Running or SessionStatus.Dispatching or SessionStatus.Joined)
+                        priorProcess = CaptureTrackedProcess(session);
+
+                    session.Status = SessionStatus.Joined;
+                    ClearTrackedProcess(session);
+                    session.UpdatedAt = DateTimeOffset.UtcNow;
+                    stateStore.SaveState(state);
+                }, ct);
+
+                if (errorMessage is not null)
+                {
+                    ConsoleOutput.Error(errorMessage);
+                    if (errorMessage.StartsWith("No session found", StringComparison.Ordinal))
+                        ConsoleOutput.Info("Use 'copilotd session list --all' to see all tracked sessions.");
                     return 1;
                 }
 
-                if (string.IsNullOrEmpty(session.CopilotSessionId))
+                if (priorProcess.HasProcess)
                 {
-                    ConsoleOutput.Error($"Session for '{issueKey}' has no copilot session ID.");
-                    return 1;
+                    var message = priorStatus is SessionStatus.Joined
+                        ? $"Stopping previously joined interactive session for {issueKey} (PID {priorProcess.ProcessId})..."
+                        : $"Stopping orchestrated session for {issueKey} (PID {priorProcess.ProcessId})...";
+                    ConsoleOutput.Info(message);
+                    processManager.TerminateProcess(priorProcess.Label, priorProcess.ProcessId, priorProcess.ProcessStartTime);
                 }
 
-                // Use worktree path if available, otherwise resolve the main repo
-                var repoResolver = services.GetRequiredService<RepoPathResolver>();
-                var workingDir = session.WorktreePath ?? repoResolver.ResolveRepoPath(session.Repo, config, state);
-                if (workingDir is null || !Directory.Exists(workingDir))
-                {
-                    ConsoleOutput.Error($"Working directory not found for {session.Repo}. Ensure the repository is cloned under the configured RepoHome directory.");
-                    return 1;
-                }
-
-                // If the session is currently running, terminate the orchestrated process first
-                if (session.Status is SessionStatus.Running or SessionStatus.Dispatching)
-                {
-                    ConsoleOutput.Info($"Stopping orchestrated session for {issueKey} (PID {session.ProcessId})...");
-                    processManager.TerminateProcess(session);
-                }
-                else if (session.Status is SessionStatus.Joined)
-                {
-                    ConsoleOutput.Info($"Session was previously joined but not cleaned up. Resuming...");
-                }
-
-                // Mark as Joined so the daemon doesn't interfere
-                session.Status = SessionStatus.Joined;
-                session.ProcessId = null;
-                session.ProcessStartTime = null;
-                session.UpdatedAt = DateTimeOffset.UtcNow;
-                stateStore.SaveState(state);
-
-                ConsoleOutput.Success($"Joining session {session.CopilotSessionId} for {issueKey}");
-                if (session.WorktreePath is not null)
-                    ConsoleOutput.Info($"Working directory: {session.WorktreePath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar)}");
+                ConsoleOutput.Success($"Joining session {sessionId} for {issueKey}");
+                if (worktreePath is not null)
+                    ConsoleOutput.Info($"Working directory: {worktreePath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar)}");
                 ConsoleOutput.Info("Press Ctrl+C to exit the interactive session.");
                 Console.WriteLine();
 
@@ -165,7 +184,7 @@ public static class SessionCommand
                 var psi = new ProcessStartInfo
                 {
                     FileName = "copilot",
-                    Arguments = $"--resume={session.CopilotSessionId}",
+                    Arguments = $"--resume={sessionId}",
                     WorkingDirectory = workingDir,
                     UseShellExecute = false,
                     RedirectStandardInput = false,
@@ -186,14 +205,17 @@ public static class SessionCommand
 
                     // Track the interactive process PID so the daemon can detect
                     // if it exits (e.g., terminal killed without cleanup)
-                    state = stateStore.LoadState();
-                    if (state.Sessions.TryGetValue(issueKey, out var tracked))
+                    stateStore.WithStateLock(() =>
                     {
-                        tracked.ProcessId = interactiveProcess.Id;
-                        try { tracked.ProcessStartTime = new DateTimeOffset(interactiveProcess.StartTime.ToUniversalTime(), TimeSpan.Zero); }
-                        catch { tracked.ProcessStartTime = DateTimeOffset.UtcNow; }
-                        stateStore.SaveState(state);
-                    }
+                        var state = stateStore.LoadState();
+                        if (state.Sessions.TryGetValue(issueKey, out var tracked))
+                        {
+                            tracked.ProcessId = interactiveProcess.Id;
+                            try { tracked.ProcessStartTime = new DateTimeOffset(interactiveProcess.StartTime.ToUniversalTime(), TimeSpan.Zero); }
+                            catch { tracked.ProcessStartTime = DateTimeOffset.UtcNow; }
+                            stateStore.SaveState(state);
+                        }
+                    }, ct);
 
                     await interactiveProcess.WaitForExitAsync(ct);
                     var exitCode = interactiveProcess.ExitCode;
@@ -246,39 +268,83 @@ public static class SessionCommand
             {
                 var stateStore = services.GetRequiredService<StateStore>();
                 var ghCli = services.GetRequiredService<GhCliService>();
-                var state = stateStore.LoadState();
+                var processManager = services.GetRequiredService<ProcessManager>();
 
                 var issueKey = parseResult.GetValue(issueArg)!;
                 var message = parseResult.GetValue(messageOption)!;
+                var trackedProcess = default(TrackedProcessRef);
+                string? repo = null;
+                var issueNumber = 0;
+                string? expectedSessionId = null;
+                string? errorMessage = null;
 
-                if (!state.Sessions.TryGetValue(issueKey, out var session))
+                stateStore.WithStateLock(() =>
                 {
-                    ConsoleOutput.Error($"No session found for '{issueKey}'.");
+                    var state = stateStore.LoadState();
+                    if (!state.Sessions.TryGetValue(issueKey, out var session))
+                    {
+                        errorMessage = $"No session found for '{issueKey}'.";
+                        return;
+                    }
+
+                    if (session.IsTerminal)
+                    {
+                        errorMessage = $"Session for '{issueKey}' is already {session.Status.ToString().ToLowerInvariant()}.";
+                        return;
+                    }
+                    repo = session.Repo;
+                    issueNumber = session.IssueNumber;
+                    expectedSessionId = session.CopilotSessionId;
+                }, ct);
+
+                if (errorMessage is not null)
+                {
+                    ConsoleOutput.Error(errorMessage);
                     return 1;
                 }
 
-                if (session.IsTerminal)
-                {
-                    ConsoleOutput.Error($"Session for '{issueKey}' is already {session.Status.ToString().ToLowerInvariant()}.");
-                    return 1;
-                }
-
-                // Post the comment to the issue
-                if (!ghCli.PostIssueComment(session.Repo, session.IssueNumber, message))
+                if (!ghCli.PostIssueComment(repo!, issueNumber, message))
                 {
                     ConsoleOutput.Error($"Failed to post comment on {issueKey}.");
                     return 1;
                 }
 
-                // Transition to WaitingForFeedback. The calling copilot process is
-                // expected to exit on its own after this command returns. We clear the
-                // PID so the reconciler doesn't try to verify a dead process.
-                session.Status = SessionStatus.WaitingForFeedback;
-                session.WaitingSince = DateTimeOffset.UtcNow;
-                session.ProcessId = null;
-                session.ProcessStartTime = null;
-                session.UpdatedAt = DateTimeOffset.UtcNow;
-                stateStore.SaveState(state);
+                stateStore.WithStateLock(() =>
+                {
+                    var state = stateStore.LoadState();
+                    if (!state.Sessions.TryGetValue(issueKey, out var session))
+                    {
+                        errorMessage = $"Comment posted on {issueKey}, but the session is no longer tracked.";
+                        return;
+                    }
+
+                    if (session.CopilotSessionId != expectedSessionId)
+                    {
+                        errorMessage = $"Comment posted on {issueKey}, but the session was reset before the wait state could be recorded.";
+                        return;
+                    }
+
+                    if (session.IsTerminal)
+                    {
+                        errorMessage = $"Comment posted on {issueKey}, but the session is already {session.Status.ToString().ToLowerInvariant()}.";
+                        return;
+                    }
+
+                    trackedProcess = CaptureTrackedProcess(session);
+                    session.Status = SessionStatus.WaitingForFeedback;
+                    session.WaitingSince = DateTimeOffset.UtcNow;
+                    ClearTrackedProcess(session);
+                    session.UpdatedAt = DateTimeOffset.UtcNow;
+                    stateStore.SaveState(state);
+                }, ct);
+
+                if (errorMessage is not null)
+                {
+                    ConsoleOutput.Error(errorMessage);
+                    return 1;
+                }
+
+                processManager.TerminateProcess(trackedProcess.Label, trackedProcess.ProcessId, trackedProcess.ProcessStartTime);
 
                 ConsoleOutput.Success($"Comment posted on {issueKey}. Session is now waiting for feedback.");
                 return 0;
@@ -303,28 +369,49 @@ public static class SessionCommand
             return await ConsoleOutput.RunWithErrorHandling(async () =>
             {
                 var stateStore = services.GetRequiredService<StateStore>();
-                var state = stateStore.LoadState();
+                var processManager = services.GetRequiredService<ProcessManager>();
 
                 var issueKey = parseResult.GetValue(issueArg)!;
+                var trackedProcess = default(TrackedProcessRef);
+                string? terminalStatus = null;
+                string? errorMessage = null;
 
-                if (!state.Sessions.TryGetValue(issueKey, out var session))
+                stateStore.WithStateLock(() =>
                 {
-                    ConsoleOutput.Error($"No session found for '{issueKey}'.");
+                    var state = stateStore.LoadState();
+                    if (!state.Sessions.TryGetValue(issueKey, out var session))
+                    {
+                        errorMessage = $"No session found for '{issueKey}'.";
+                        return;
+                    }
+
+                    if (session.IsTerminal)
+                    {
+                        terminalStatus = session.Status.ToString().ToLowerInvariant();
+                        return;
+                    }
+
+                    trackedProcess = CaptureTrackedProcess(session);
+                    session.Status = SessionStatus.Completed;
+                    session.CompletedBySession = true;
+                    ClearTrackedProcess(session);
+                    session.UpdatedAt = DateTimeOffset.UtcNow;
+                    stateStore.SaveState(state);
+                }, ct);
+
+                if (errorMessage is not null)
+                {
+                    ConsoleOutput.Error(errorMessage);
                     return 1;
                 }
 
-                if (session.IsTerminal)
+                if (terminalStatus is not null)
                 {
-                    ConsoleOutput.Info($"Session for '{issueKey}' is already {session.Status.ToString().ToLowerInvariant()}.");
+                    ConsoleOutput.Info($"Session for '{issueKey}' is already {terminalStatus}.");
                     return 0;
                 }
 
-                session.Status = SessionStatus.Completed;
-                session.CompletedBySession = true;
-                session.ProcessId = null;
-                session.ProcessStartTime = null;
-                session.UpdatedAt = DateTimeOffset.UtcNow;
-                stateStore.SaveState(state);
+                processManager.TerminateProcess(trackedProcess.Label, trackedProcess.ProcessId, trackedProcess.ProcessStartTime);
 
                 ConsoleOutput.Success($"Session for {issueKey} marked as completed.");
                 return 0;
@@ -352,22 +439,10 @@ public static class SessionCommand
             return await ConsoleOutput.RunWithErrorHandling(async () =>
             {
                 var stateStore = services.GetRequiredService<StateStore>();
-                var state = stateStore.LoadState();
+                var processManager = services.GetRequiredService<ProcessManager>();
 
                 var prNumber = parseResult.GetValue(prNumberArg);
                 var issueKey = parseResult.GetValue(issueArg)!;
-
-                if (!state.Sessions.TryGetValue(issueKey, out var session))
-                {
-                    ConsoleOutput.Error($"No session found for '{issueKey}'.");
-                    return 1;
-                }
-
-                if (session.IsTerminal)
-                {
-                    ConsoleOutput.Error($"Session for '{issueKey}' is already {session.Status.ToString().ToLowerInvariant()}.");
-                    return 1;
-                }
 
                 if (prNumber <= 0)
                 {
@@ -375,13 +450,40 @@ public static class SessionCommand
                     return 1;
                 }
 
-                session.PullRequestNumber = prNumber;
-                session.Status = SessionStatus.WaitingForReview;
-                session.WaitingSince = DateTimeOffset.UtcNow;
-                session.ProcessId = null;
-                session.ProcessStartTime = null;
-                session.UpdatedAt = DateTimeOffset.UtcNow;
-                stateStore.SaveState(state);
+                var trackedProcess = default(TrackedProcessRef);
+                string? errorMessage = null;
+
+                stateStore.WithStateLock(() =>
+                {
+                    var state = stateStore.LoadState();
+                    if (!state.Sessions.TryGetValue(issueKey, out var session))
+                    {
+                        errorMessage = $"No session found for '{issueKey}'.";
+                        return;
+                    }
+
+                    if (session.IsTerminal)
+                    {
+                        errorMessage = $"Session for '{issueKey}' is already {session.Status.ToString().ToLowerInvariant()}.";
+                        return;
+                    }
+
+                    trackedProcess = CaptureTrackedProcess(session);
+                    session.PullRequestNumber = prNumber;
+                    session.Status = SessionStatus.WaitingForReview;
+                    session.WaitingSince = DateTimeOffset.UtcNow;
+                    ClearTrackedProcess(session);
+                    session.UpdatedAt = DateTimeOffset.UtcNow;
+                    stateStore.SaveState(state);
+                }, ct);
+
+                if (errorMessage is not null)
+                {
+                    ConsoleOutput.Error(errorMessage);
+                    return 1;
+                }
+
+                processManager.TerminateProcess(trackedProcess.Label, trackedProcess.ProcessId, trackedProcess.ProcessStartTime);
 
                 ConsoleOutput.Success($"PR #{prNumber} associated with session for {issueKey}. Session is now waiting for review feedback.");
                 return 0;
@@ -407,40 +509,59 @@ public static class SessionCommand
             {
                 var stateStore = services.GetRequiredService<StateStore>();
                 var processManager = services.GetRequiredService<ProcessManager>();
-                var state = stateStore.LoadState();
                 var config = stateStore.LoadConfig();
 
                 var issueKey = parseResult.GetValue(issueArg)!;
+                var pending = false;
+                string? errorMessage = null;
+                string? newSessionId = null;
 
-                if (!state.Sessions.TryGetValue(issueKey, out var session))
+                stateStore.WithStateLock(() =>
                 {
-                    ConsoleOutput.Error($"No session found for '{issueKey}'.");
+                    var state = stateStore.LoadState();
+
+                    if (!state.Sessions.TryGetValue(issueKey, out var session))
+                    {
+                        errorMessage = $"No session found for '{issueKey}'.";
+                        return;
+                    }
+
+                    if (session.Status == SessionStatus.Pending)
+                    {
+                        pending = true;
+                        return;
+                    }
+
+                    processManager.TerminateProcess(session.IssueKey, session.ProcessId, session.ProcessStartTime);
+                    processManager.CleanupWorktree(session, config, state);
+
+                    session.Status = SessionStatus.Pending;
+                    session.CompletedBySession = false;
+                    session.PullRequestNumber = null;
+                    session.CopilotSessionId = Guid.NewGuid().ToString();
+                    ClearTrackedProcess(session);
+                    session.RetryCount = 0;
+                    session.RedispatchCount = 0;
+                    session.LastFailureAt = null;
+                    session.WaitingSince = null;
+                    session.UpdatedAt = DateTimeOffset.UtcNow;
+                    newSessionId = session.CopilotSessionId;
+                    stateStore.SaveState(state);
+                }, ct);
+
+                if (errorMessage is not null)
+                {
+                    ConsoleOutput.Error(errorMessage);
                     return 1;
                 }
 
-                if (session.Status == SessionStatus.Pending)
+                if (pending)
                 {
                     ConsoleOutput.Info($"Session for '{issueKey}' is already pending.");
                     return 0;
                 }
 
-                // Clean up old worktree before resetting
-                processManager.CleanupWorktree(session, config, state);
-
-                session.Status = SessionStatus.Pending;
-                session.CompletedBySession = false;
-                session.PullRequestNumber = null;
-                session.CopilotSessionId = Guid.NewGuid().ToString();
-                session.ProcessId = null;
-                session.ProcessStartTime = null;
-                session.RetryCount = 0;
-                session.RedispatchCount = 0;
-                session.LastFailureAt = null;
-                session.WaitingSince = null;
-                session.UpdatedAt = DateTimeOffset.UtcNow;
-                stateStore.SaveState(state);
-
-                ConsoleOutput.Success($"Session for {issueKey} reset to pending (new session {session.CopilotSessionId}).");
+                ConsoleOutput.Success($"Session for {issueKey} reset to pending (new session {newSessionId}).");
                 return 0;
             }, logger);
         });
@@ -457,37 +578,42 @@ public static class SessionCommand
     public static int RenderSessionList(StateStore stateStore, ProcessManager processManager,
         string? filterValue, bool showAll)
     {
-        var state = stateStore.LoadState();
-
-        // Recover stale Joined sessions — no PID or process dead
         var stateChanged = false;
-        foreach (var (key, s) in state.Sessions)
+        var state = stateStore.WithStateLock(() =>
         {
-            if (s.Status != SessionStatus.Joined)
-                continue;
+            var currentState = stateStore.LoadState();
 
-            var isStale = s.ProcessId is null;
-            if (!isStale)
+            // Recover stale Joined sessions — no PID or process dead
+            foreach (var (key, s) in currentState.Sessions)
             {
-                var liveness = processManager.CheckProcess(s);
-                isStale = liveness is ProcessLivenessResult.Dead or ProcessLivenessResult.PidReused;
-            }
+                if (s.Status != SessionStatus.Joined)
+                    continue;
 
-            if (isStale)
-            {
+                var isStale = s.ProcessId is null;
+                if (!isStale)
+                {
+                    var liveness = processManager.CheckProcess(s);
+                    isStale = liveness is ProcessLivenessResult.Dead or ProcessLivenessResult.PidReused;
+                }
+
+                if (!isStale)
+                    continue;
+
                 s.Status = SessionStatus.Pending;
-                s.ProcessId = null;
-                s.ProcessStartTime = null;
+                ClearTrackedProcess(s);
                 s.UpdatedAt = DateTimeOffset.UtcNow;
                 stateChanged = true;
                 ConsoleOutput.Warning($"Recovered stale joined session {key} → Pending");
             }
-        }
+
+            if (stateChanged)
+                stateStore.SaveState(currentState);
+
+            return currentState;
+        });
+
         if (stateChanged)
-        {
-            stateStore.SaveState(state);
             AnsiConsole.WriteLine();
-        }
 
         // Filter sessions
         SessionStatus? statusFilter = null;
@@ -601,22 +727,38 @@ public static class SessionCommand
     {
         try
         {
-            var state = stateStore.LoadState();
-            if (state.Sessions.TryGetValue(issueKey, out var session) &&
-                session.Status == SessionStatus.Joined)
+            stateStore.WithStateLock(() =>
             {
-                session.Status = SessionStatus.Pending;
-                session.ProcessId = null;
-                session.ProcessStartTime = null;
-                session.UpdatedAt = DateTimeOffset.UtcNow;
-                stateStore.SaveState(state);
-                ConsoleOutput.Info("Session re-queued for orchestrated dispatch.");
-            }
+                var state = stateStore.LoadState();
+                if (state.Sessions.TryGetValue(issueKey, out var session) &&
+                    session.Status == SessionStatus.Joined)
+                {
+                    session.Status = SessionStatus.Pending;
+                    ClearTrackedProcess(session);
+                    session.UpdatedAt = DateTimeOffset.UtcNow;
+                    stateStore.SaveState(state);
+                    ConsoleOutput.Info("Session re-queued for orchestrated dispatch.");
+                }
+            });
         }
         catch
         {
             // Best effort — if state save fails, the daemon's safety net
             // will detect the stale Joined session and reset it
         }
+    }
+
+    private static TrackedProcessRef CaptureTrackedProcess(DispatchSession session)
+        => new(session.IssueKey, session.ProcessId, session.ProcessStartTime);
+
+    private static void ClearTrackedProcess(DispatchSession session)
+    {
+        session.ProcessId = null;
+        session.ProcessStartTime = null;
+    }
+
+    private readonly record struct TrackedProcessRef(string Label, int? ProcessId, DateTimeOffset? ProcessStartTime)
+    {
+        public bool HasProcess => ProcessId is not null;
     }
 }

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -179,10 +179,17 @@ public sealed partial class ProcessManager
     /// Returns true if the process was successfully terminated or was already dead.
     /// </summary>
     public bool TerminateProcess(DispatchSession session)
+        => TerminateProcess(session.IssueKey, session.ProcessId, session.ProcessStartTime);
+
+    /// <summary>
+    /// Gracefully terminates a tracked copilot process using the saved PID and start time.
+    /// The label is used only for logging.
+    /// </summary>
+    public bool TerminateProcess(string processLabel, int? processId, DateTimeOffset? processStartTime)
     {
-        if (session.ProcessId is not { } pid)
+        if (processId is not { } pid)
         {
-            _logger.LogDebug("No PID tracked for {Key}, nothing to terminate", session.IssueKey);
+            _logger.LogDebug("No PID tracked for {ProcessLabel}, nothing to terminate", processLabel);
             return true;
         }
 
@@ -193,31 +200,31 @@ public sealed partial class ProcessManager
         }
         catch (ArgumentException)
         {
-            _logger.LogDebug("Process {Pid} for {Key} not found, already exited", pid, session.IssueKey);
+            _logger.LogDebug("Process {Pid} for {ProcessLabel} not found, already exited", pid, processLabel);
             return true;
         }
 
         try
         {
             // Verify start time to avoid terminating a different process that reused the PID
-            if (session.ProcessStartTime is { } expectedStart)
+            if (processStartTime is { } expectedStart)
             {
                 var actualStart = GetProcessStartTime(process);
                 if (actualStart is not null && Math.Abs((actualStart.Value - expectedStart).TotalSeconds) > 5)
                 {
-                    _logger.LogWarning("PID {Pid} for {Key} was reused by another process, skipping termination",
-                        pid, session.IssueKey);
+                    _logger.LogWarning("PID {Pid} for {ProcessLabel} was reused by another process, skipping termination",
+                        pid, processLabel);
                     return true;
                 }
             }
 
             if (process.HasExited)
             {
-                _logger.LogDebug("Process {Pid} for {Key} already exited", pid, session.IssueKey);
+                _logger.LogDebug("Process {Pid} for {ProcessLabel} already exited", pid, processLabel);
                 return true;
             }
 
-            _logger.LogInformation("Gracefully terminating copilot process {Pid} for {Key}", pid, session.IssueKey);
+            _logger.LogInformation("Gracefully terminating copilot process {Pid} for {ProcessLabel}", pid, processLabel);
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -230,7 +237,7 @@ public sealed partial class ProcessManager
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to terminate process {Pid} for {Key}", pid, session.IssueKey);
+            _logger.LogWarning(ex, "Failed to terminate process {Pid} for {ProcessLabel}", pid, processLabel);
             return false;
         }
         finally
@@ -416,7 +423,7 @@ public sealed partial class ProcessManager
             StartedAt = DateTimeOffset.UtcNow,
         };
 
-        var args = BuildControlSessionArguments(CopilotdConfig.ControlSessionPrompt, config.DefaultModel);
+        var args = BuildControlSessionArguments(session.CopilotSessionId, CopilotdConfig.ControlSessionPrompt, config.DefaultModel);
         _logger.LogInformation("Launching control session {SessionId}", session.CopilotSessionId);
         _logger.LogDebug("copilot {Args}", args);
 
@@ -494,69 +501,14 @@ public sealed partial class ProcessManager
     /// Gracefully terminates the control session process.
     /// </summary>
     public bool TerminateControlSession(ControlSessionInfo session)
-    {
-        if (session.ProcessId is not { } pid)
-        {
-            _logger.LogDebug("No PID tracked for control session, nothing to terminate");
-            return true;
-        }
+        => TerminateProcess("control session", session.ProcessId, session.ProcessStartTime);
 
-        Process process;
-        try
-        {
-            process = Process.GetProcessById(pid);
-        }
-        catch (ArgumentException)
-        {
-            _logger.LogDebug("Control session process {Pid} not found, already exited", pid);
-            return true;
-        }
-
-        try
-        {
-            if (session.ProcessStartTime is { } expectedStart)
-            {
-                var actualStart = GetProcessStartTime(process);
-                if (actualStart is not null && Math.Abs((actualStart.Value - expectedStart).TotalSeconds) > 5)
-                {
-                    _logger.LogWarning("Control session PID {Pid} was reused by another process, skipping termination", pid);
-                    return true;
-                }
-            }
-
-            if (process.HasExited)
-            {
-                _logger.LogDebug("Control session process {Pid} already exited", pid);
-                return true;
-            }
-
-            _logger.LogInformation("Gracefully terminating control session process {Pid}", pid);
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                return TerminateViaShutdownInstance(process, pid);
-            }
-            else
-            {
-                return TerminateViaSignals(process, pid);
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to terminate control session process {Pid}", pid);
-            return false;
-        }
-        finally
-        {
-            process.Dispose();
-        }
-    }
-
-    private static string BuildControlSessionArguments(string prompt, string? defaultModel)
+    private static string BuildControlSessionArguments(string sessionId, string prompt, string? defaultModel)
     {
         var args = new List<string>
         {
             "--remote",
+            $"--resume={sessionId}",
             "-i", $"\"{EscapeArg(prompt)}\"",
             // Only allow copilotd, gh, and git commands — no general shell access
             "--allow-tool=shell(copilotd:*)",

--- a/src/copilotd/Infrastructure/StateStore.cs
+++ b/src/copilotd/Infrastructure/StateStore.cs
@@ -16,6 +16,7 @@ public sealed class StateStore
     private readonly string _statePath;
     private readonly string _updateStatePath;
     private readonly string _lockPath;
+    private readonly string _stateLockPath;
     private readonly string _updateLockPath;
     private readonly string _pidPath;
     private readonly ILogger<StateStore> _logger;
@@ -33,6 +34,7 @@ public sealed class StateStore
         _statePath = Path.Combine(_configDir, "state.json");
         _updateStatePath = Path.Combine(_configDir, "update-state.json");
         _lockPath = Path.Combine(_configDir, ".lock");
+        _stateLockPath = Path.Combine(_configDir, ".state-lock");
         _updateLockPath = Path.Combine(_configDir, ".update-lock");
         _pidPath = Path.Combine(_configDir, ".pid");
         Directory.CreateDirectory(_configDir);
@@ -99,6 +101,23 @@ public sealed class StateStore
         AtomicWrite(_statePath, json);
         _logger.LogDebug("State saved to {Path}", _statePath);
     }
+
+    /// <summary>
+    /// Serializes state mutations across daemon and CLI commands so load-modify-save
+    /// sequences cannot overwrite each other.
+    /// </summary>
+    public T WithStateLock<T>(Func<T> action, CancellationToken ct = default)
+    {
+        using var lockStream = AcquireExclusiveLock(_stateLockPath, ct);
+        return action();
+    }
+
+    public void WithStateLock(Action action, CancellationToken ct = default)
+        => WithStateLock(() =>
+        {
+            action();
+            return 0;
+        }, ct);
 
     // --- Prompt ---
 
@@ -285,6 +304,29 @@ public sealed class StateStore
         var tmp = Path.Combine(dir, $".{Path.GetFileName(path)}.tmp");
         File.WriteAllText(tmp, content);
         File.Move(tmp, path, overwrite: true);
+    }
+
+    private FileStream AcquireExclusiveLock(string path, CancellationToken ct)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
+
+        while (true)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            try
+            {
+                return new FileStream(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+            }
+            catch (IOException ex)
+            {
+                if (DateTime.UtcNow >= deadline)
+                    throw new TimeoutException($"Timed out waiting to acquire state lock '{path}'.", ex);
+
+                if (ct.WaitHandle.WaitOne(TimeSpan.FromMilliseconds(100)))
+                    ct.ThrowIfCancellationRequested();
+            }
+        }
     }
 
     // --- Update state ---


### PR DESCRIPTION
## Summary
- serialize daemon and session state mutations with a dedicated state lock
- explicitly terminate tracked copilot processes when session lifecycle commands transition to waiting/completed states
- launch control sessions with a stable resume id and harden join/reset/shutdown cleanup paths

## Testing
- dotnet build src/copilotd/copilotd.csproj --nologo