### PR TITLE
Add delayed shutdown for session handoff commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ When running from source or a local repo publish, copilotd suppresses automatic 
 | `copilotd session pr <pr-number> <issue>` | Associate a PR with a session and wait for review feedback (callable from within a copilot session) |
 | `copilotd session reset <issue>` | Reset a completed/failed session to pending for re-dispatch |
 | `copilotd config` | Display current configuration |
-| `copilotd config --set key=value` | Set a config value (`repo_home`, `default_model`, `custom_prompt`, `max_instances`) |
+| `copilotd config --set key=value` | Set a config value (`repo_home`, `default_model`, `custom_prompt`, `max_instances`, `session_shutdown_delay_seconds`) |
 | `copilotd rules list` | List all dispatch rules |
 | `copilotd rules add <name>` | Add a new dispatch rule |
 | `copilotd rules update <name>` | Update an existing rule |
@@ -358,6 +358,7 @@ Stored in `~/.copilotd/`:
 | `default_model` | *(none)* | Default model passed to copilot via `--model` for all sessions (rule-specific `model` overrides) |
 | `prompt` | *(empty)* | Custom prompt text appended to the built-in prompt |
 | `max_instances` | `3` | Maximum concurrent copilot processes; excess sessions queue as Pending |
+| `session_shutdown_delay_seconds` | `15` | Delay before shutting down an orchestrated session after `session comment`, `session pr`, or `session complete` |
 | `max_redispatches` | `10` | Maximum re-dispatches per session via comment/review feedback loops before requiring manual reset |
 | `enable_control_session` | `true` | Launch a control remote session when the daemon starts for remote management via the GitHub remote sessions UI |
 

--- a/src/copilotd/Commands/ConfigCommand.cs
+++ b/src/copilotd/Commands/ConfigCommand.cs
@@ -38,6 +38,7 @@ public static class ConfigCommand
                     table.AddRow("custom_prompt", Markup.Escape(string.IsNullOrEmpty(config.Prompt) ? "(not set)" : config.Prompt));
                     table.AddRow("current_user", Markup.Escape(config.CurrentUser ?? "(not set)"));
                     table.AddRow("max_instances", Markup.Escape(config.MaxInstances.ToString()));
+                    table.AddRow("session_shutdown_delay_seconds", Markup.Escape(config.SessionShutdownDelaySeconds.ToString()));
                     table.AddRow("rules", Markup.Escape($"{config.Rules.Count} rule(s)"));
 
                     if (config.Rules.Count > 0)
@@ -122,9 +123,23 @@ public static class ConfigCommand
                         }
                         break;
 
+                    case "session_shutdown_delay_seconds":
+                    case "shutdown_delay_seconds":
+                        if (int.TryParse(value, out var shutdownDelaySeconds) && shutdownDelaySeconds >= 0)
+                        {
+                            cfg.SessionShutdownDelaySeconds = shutdownDelaySeconds;
+                            ConsoleOutput.Success($"session_shutdown_delay_seconds set to: {shutdownDelaySeconds}");
+                        }
+                        else
+                        {
+                            ConsoleOutput.Error("session_shutdown_delay_seconds must be a non-negative integer");
+                            return 1;
+                        }
+                        break;
+
                     default:
                         ConsoleOutput.Error($"Unknown config key: {key}");
-                        ConsoleOutput.Info("Valid keys: repo_home, default_model, custom_prompt, max_instances");
+                        ConsoleOutput.Info("Valid keys: repo_home, default_model, custom_prompt, max_instances, session_shutdown_delay_seconds");
                         return 1;
                 }
 

--- a/src/copilotd/Commands/InitCommand.cs
+++ b/src/copilotd/Commands/InitCommand.cs
@@ -121,15 +121,6 @@ public static class InitCommand
                         .Validate(v => v > 0 ? ValidationResult.Success() : ValidationResult.Error("Must be a positive integer")));
                 AnsiConsole.WriteLine();
 
-                // Delay before self-shutdown after session handoff commands
-                AnsiConsole.MarkupLine("[grey]Seconds to wait before shutting down a session after it calls session comment/pr/complete.[/]");
-                AnsiConsole.MarkupLine("[grey]Set to 0 to shut down immediately.[/]");
-                config.SessionShutdownDelaySeconds = AnsiConsole.Prompt(
-                    new TextPrompt<int>("Session shutdown delay (seconds):")
-                        .DefaultValue(config.SessionShutdownDelaySeconds)
-                        .Validate(v => v >= 0 ? ValidationResult.Success() : ValidationResult.Error("Must be zero or greater")));
-                AnsiConsole.WriteLine();
-
                 // Default model
                 AnsiConsole.MarkupLine("[grey]Optional default model for all sessions (e.g., claude-sonnet-4, o4-mini).[/]");
                 AnsiConsole.MarkupLine("[grey]Leave empty to use the copilot CLI default. Can be overridden per rule.[/]");
@@ -330,7 +321,6 @@ public static class InitCommand
 
                 summaryTable.AddRow("[blue]Repo home[/]", Markup.Escape(config.RepoHome));
                 summaryTable.AddRow("[blue]Max concurrent sessions[/]", Markup.Escape(config.MaxInstances.ToString()));
-                summaryTable.AddRow("[blue]Session shutdown delay[/]", Markup.Escape($"{config.SessionShutdownDelaySeconds} second(s)"));
                 summaryTable.AddRow("[blue]Default model[/]", Markup.Escape(config.DefaultModel ?? "(copilot default)"));
                 summaryTable.AddRow("", "");
                 summaryTable.AddRow("[bold blue]Default Rule[/]", "");
@@ -353,7 +343,6 @@ public static class InitCommand
                 AnsiConsole.MarkupLine("  [blue]copilotd rules update Default --add-repo org/repo[/]      Add another repo to the default rule");
                 AnsiConsole.MarkupLine("  [blue]copilotd rules add MyRule --label bug --yolo[/]           Create a new dispatch rule");
                 AnsiConsole.MarkupLine("  [blue]copilotd config --set max_instances=5[/]                  Change concurrency limit");
-                AnsiConsole.MarkupLine("  [blue]copilotd config --set session_shutdown_delay_seconds=30[/] Configure post-command shutdown delay");
                 AnsiConsole.MarkupLine("  [blue]copilotd config --set default_model=claude-sonnet-4[/]    Set the default model");
                 AnsiConsole.MarkupLine("  [blue]copilotd status[/]                                        Check daemon health and sessions");
                 AnsiConsole.WriteLine();

--- a/src/copilotd/Commands/InitCommand.cs
+++ b/src/copilotd/Commands/InitCommand.cs
@@ -121,6 +121,15 @@ public static class InitCommand
                         .Validate(v => v > 0 ? ValidationResult.Success() : ValidationResult.Error("Must be a positive integer")));
                 AnsiConsole.WriteLine();
 
+                // Delay before self-shutdown after session handoff commands
+                AnsiConsole.MarkupLine("[grey]Seconds to wait before shutting down a session after it calls session comment/pr/complete.[/]");
+                AnsiConsole.MarkupLine("[grey]Set to 0 to shut down immediately.[/]");
+                config.SessionShutdownDelaySeconds = AnsiConsole.Prompt(
+                    new TextPrompt<int>("Session shutdown delay (seconds):")
+                        .DefaultValue(config.SessionShutdownDelaySeconds)
+                        .Validate(v => v >= 0 ? ValidationResult.Success() : ValidationResult.Error("Must be zero or greater")));
+                AnsiConsole.WriteLine();
+
                 // Default model
                 AnsiConsole.MarkupLine("[grey]Optional default model for all sessions (e.g., claude-sonnet-4, o4-mini).[/]");
                 AnsiConsole.MarkupLine("[grey]Leave empty to use the copilot CLI default. Can be overridden per rule.[/]");
@@ -321,6 +330,7 @@ public static class InitCommand
 
                 summaryTable.AddRow("[blue]Repo home[/]", Markup.Escape(config.RepoHome));
                 summaryTable.AddRow("[blue]Max concurrent sessions[/]", Markup.Escape(config.MaxInstances.ToString()));
+                summaryTable.AddRow("[blue]Session shutdown delay[/]", Markup.Escape($"{config.SessionShutdownDelaySeconds} second(s)"));
                 summaryTable.AddRow("[blue]Default model[/]", Markup.Escape(config.DefaultModel ?? "(copilot default)"));
                 summaryTable.AddRow("", "");
                 summaryTable.AddRow("[bold blue]Default Rule[/]", "");
@@ -343,6 +353,7 @@ public static class InitCommand
                 AnsiConsole.MarkupLine("  [blue]copilotd rules update Default --add-repo org/repo[/]      Add another repo to the default rule");
                 AnsiConsole.MarkupLine("  [blue]copilotd rules add MyRule --label bug --yolo[/]           Create a new dispatch rule");
                 AnsiConsole.MarkupLine("  [blue]copilotd config --set max_instances=5[/]                  Change concurrency limit");
+                AnsiConsole.MarkupLine("  [blue]copilotd config --set session_shutdown_delay_seconds=30[/] Configure post-command shutdown delay");
                 AnsiConsole.MarkupLine("  [blue]copilotd config --set default_model=claude-sonnet-4[/]    Set the default model");
                 AnsiConsole.MarkupLine("  [blue]copilotd status[/]                                        Check daemon health and sessions");
                 AnsiConsole.WriteLine();

--- a/src/copilotd/Commands/SessionCommand.cs
+++ b/src/copilotd/Commands/SessionCommand.cs
@@ -269,6 +269,7 @@ public static class SessionCommand
                 var stateStore = services.GetRequiredService<StateStore>();
                 var ghCli = services.GetRequiredService<GhCliService>();
                 var processManager = services.GetRequiredService<ProcessManager>();
+                var config = stateStore.LoadConfig();
 
                 var issueKey = parseResult.GetValue(issueArg)!;
                 var message = parseResult.GetValue(messageOption)!;
@@ -344,9 +345,8 @@ public static class SessionCommand
                     return 1;
                 }
 
-                processManager.TerminateProcess(trackedProcess.Label, trackedProcess.ProcessId, trackedProcess.ProcessStartTime);
-
                 ConsoleOutput.Success($"Comment posted on {issueKey}. Session is now waiting for feedback.");
+                ScheduleSessionShutdown(processManager, trackedProcess, config);
                 return 0;
             }, logger);
         });
@@ -370,6 +370,7 @@ public static class SessionCommand
             {
                 var stateStore = services.GetRequiredService<StateStore>();
                 var processManager = services.GetRequiredService<ProcessManager>();
+                var config = stateStore.LoadConfig();
 
                 var issueKey = parseResult.GetValue(issueArg)!;
                 var trackedProcess = default(TrackedProcessRef);
@@ -411,9 +412,8 @@ public static class SessionCommand
                     return 0;
                 }
 
-                processManager.TerminateProcess(trackedProcess.Label, trackedProcess.ProcessId, trackedProcess.ProcessStartTime);
-
                 ConsoleOutput.Success($"Session for {issueKey} marked as completed.");
+                ScheduleSessionShutdown(processManager, trackedProcess, config);
                 return 0;
             }, logger);
         });
@@ -440,6 +440,7 @@ public static class SessionCommand
             {
                 var stateStore = services.GetRequiredService<StateStore>();
                 var processManager = services.GetRequiredService<ProcessManager>();
+                var config = stateStore.LoadConfig();
 
                 var prNumber = parseResult.GetValue(prNumberArg);
                 var issueKey = parseResult.GetValue(issueArg)!;
@@ -483,9 +484,8 @@ public static class SessionCommand
                     return 1;
                 }
 
-                processManager.TerminateProcess(trackedProcess.Label, trackedProcess.ProcessId, trackedProcess.ProcessStartTime);
-
                 ConsoleOutput.Success($"PR #{prNumber} associated with session for {issueKey}. Session is now waiting for review feedback.");
+                ScheduleSessionShutdown(processManager, trackedProcess, config);
                 return 0;
             }, logger);
         });
@@ -721,6 +721,24 @@ public static class SessionCommand
         if (age.TotalHours < 1) return $"{(int)age.TotalMinutes}m ago";
         if (age.TotalDays < 1) return $"{(int)age.TotalHours}h {age.Minutes}m ago";
         return local.ToString("yyyy-MM-dd HH:mm");
+    }
+
+    private static void ScheduleSessionShutdown(ProcessManager processManager, TrackedProcessRef trackedProcess, CopilotdConfig config)
+    {
+        if (!trackedProcess.HasProcess)
+            return;
+
+        var shutdownDelay = TimeSpan.FromSeconds(Math.Max(0, config.SessionShutdownDelaySeconds));
+        processManager.ScheduleTerminateProcess(trackedProcess.Label, trackedProcess.ProcessId, trackedProcess.ProcessStartTime, shutdownDelay);
+
+        if (shutdownDelay > TimeSpan.Zero)
+            ConsoleOutput.Info($"The current copilot session will shut down in {FormatDuration(shutdownDelay)}.");
+    }
+
+    private static string FormatDuration(TimeSpan duration)
+    {
+        var totalSeconds = (int)Math.Ceiling(duration.TotalSeconds);
+        return totalSeconds == 1 ? "1 second" : $"{totalSeconds} seconds";
     }
 
     private static void RequeueSession(StateStore stateStore, string issueKey)

--- a/src/copilotd/Commands/ShutdownInstanceCommand.cs
+++ b/src/copilotd/Commands/ShutdownInstanceCommand.cs
@@ -1,6 +1,7 @@
 using System.CommandLine;
 using System.CommandLine.Parsing;
 using System.Diagnostics;
+using System.Globalization;
 using System.Runtime.InteropServices;
 
 namespace Copilotd.Commands;
@@ -24,19 +25,35 @@ public static class ShutdownInstanceCommand
         };
 
         var pidOption = new Option<int>("--pid") { Description = "Process ID to shut down" };
+        var expectedStartOption = new Option<string?>("--expected-start") { Description = "Expected UTC process start time in round-trip format" };
+        var delaySecondsOption = new Option<int>("--delay-seconds") { Description = "Seconds to wait before beginning shutdown" };
         command.Options.Add(pidOption);
+        command.Options.Add(expectedStartOption);
+        command.Options.Add(delaySecondsOption);
 
         command.SetAction(async (ParseResult parseResult, CancellationToken ct) =>
         {
             var pid = parseResult.GetValue(pidOption);
-            return ShutdownProcess(pid);
+            var expectedStartText = parseResult.GetValue(expectedStartOption);
+            var delaySeconds = parseResult.GetValue(delaySecondsOption);
+            if (delaySeconds < 0)
+                return 1;
+
+            if (!TryParseExpectedStart(expectedStartText, out var expectedStart))
+                return 1;
+
+            return ShutdownProcess(pid, expectedStart, TimeSpan.FromSeconds(delaySeconds));
         });
 
         return command;
     }
 
-    private static int ShutdownProcess(int pid)
+    private static int ShutdownProcess(int pid, DateTimeOffset? expectedStart, TimeSpan shutdownDelay)
     {
+        var effectiveDelay = shutdownDelay < TimeSpan.Zero ? TimeSpan.Zero : shutdownDelay;
+        if (effectiveDelay > TimeSpan.Zero)
+            Thread.Sleep(effectiveDelay);
+
         Process process;
         try
         {
@@ -50,6 +67,13 @@ public static class ShutdownInstanceCommand
 
         try
         {
+            if (expectedStart is { } expectedStartTime)
+            {
+                var actualStart = GetProcessStartTime(process);
+                if (actualStart is not null && Math.Abs((actualStart.Value - expectedStartTime).TotalSeconds) > 5)
+                    return 0;
+            }
+
             if (process.HasExited)
                 return 0;
 
@@ -141,6 +165,31 @@ public static class ShutdownInstanceCommand
         catch
         {
             return 1;
+        }
+    }
+
+    private static bool TryParseExpectedStart(string? text, out DateTimeOffset? expectedStart)
+    {
+        expectedStart = null;
+        if (string.IsNullOrWhiteSpace(text))
+            return true;
+
+        if (!DateTimeOffset.TryParseExact(text, "O", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed))
+            return false;
+
+        expectedStart = parsed;
+        return true;
+    }
+
+    private static DateTimeOffset? GetProcessStartTime(Process process)
+    {
+        try
+        {
+            return new DateTimeOffset(process.StartTime.ToUniversalTime(), TimeSpan.Zero);
+        }
+        catch
+        {
+            return null;
         }
     }
 

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -236,7 +236,7 @@ public sealed partial class ProcessManager
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                return TerminateViaShutdownInstance(process, pid);
+                return TerminateViaShutdownInstance(process, pid, processStartTime);
             }
             else
             {
@@ -255,13 +255,60 @@ public sealed partial class ProcessManager
     }
 
     /// <summary>
+    /// Schedules a background shutdown helper for a tracked copilot process. This keeps the
+    /// caller responsive while the helper optionally waits before sending shutdown signals.
+    /// Falls back to synchronous termination if the helper cannot be started.
+    /// </summary>
+    public bool ScheduleTerminateProcess(string processLabel, int? processId, DateTimeOffset? processStartTime, TimeSpan shutdownDelay)
+    {
+        if (processId is not { } pid)
+        {
+            _logger.LogDebug("No PID tracked for {ProcessLabel}, nothing to schedule", processLabel);
+            return true;
+        }
+
+        var invocation = GetShutdownInstanceInvocation(pid, processStartTime, shutdownDelay);
+        if (invocation is null)
+        {
+            _logger.LogWarning("Cannot determine copilotd executable path, falling back to synchronous termination");
+            return TerminateProcess(processLabel, processId, processStartTime);
+        }
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = invocation.FileName,
+            Arguments = invocation.Arguments,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        try
+        {
+            using var helper = Process.Start(psi);
+            if (helper is null)
+            {
+                _logger.LogWarning("Failed to start shutdown-instance helper for PID {Pid}, falling back to synchronous termination", pid);
+                return TerminateProcess(processLabel, processId, processStartTime);
+            }
+
+            _logger.LogInformation("Scheduled shutdown-instance for {ProcessLabel} (PID {Pid}) with delay {Delay}", processLabel, pid, shutdownDelay);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to schedule shutdown-instance for {ProcessLabel} (PID {Pid}), falling back to synchronous termination", processLabel, pid);
+            return TerminateProcess(processLabel, processId, processStartTime);
+        }
+    }
+
+    /// <summary>
     /// Windows: spawns 'copilotd shutdown-instance --pid PID' which handles the full
     /// graceful shutdown lifecycle (Ctrl+Break → Ctrl+C → Kill) from a separate process
     /// that can safely attach to the target's console.
     /// </summary>
-    private bool TerminateViaShutdownInstance(Process process, int pid)
+    private bool TerminateViaShutdownInstance(Process process, int pid, DateTimeOffset? processStartTime)
     {
-        var invocation = _runtimeContext.GetSelfInvocation($"shutdown-instance --pid {pid}");
+        var invocation = GetShutdownInstanceInvocation(pid, processStartTime, TimeSpan.Zero);
         if (invocation is null)
         {
             _logger.LogWarning("Cannot determine copilotd executable path, falling back to kill");
@@ -322,6 +369,20 @@ public sealed partial class ProcessManager
             process.Kill(entireProcessTree: true);
             return true;
         }
+    }
+
+    private CommandInvocation? GetShutdownInstanceInvocation(int pid, DateTimeOffset? processStartTime, TimeSpan shutdownDelay)
+    {
+        var effectiveDelay = shutdownDelay < TimeSpan.Zero ? TimeSpan.Zero : shutdownDelay;
+
+        var arguments = $"shutdown-instance --pid {pid}";
+        if (processStartTime is { } expectedStart)
+            arguments += $" --expected-start {expectedStart:O}";
+
+        if (effectiveDelay > TimeSpan.Zero)
+            arguments += $" --delay-seconds {(int)Math.Ceiling(effectiveDelay.TotalSeconds)}";
+
+        return _runtimeContext.GetSelfInvocation(arguments);
     }
 
     /// <summary>

--- a/src/copilotd/Models/CopilotdConfig.cs
+++ b/src/copilotd/Models/CopilotdConfig.cs
@@ -42,6 +42,14 @@ public sealed class CopilotdConfig
     public int MaxInstances { get; set; } = 3;
 
     /// <summary>
+    /// Delay, in seconds, before shutting down an orchestrated copilot session after it
+    /// calls <c>session comment</c>, <c>session pr</c>, or <c>session complete</c>.
+    /// Gives the agent time to observe command success and print any follow-up output.
+    /// Default is 15.
+    /// </summary>
+    public int SessionShutdownDelaySeconds { get; set; } = 15;
+
+    /// <summary>
     /// Default model to use for all copilot sessions. When set, <c>--model</c> is
     /// passed to the copilot CLI unless a rule specifies its own model override.
     /// </summary>


### PR DESCRIPTION
## Summary
- add a global session shutdown delay setting with a 15 second default
- schedule session comment/pr/complete shutdowns in the background via shutdown-instance
- expose and document the new setting in config, init, and README

Closes #103