### PR TITLE
Improve source-run callbacks and self-update behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ copilotd.cmd run            # Windows
 
 Convenience scripts `copilotd.sh` and `copilotd.cmd` in the repo root run the project from source via `dotnet run`, passing all arguments through.
 
+When running from source or a local repo publish, copilotd suppresses automatic background self-updates by default so local scenario verification is not interrupted by GitHub releases. You can still disable them explicitly with `COPILOTD_DISABLE_SELF_UPDATES=1` or `--disable-self-updates`, and `copilotd update --check` remains available to inspect update availability.
+
 ## Commands
 
 | Command | Description |

--- a/src/copilotd/Commands/RunCommand.cs
+++ b/src/copilotd/Commands/RunCommand.cs
@@ -15,9 +15,14 @@ public static class RunCommand
         var command = new Command("run", "Start the copilotd daemon");
         var intervalOption = new Option<int>("--interval") { Description = "Polling interval in seconds", DefaultValueFactory = _ => 60 };
         var logLevelOption = new Option<string?>("--log-level") { Description = "Set console logging level (default: info). Use 'debug' for more detail or 'error' for less." };
+        var disableSelfUpdatesOption = new Option<bool>("--disable-self-updates")
+        {
+            Description = $"Disable automatic background self-updates for this daemon run (also supported via {RuntimeContext.DisableSelfUpdatesEnvVar})."
+        };
 
         command.Options.Add(intervalOption);
         command.Options.Add(logLevelOption);
+        command.Options.Add(disableSelfUpdatesOption);
 
         command.SetAction(async (ParseResult parseResult, CancellationToken ct) =>
         {
@@ -29,8 +34,10 @@ public static class RunCommand
                 var stateStore = services.GetRequiredService<StateStore>();
                 var reconciliation = services.GetRequiredService<ReconciliationEngine>();
                 var processManager = services.GetRequiredService<ProcessManager>();
+                var runtimeContext = services.GetRequiredService<RuntimeContext>();
 
                 var interval = parseResult.GetValue(intervalOption);
+                var disableSelfUpdates = runtimeContext.IsAutomaticSelfUpdateDisabled(parseResult.GetValue(disableSelfUpdatesOption));
 
                 // Pre-flight checks
                 var preflightResult = PreflightChecks.Run(ghCli, copilotCli, stateStore);
@@ -51,6 +58,8 @@ public static class RunCommand
                 try
                 {
                     ConsoleOutput.Success($"copilotd daemon started (polling every {interval}s). Press Ctrl+C to stop.");
+                    if (disableSelfUpdates && runtimeContext.GetAutomaticSelfUpdateDisableReason(parseResult.GetValue(disableSelfUpdatesOption)) is { } reason)
+                        ConsoleOutput.Info($"Automatic self-updates {reason}.");
 
                     // Startup reconciliation pass
                     var config = stateStore.LoadConfig();
@@ -184,42 +193,43 @@ public static class RunCommand
                                 }
                             }, cts.Token);
 
-                            // Self-update: check for staged update or fire background check
-                            var updateState = stateStore.LoadUpdateState();
-                            if (updateState.Status == UpdateStatus.Staged
-                                && !string.IsNullOrEmpty(updateState.StagedPath)
-                                && File.Exists(updateState.StagedPath))
+                            if (!disableSelfUpdates)
                             {
-                                // Staged update ready — spawn install process and exit daemon
-                                ConsoleOutput.Info($"Staged update {updateState.StagedVersion} detected, initiating install...");
-                                logger.LogInformation("Spawning update installer for staged version {Version}", updateState.StagedVersion);
-                                if (SpawnUpdateInstaller(logger))
+                                // Self-update: check for staged update or fire background check
+                                var updateState = stateStore.LoadUpdateState();
+                                if (updateState.Status == UpdateStatus.Staged
+                                    && !string.IsNullOrEmpty(updateState.StagedPath)
+                                    && File.Exists(updateState.StagedPath))
                                 {
-                                    cts.Cancel();
-                                    break;
-                                }
-                                else
-                                {
+                                    // Staged update ready — spawn install process and exit daemon
+                                    ConsoleOutput.Info($"Staged update {updateState.StagedVersion} detected, initiating install...");
+                                    logger.LogInformation("Spawning update installer for staged version {Version}", updateState.StagedVersion);
+                                    if (SpawnUpdateInstaller(runtimeContext, logger))
+                                    {
+                                        cts.Cancel();
+                                        break;
+                                    }
+
                                     ConsoleOutput.Warning("Failed to spawn update installer, will retry next cycle.");
                                 }
-                            }
 
-                            // Fire non-blocking update check/stage (runs in background, result picked up next cycle)
-                            _ = Task.Run(async () =>
-                            {
-                                try
+                                // Fire non-blocking update check/stage (runs in background, result picked up next cycle)
+                                _ = Task.Run(async () =>
                                 {
-                                    await updateService.CheckAndStageAsync(
-                                        allowPreRelease: false,
-                                        skipProvenance: false,
-                                        cts.Token);
-                                }
-                                catch (OperationCanceledException) { }
-                                catch (Exception ex)
-                                {
-                                    logger.LogDebug(ex, "Background update check failed");
-                                }
-                            }, cts.Token);
+                                    try
+                                    {
+                                        await updateService.CheckAndStageAsync(
+                                            allowPreRelease: false,
+                                            skipProvenance: false,
+                                            cts.Token);
+                                    }
+                                    catch (OperationCanceledException) { }
+                                    catch (Exception ex)
+                                    {
+                                        logger.LogDebug(ex, "Background update check failed");
+                                    }
+                                }, cts.Token);
+                            }
                         }
                         catch (Exception ex)
                         {
@@ -283,27 +293,27 @@ public static class RunCommand
     /// Unix: setsid for session detachment, with fallback to direct Process.Start.
     /// Returns true if the process was successfully spawned.
     /// </summary>
-    private static bool SpawnUpdateInstaller(ILogger logger)
+    private static bool SpawnUpdateInstaller(RuntimeContext runtimeContext, ILogger logger)
     {
-        var exePath = Environment.ProcessPath;
-        if (exePath is null)
+        var invocation = runtimeContext.GetSelfInvocation("update --install-staged");
+        if (invocation is null)
         {
             logger.LogError("Cannot determine executable path for update installer");
             return false;
         }
 
-        var commandLine = $"\"{exePath}\" update --install-staged";
+        var commandLine = invocation.GetCommandLine();
         logger.LogDebug("Spawning update installer: {CommandLine}", commandLine);
 
         if (OperatingSystem.IsWindows())
-            return SpawnUpdateInstallerWindows(exePath, logger);
+            return SpawnUpdateInstallerWindows(invocation, logger);
 
-        return SpawnUpdateInstallerUnix(exePath, logger);
+        return SpawnUpdateInstallerUnix(invocation, logger);
     }
 
-    private static bool SpawnUpdateInstallerWindows(string exePath, ILogger logger)
+    private static bool SpawnUpdateInstallerWindows(CommandInvocation invocation, ILogger logger)
     {
-        var commandLine = $"\"{exePath}\" update --install-staged";
+        var commandLine = invocation.GetCommandLine();
 
         var si = new NativeInterop.STARTUPINFO { cb = System.Runtime.InteropServices.Marshal.SizeOf<NativeInterop.STARTUPINFO>() };
         si.dwFlags = NativeInterop.STARTF_USESHOWWINDOW;
@@ -337,13 +347,13 @@ public static class RunCommand
     /// Spawns the update installer as a detached process on Unix using setsid,
     /// mirroring the pattern used by <see cref="StartCommand"/>.
     /// </summary>
-    private static bool SpawnUpdateInstallerUnix(string exePath, ILogger logger)
+    private static bool SpawnUpdateInstallerUnix(CommandInvocation invocation, ILogger logger)
     {
         // Try setsid first for full session detachment
         var psi = new ProcessStartInfo
         {
             FileName = "setsid",
-            Arguments = $"\"{exePath}\" update --install-staged",
+            Arguments = invocation.GetCommandLine(),
             UseShellExecute = false,
             RedirectStandardInput = true,
             RedirectStandardOutput = true,
@@ -370,8 +380,8 @@ public static class RunCommand
         // Fallback: direct process launch
         var fallbackPsi = new ProcessStartInfo
         {
-            FileName = exePath,
-            Arguments = "update --install-staged",
+            FileName = invocation.FileName,
+            Arguments = invocation.Arguments,
             UseShellExecute = false,
             RedirectStandardInput = true,
             RedirectStandardOutput = true,

--- a/src/copilotd/Commands/StartCommand.cs
+++ b/src/copilotd/Commands/StartCommand.cs
@@ -20,9 +20,14 @@ public static class StartCommand
         var command = new Command("start", "Start the copilotd daemon in the background");
         var intervalOption = new Option<int>("--interval") { Description = "Polling interval in seconds", DefaultValueFactory = _ => 60 };
         var logLevelOption = new Option<string?>("--log-level") { Description = "Set logging level (default: info). Use 'debug' for more detail or 'error' for less." };
+        var disableSelfUpdatesOption = new Option<bool>("--disable-self-updates")
+        {
+            Description = $"Disable automatic background self-updates for the started daemon (also supported via {RuntimeContext.DisableSelfUpdatesEnvVar})."
+        };
 
         command.Options.Add(intervalOption);
         command.Options.Add(logLevelOption);
+        command.Options.Add(disableSelfUpdatesOption);
 
         command.SetAction(async (ParseResult parseResult, CancellationToken ct) =>
         {
@@ -32,9 +37,11 @@ public static class StartCommand
                 var ghCli = services.GetRequiredService<GhCliService>();
                 var copilotCli = services.GetRequiredService<CopilotCliService>();
                 var stateStore = services.GetRequiredService<StateStore>();
+                var runtimeContext = services.GetRequiredService<RuntimeContext>();
 
                 var interval = parseResult.GetValue(intervalOption);
                 var logLevel = parseResult.GetValue(logLevelOption);
+                var disableSelfUpdates = parseResult.GetValue(disableSelfUpdatesOption);
 
                 // Pre-flight checks
                 var preflightResult = PreflightChecks.Run(ghCli, copilotCli, stateStore);
@@ -54,9 +61,13 @@ public static class StartCommand
                 {
                     args += $" --log-level {logLevel}";
                 }
+                if (disableSelfUpdates)
+                {
+                    args += " --disable-self-updates";
+                }
 
-                var copilotdPath = Environment.ProcessPath;
-                if (copilotdPath is null)
+                var invocation = runtimeContext.GetSelfInvocation(args);
+                if (invocation is null)
                 {
                     ConsoleOutput.Error("Cannot determine copilotd executable path.");
                     return 1;
@@ -66,11 +77,11 @@ public static class StartCommand
                 int childPid;
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
-                    childPid = LaunchDetachedWindows(copilotdPath, args);
+                    childPid = LaunchDetachedWindows(invocation);
                 }
                 else
                 {
-                    childPid = LaunchDetachedUnix(copilotdPath, args);
+                    childPid = LaunchDetachedUnix(invocation);
                 }
 
                 if (childPid <= 0)
@@ -130,7 +141,7 @@ public static class StartCommand
                     return 1;
                 }
 
-                ConsoleOutput.Success($"copilotd daemon started in background (PID: {childPid}). Use 'copilotd stop' to shut down.");
+                ConsoleOutput.Success($"copilotd daemon started in background (PID: {childPid}). Use '{runtimeContext.GetCopilotdCallbackCommand()} stop' to shut down.");
                 return 0;
             }, logger);
         });
@@ -142,13 +153,13 @@ public static class StartCommand
     /// Windows: use CreateProcessW with CREATE_NEW_CONSOLE to give the daemon its own
     /// console (hidden). This is required for shutdown-instance to attach and send signals.
     /// </summary>
-    private static int LaunchDetachedWindows(string exePath, string args)
+    private static int LaunchDetachedWindows(CommandInvocation invocation)
     {
         var si = new STARTUPINFO { cb = Marshal.SizeOf<STARTUPINFO>() };
         si.dwFlags = STARTF_USESHOWWINDOW;
         si.wShowWindow = SW_HIDE;
 
-        var cmdLine = $"\"{exePath}\" {args}";
+        var cmdLine = invocation.GetCommandLine();
         var flags = CREATE_NEW_CONSOLE | CREATE_NEW_PROCESS_GROUP;
 
         if (!CreateProcessW(null, cmdLine, IntPtr.Zero, IntPtr.Zero, false,
@@ -167,12 +178,12 @@ public static class StartCommand
     /// Unix: use setsid to create a new session, detaching from the terminal.
     /// Stdin/stdout/stderr are redirected to /dev/null.
     /// </summary>
-    private static int LaunchDetachedUnix(string exePath, string args)
+    private static int LaunchDetachedUnix(CommandInvocation invocation)
     {
         var psi = new ProcessStartInfo
         {
             FileName = "setsid",
-            Arguments = $"\"{exePath}\" {args}",
+            Arguments = invocation.GetCommandLine(),
             UseShellExecute = false,
             RedirectStandardInput = true,
             RedirectStandardOutput = true,
@@ -202,8 +213,8 @@ public static class StartCommand
             // setsid not available, fall back to direct launch
             var fallbackPsi = new ProcessStartInfo
             {
-                FileName = exePath,
-                Arguments = args,
+                FileName = invocation.FileName,
+                Arguments = invocation.Arguments,
                 UseShellExecute = false,
                 RedirectStandardInput = true,
                 RedirectStandardOutput = true,

--- a/src/copilotd/Commands/StopCommand.cs
+++ b/src/copilotd/Commands/StopCommand.cs
@@ -24,6 +24,7 @@ public static class StopCommand
             return await ConsoleOutput.RunWithErrorHandling(async () =>
             {
                 var stateStore = services.GetRequiredService<StateStore>();
+                var runtimeContext = services.GetRequiredService<RuntimeContext>();
 
                 // Check if daemon is running
                 if (!stateStore.IsLockHeld())
@@ -37,7 +38,7 @@ public static class StopCommand
                 if (pidInfo is null)
                 {
                     ConsoleOutput.Error("Daemon appears to be running but PID file is missing. Cannot send shutdown signal.");
-                    ConsoleOutput.Info("If the daemon was started with 'copilotd run', press Ctrl+C in that terminal instead.");
+                    ConsoleOutput.Info($"If the daemon was started with '{runtimeContext.GetCopilotdCallbackCommand()} run', press Ctrl+C in that terminal instead.");
                     return 1;
                 }
 
@@ -83,7 +84,7 @@ public static class StopCommand
                     bool terminated;
                     if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                     {
-                        terminated = StopDaemonWindows(process, pid);
+                        terminated = StopDaemonWindows(process, pid, runtimeContext);
                     }
                     else
                     {
@@ -120,10 +121,10 @@ public static class StopCommand
     /// Windows: use the shutdown-instance helper to attach to the daemon's console
     /// and send Ctrl+Break/Ctrl+C, triggering Console.CancelKeyPress in the daemon.
     /// </summary>
-    private static bool StopDaemonWindows(Process process, int pid)
+    private static bool StopDaemonWindows(Process process, int pid, RuntimeContext runtimeContext)
     {
-        var copilotdPath = Environment.ProcessPath;
-        if (copilotdPath is null)
+        var invocation = runtimeContext.GetSelfInvocation($"shutdown-instance --pid {pid}");
+        if (invocation is null)
         {
             ConsoleOutput.Warning("Cannot determine copilotd path, forcing termination.");
             return FallbackKill(process);
@@ -131,8 +132,8 @@ public static class StopCommand
 
         var psi = new ProcessStartInfo
         {
-            FileName = copilotdPath,
-            Arguments = $"shutdown-instance --pid {pid}",
+            FileName = invocation.FileName,
+            Arguments = invocation.Arguments,
             UseShellExecute = false,
             CreateNoWindow = true,
         };

--- a/src/copilotd/Commands/UpdateCommand.cs
+++ b/src/copilotd/Commands/UpdateCommand.cs
@@ -54,6 +54,7 @@ public static class UpdateCommand
             {
                 var updateService = services.GetRequiredService<UpdateService>();
                 var stateStore = services.GetRequiredService<StateStore>();
+                var runtimeContext = services.GetRequiredService<RuntimeContext>();
 
                 var check = parseResult.GetValue(checkOption);
                 var preRelease = parseResult.GetValue(preReleaseOption);
@@ -74,6 +75,12 @@ public static class UpdateCommand
 
                 if (installStaged)
                 {
+                    if (!runtimeContext.SupportsInPlaceSelfUpdate() && runtimeContext.GetUnsupportedSelfUpdateReason() is { } reason)
+                    {
+                        ConsoleOutput.Error(reason);
+                        return 1;
+                    }
+
                     if (dryRun)
                     {
                         ConsoleOutput.Info("[dry-run] Would install staged update.");
@@ -85,6 +92,12 @@ public static class UpdateCommand
                 if (check)
                 {
                     return HandleCheckOnly(updateService, preRelease);
+                }
+
+                if (!runtimeContext.SupportsInPlaceSelfUpdate() && runtimeContext.GetUnsupportedSelfUpdateReason() is { } unsupportedReason)
+                {
+                    ConsoleOutput.Error(unsupportedReason);
+                    return 1;
                 }
 
                 return await HandleFullUpdate(updateService, stateStore, preRelease, skipProvenance, dryRun, ct);

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -17,12 +17,14 @@ public sealed partial class ProcessManager
 
     private readonly StateStore _stateStore;
     private readonly RepoPathResolver _repoResolver;
+    private readonly RuntimeContext _runtimeContext;
     private readonly ILogger<ProcessManager> _logger;
 
-    public ProcessManager(StateStore stateStore, RepoPathResolver repoResolver, ILogger<ProcessManager> logger)
+    public ProcessManager(StateStore stateStore, RepoPathResolver repoResolver, RuntimeContext runtimeContext, ILogger<ProcessManager> logger)
     {
         _stateStore = stateStore;
         _repoResolver = repoResolver;
+        _runtimeContext = runtimeContext;
         _logger = logger;
     }
 
@@ -41,8 +43,14 @@ public sealed partial class ProcessManager
         }
 
         var customPrompt = _stateStore.LoadCustomPrompt(config);
-        var prompt = BuildPrompt(customPrompt, issue, session, config);
-        var args = BuildArguments(session, prompt, config.Rules.GetValueOrDefault(session.RuleName), repoPath, config.DefaultModel);
+        var prompt = BuildPrompt(customPrompt, issue, session, config, _runtimeContext.GetCopilotdCallbackCommand());
+        var args = BuildArguments(
+            session,
+            prompt,
+            config.Rules.GetValueOrDefault(session.RuleName),
+            repoPath,
+            config.DefaultModel,
+            _runtimeContext.GetExtraAllowedDirectories());
 
         _logger.LogInformation("Launching copilot for {IssueKey} with session {SessionId}", session.IssueKey, session.CopilotSessionId);
         _logger.LogDebug("copilot {Args}", args);
@@ -253,8 +261,8 @@ public sealed partial class ProcessManager
     /// </summary>
     private bool TerminateViaShutdownInstance(Process process, int pid)
     {
-        var copilotdPath = Environment.ProcessPath;
-        if (copilotdPath is null)
+        var invocation = _runtimeContext.GetSelfInvocation($"shutdown-instance --pid {pid}");
+        if (invocation is null)
         {
             _logger.LogWarning("Cannot determine copilotd executable path, falling back to kill");
             process.Kill(entireProcessTree: true);
@@ -265,8 +273,8 @@ public sealed partial class ProcessManager
 
         var psi = new ProcessStartInfo
         {
-            FileName = copilotdPath,
-            Arguments = $"shutdown-instance --pid {pid}",
+            FileName = invocation.FileName,
+            Arguments = invocation.Arguments,
             UseShellExecute = false,
             CreateNoWindow = true,
         };
@@ -423,7 +431,9 @@ public sealed partial class ProcessManager
             StartedAt = DateTimeOffset.UtcNow,
         };
 
-        var args = BuildControlSessionArguments(session.CopilotSessionId, CopilotdConfig.ControlSessionPrompt, config.DefaultModel);
+        var prompt = CopilotdConfig.ControlSessionPrompt
+            .Replace("$(copilotd.command)", _runtimeContext.GetCopilotdCallbackCommand(), StringComparison.Ordinal);
+        var args = BuildControlSessionArguments(session.CopilotSessionId, prompt, config.DefaultModel, _runtimeContext);
         _logger.LogInformation("Launching control session {SessionId}", session.CopilotSessionId);
         _logger.LogDebug("copilot {Args}", args);
 
@@ -503,23 +513,29 @@ public sealed partial class ProcessManager
     public bool TerminateControlSession(ControlSessionInfo session)
         => TerminateProcess("control session", session.ProcessId, session.ProcessStartTime);
 
-    private static string BuildControlSessionArguments(string sessionId, string prompt, string? defaultModel)
+    private static string BuildControlSessionArguments(string sessionId, string prompt, string? defaultModel, RuntimeContext runtimeContext)
     {
         var args = new List<string>
         {
             "--remote",
             $"--resume={sessionId}",
             "-i", $"\"{EscapeArg(prompt)}\"",
-            // Only allow copilotd, gh, and git commands — no general shell access
-            "--allow-tool=shell(copilotd:*)",
-            "--allow-tool=shell(gh:*)",
-            "--allow-tool=shell(git:*)",
         };
+
+        // Only allow the commands needed to manage the daemon remotely — no general shell access.
+        foreach (var command in runtimeContext.GetControlSessionAllowedShellCommands().Distinct(StringComparer.OrdinalIgnoreCase))
+            args.Add($"--allow-tool=shell({command}:*)");
 
         if (!string.IsNullOrWhiteSpace(defaultModel))
         {
             args.Add("--model");
             args.Add($"\"{EscapeArg(defaultModel)}\"");
+        }
+
+        foreach (var extraDir in runtimeContext.GetExtraAllowedDirectories().Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            args.Add("--add-dir");
+            args.Add($"\"{EscapeArg(extraDir)}\"");
         }
 
         return string.Join(' ', args);
@@ -599,7 +615,7 @@ public sealed partial class ProcessManager
         }
     }
 
-    private static string BuildPrompt(string globalCustomPrompt, GitHubIssue issue, DispatchSession session, CopilotdConfig config)
+    private static string BuildPrompt(string globalCustomPrompt, GitHubIssue issue, DispatchSession session, CopilotdConfig config, string copilotdCommand)
     {
         // Use a PR-specific prompt when re-dispatching for review feedback
         var prompt = session.PullRequestNumber is not null
@@ -629,6 +645,7 @@ public sealed partial class ProcessManager
 
         // Replace tokens in the entire prompt (default + custom + extra)
         prompt = prompt
+            .Replace("$(copilotd.command)", copilotdCommand, StringComparison.Ordinal)
             .Replace("$(issue.repo)", issue.Repo)
             .Replace("$(issue.id)", issue.Number.ToString())
             .Replace("$(issue.type)", issue.Type ?? "issue")
@@ -652,8 +669,8 @@ public sealed partial class ProcessManager
             - Address each review comment by making the requested changes.
             - If a review comment includes a suggested change (```suggestion block), apply it directly to the relevant file.
             - After addressing all review feedback, push your changes to update the PR.
-            - Then run `copilotd session pr $(pr.id) $(issue.repo)#$(issue.id)` to continue monitoring for further review feedback.
-            - If the changes are complete and no more reviews are expected, run `copilotd session complete $(issue.repo)#$(issue.id)` instead.
+            - Then run `$(copilotd.command) session pr $(pr.id) $(issue.repo)#$(issue.id)` to continue monitoring for further review feedback.
+            - If the changes are complete and no more reviews are expected, run `$(copilotd.command) session complete $(issue.repo)#$(issue.id)` instead.
 
             Interacting with the PR:
             - To post a general comment on the PR: `gh pr comment $(pr.id) --repo $(issue.repo) --body "Your comment"`
@@ -662,7 +679,7 @@ public sealed partial class ProcessManager
               gh api graphql -f query='mutation { addPullRequestReviewThreadReply(input: { pullRequestReviewThreadId: "THREAD_ID", body: "Your reply" }) { comment { id } } }'
               ```
               You can find thread IDs by querying: `gh api graphql -f query='{ repository(owner: "OWNER", name: "REPO") { pullRequest(number: $(pr.id)) { reviewThreads(last: 20) { nodes { id isResolved comments(last: 5) { nodes { body author { login } } } } } } } }'`
-            - Do NOT use `copilotd session comment` to post to the issue when in PR review mode. All communication should happen on the PR itself.
+            - Do NOT use `$(copilotd.command) session comment` to post to the issue when in PR review mode. All communication should happen on the PR itself.
             """;
     }
 
@@ -689,7 +706,7 @@ public sealed partial class ProcessManager
         };
     }
 
-    private static string BuildArguments(DispatchSession session, string prompt, DispatchRule? rule, string repoPath, string? defaultModel)
+    private static string BuildArguments(DispatchSession session, string prompt, DispatchRule? rule, string repoPath, string? defaultModel, IEnumerable<string> extraAllowedDirectories)
     {
         var args = new List<string>
         {
@@ -725,6 +742,15 @@ public sealed partial class ProcessManager
         // Always add the repo directory as an allowed path
         args.Add("--add-dir");
         args.Add($"\"{EscapeArg(repoPath)}\"");
+
+        var normalizedRepoPath = Path.GetFullPath(repoPath);
+        foreach (var extraDir in extraAllowedDirectories
+                     .Where(dir => !string.Equals(Path.GetFullPath(dir), normalizedRepoPath, StringComparison.OrdinalIgnoreCase))
+                     .Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            args.Add("--add-dir");
+            args.Add($"\"{EscapeArg(extraDir)}\"");
+        }
 
         return string.Join(' ', args);
     }

--- a/src/copilotd/Infrastructure/RuntimeContext.cs
+++ b/src/copilotd/Infrastructure/RuntimeContext.cs
@@ -1,0 +1,154 @@
+namespace Copilotd.Infrastructure;
+
+/// <summary>
+/// Detects how copilotd is being run so commands, helper processes, and automatic
+/// update policy can adapt to installed binaries, source-tree runs, and local publishes.
+/// </summary>
+public sealed class RuntimeContext
+{
+    public const string DisableSelfUpdatesEnvVar = "COPILOTD_DISABLE_SELF_UPDATES";
+
+    public RuntimeContext()
+    {
+        ProcessPath = Environment.ProcessPath;
+        SourceRoot = FindSourceRoot();
+        SourceProjectPath = SourceRoot is null ? null : Path.Combine(SourceRoot, "src", "copilotd");
+    }
+
+    public string? ProcessPath { get; }
+
+    public string? SourceRoot { get; }
+
+    public string? SourceProjectPath { get; }
+
+    public bool IsDotnetHosted =>
+        string.Equals(Path.GetFileName(ProcessPath), "dotnet", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(Path.GetFileName(ProcessPath), "dotnet.exe", StringComparison.OrdinalIgnoreCase);
+
+    public bool IsSourceTreeRun => SourceProjectPath is not null;
+
+    public string GetCopilotdCallbackCommand()
+    {
+        if (IsDotnetHosted && !string.IsNullOrEmpty(SourceProjectPath))
+            return $"dotnet run --project \"{SourceProjectPath}\" --";
+
+        if (IsSourceTreeRun && !string.IsNullOrEmpty(ProcessPath))
+            return $"\"{ProcessPath}\"";
+
+        return "copilotd";
+    }
+
+    public IEnumerable<string> GetExtraAllowedDirectories()
+    {
+        if (!string.IsNullOrEmpty(SourceRoot))
+            yield return SourceRoot;
+    }
+
+    public IEnumerable<string> GetControlSessionAllowedShellCommands()
+    {
+        if (IsDotnetHosted && !string.IsNullOrEmpty(SourceProjectPath))
+            yield return "dotnet";
+        else
+            yield return "copilotd";
+
+        yield return "gh";
+        yield return "git";
+    }
+
+    public bool IsAutomaticSelfUpdateDisabled(bool disableRequested)
+        => disableRequested || IsSelfUpdateDisabledByEnvironment() || IsSourceTreeRun;
+
+    public string? GetAutomaticSelfUpdateDisableReason(bool disableRequested)
+    {
+        if (disableRequested)
+            return "disabled by --disable-self-updates";
+
+        if (IsSelfUpdateDisabledByEnvironment())
+            return $"disabled by {DisableSelfUpdatesEnvVar}";
+
+        if (IsSourceTreeRun)
+            return "disabled for source/dev runs";
+
+        return null;
+    }
+
+    public bool SupportsInPlaceSelfUpdate()
+        => !IsDotnetHosted && !string.IsNullOrEmpty(ProcessPath);
+
+    public string? GetUnsupportedSelfUpdateReason()
+        => IsDotnetHosted
+            ? "Self-update is not supported when running copilotd via dotnet run. Publish or install a copilotd binary to test updates."
+            : null;
+
+    public CommandInvocation? GetSelfInvocation(string arguments)
+    {
+        if (IsDotnetHosted && !string.IsNullOrEmpty(SourceProjectPath))
+        {
+            var prefix = $"run --project \"{SourceProjectPath}\" --";
+            var resolvedArguments = string.IsNullOrWhiteSpace(arguments)
+                ? prefix
+                : $"{prefix} {arguments}";
+            return new CommandInvocation(ProcessPath ?? "dotnet", resolvedArguments);
+        }
+
+        if (string.IsNullOrEmpty(ProcessPath))
+            return null;
+
+        return new CommandInvocation(ProcessPath, arguments);
+    }
+
+    private static bool IsSelfUpdateDisabledByEnvironment()
+    {
+        var value = Environment.GetEnvironmentVariable(DisableSelfUpdatesEnvVar);
+        return value is not null
+            && (string.Equals(value, "1", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(value, "true", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(value, "yes", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(value, "on", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string? FindSourceRoot()
+    {
+        foreach (var candidate in GetSearchRoots())
+        {
+            for (var dir = candidate; dir is not null; dir = Directory.GetParent(dir)?.FullName)
+            {
+                if (LooksLikeSourceRoot(dir))
+                    return dir;
+            }
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<string> GetSearchRoots()
+    {
+        yield return Directory.GetCurrentDirectory();
+        yield return AppContext.BaseDirectory;
+
+        if (!string.IsNullOrEmpty(Environment.ProcessPath))
+        {
+            var processDir = Path.GetDirectoryName(Environment.ProcessPath);
+            if (!string.IsNullOrEmpty(processDir))
+                yield return processDir;
+        }
+    }
+
+    private static bool LooksLikeSourceRoot(string path)
+    {
+        var projectPath = Path.Combine(path, "src", "copilotd", "copilotd.csproj");
+        if (!File.Exists(projectPath))
+            return false;
+
+        return File.Exists(Path.Combine(path, "copilotd.cmd"))
+            || File.Exists(Path.Combine(path, "copilotd.sh"));
+    }
+}
+
+public sealed record CommandInvocation(string FileName, string Arguments)
+{
+    public string GetCommandLine()
+        => string.IsNullOrWhiteSpace(Arguments)
+            ? $"\"{FileName}\""
+            : $"\"{FileName}\" {Arguments}";
+}

--- a/src/copilotd/Infrastructure/StateStore.cs
+++ b/src/copilotd/Infrastructure/StateStore.cs
@@ -166,7 +166,9 @@ public sealed class StateStore
     /// should be treated as "no custom prompt" rather than appended content.
     /// </summary>
     private static bool IsDefaultPrompt(string content)
-        => NormalizeForComparison(content) == NormalizeForComparison(CopilotdConfig.DefaultPrompt);
+        => GetDefaultPromptVariants()
+            .Select(NormalizeForComparison)
+            .Any(defaultPrompt => NormalizeForComparison(content) == defaultPrompt);
 
     /// <summary>
     /// If the content starts with the default prompt (e.g. a user appended to the old
@@ -175,15 +177,23 @@ public sealed class StateStore
     private static string StripDefaultPromptPrefix(string content)
     {
         var normalizedContent = NormalizeForComparison(content);
-        var normalizedDefault = NormalizeForComparison(CopilotdConfig.DefaultPrompt);
-
-        if (normalizedContent.StartsWith(normalizedDefault, StringComparison.Ordinal))
+        foreach (var defaultPrompt in GetDefaultPromptVariants())
         {
-            var remainder = content.Trim()[CopilotdConfig.DefaultPrompt.Trim().Length..].Trim();
-            return remainder;
+            var normalizedDefault = NormalizeForComparison(defaultPrompt);
+            if (normalizedContent.StartsWith(normalizedDefault, StringComparison.Ordinal))
+            {
+                var remainder = content.Trim()[defaultPrompt.Trim().Length..].Trim();
+                return remainder;
+            }
         }
 
         return content;
+    }
+
+    private static IEnumerable<string> GetDefaultPromptVariants()
+    {
+        yield return CopilotdConfig.DefaultPrompt;
+        yield return CopilotdConfig.DefaultPrompt.Replace("$(copilotd.command)", "copilotd", StringComparison.Ordinal);
     }
 
     private static string NormalizeForComparison(string s)

--- a/src/copilotd/Models/CopilotdConfig.cs
+++ b/src/copilotd/Models/CopilotdConfig.cs
@@ -96,10 +96,10 @@ public sealed class CopilotdConfig
         If you have enough information to implement the requested changes:
         - You are already on a new branch created for this issue. Commit your changes here.
         - When your work is complete, push the branch and create a pull request that references the issue (e.g., "Closes #$(issue.id)").
-        - After the pull request is created, run `copilotd session pr <pr-number> $(issue.repo)#$(issue.id)` to enable automatic review feedback handling (replace <pr-number> with the actual PR number).
+        - After the pull request is created, run `$(copilotd.command) session pr <pr-number> $(issue.repo)#$(issue.id)` to enable automatic review feedback handling (replace <pr-number> with the actual PR number).
 
         If you need more information or clarification before proceeding:
-        - Run `copilotd session comment $(issue.repo)#$(issue.id) --message "Your question or findings here"` to post a comment on the issue.
+        - Run `$(copilotd.command) session comment $(issue.repo)#$(issue.id) --message "Your question or findings here"` to post a comment on the issue.
         - This will pause your session until a response is posted on the issue, at which point your session will automatically resume.
         """;
 
@@ -110,21 +110,21 @@ public sealed class CopilotdConfig
         matching configured rules. You help the user monitor and manage copilotd remotely.
 
         AVAILABLE COMMANDS (run these in the terminal):
-        - `copilotd status`                          — Show daemon health, watched repos, and session summary
-        - `copilotd session list [--all]`             — List active sessions (--all includes completed/failed)
-        - `copilotd session list --filter <status>`   — Filter by status: pending, running, completed, failed, orphaned, joined, waitingforfeedback, waitingforreview
-        - `copilotd session reset <issue>`            — Reset a session for re-dispatch (e.g., "org/repo#42")
-        - `copilotd session complete <issue>`         — Mark a session as completed
-        - `copilotd session comment <issue> --message "text"` — Post a comment on the issue and pause the session
-        - `copilotd session pr <pr-number> <issue>`   — Associate a PR with a session for review monitoring
-        - `copilotd rules list`                       — Show configured dispatch rules
-        - `copilotd config`                           — Show current configuration
+        - `$(copilotd.command) status`                          — Show daemon health, watched repos, and session summary
+        - `$(copilotd.command) session list [--all]`             — List active sessions (--all includes completed/failed)
+        - `$(copilotd.command) session list --filter <status>`   — Filter by status: pending, running, completed, failed, orphaned, joined, waitingforfeedback, waitingforreview
+        - `$(copilotd.command) session reset <issue>`            — Reset a session for re-dispatch (e.g., "org/repo#42")
+        - `$(copilotd.command) session complete <issue>`         — Mark a session as completed
+        - `$(copilotd.command) session comment <issue> --message "text"` — Post a comment on the issue and pause the session
+        - `$(copilotd.command) session pr <pr-number> <issue>`   — Associate a PR with a session for review monitoring
+        - `$(copilotd.command) rules list`                       — Show configured dispatch rules
+        - `$(copilotd.command) config`                           — Show current configuration
 
         FORBIDDEN COMMANDS (do NOT run these — they would disrupt the daemon):
-        - `copilotd run` / `copilotd start` / `copilotd stop` — Would interfere with the running daemon
-        - `copilotd update` — Could replace the running binary
-        - `copilotd init` — Interactive setup, not appropriate for remote sessions
-        - `copilotd shutdown-instance` — Internal command, never run directly
+        - `$(copilotd.command) run` / `$(copilotd.command) start` / `$(copilotd.command) stop` — Would interfere with the running daemon
+        - `$(copilotd.command) update` — Could replace the running binary
+        - `$(copilotd.command) init` — Interactive setup, not appropriate for remote sessions
+        - `$(copilotd.command) shutdown-instance` — Internal command, never run directly
 
         SESSION LIFECYCLE:
         Issues matching rules are dispatched as copilot sessions that progress through:

--- a/src/copilotd/Program.cs
+++ b/src/copilotd/Program.cs
@@ -57,6 +57,7 @@ public class Program
         serviceCollection.AddSingleton<ReconciliationEngine>();
         serviceCollection.AddSingleton<GitHubReleaseService>();
         serviceCollection.AddSingleton<ProvenanceVerifier>();
+        serviceCollection.AddSingleton<RuntimeContext>();
         serviceCollection.AddSingleton<UpdateService>();
 
         return serviceCollection.BuildServiceProvider();


### PR DESCRIPTION
## Summary
- resolve copilotd callback commands at runtime so source and local publish runs no longer assume a PATH-installed binary
- suppress automatic background self-updates for source/dev runs, with explicit --disable-self-updates support on run/start
- add scoped source-tree access for source-driven callbacks and update the source-running guidance

Closes #104