### PR TITLE
Fix locked source-shim builds on Windows

### DIFF
--- a/scripts/Generate-VerifyProvenance.ps1
+++ b/scripts/Generate-VerifyProvenance.ps1
@@ -226,5 +226,12 @@ if (-not (Test-Path $outputDir))
     New-Item -ItemType Directory -Path $outputDir -Force | Out-Null
 }
 
+$existingOutput = if (Test-Path $OutputPath) { Get-Content -Path $OutputPath -Raw } else { $null }
+if ($existingOutput -ceq $output)
+{
+    Write-Host "verify-provenance.ps1 already up to date at '$OutputPath'"
+    return
+}
+
 Set-Content -Path $OutputPath -Value $output -NoNewline
 Write-Host "Generated verify-provenance.ps1 at '$OutputPath'"

--- a/src/copilotd/copilotd.csproj
+++ b/src/copilotd/copilotd.csproj
@@ -13,6 +13,11 @@
     <AssemblyName>copilotd</AssemblyName>
   </PropertyGroup>
 
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+    <VerifyProvenanceGeneratorPath>$(MSBuildProjectDirectory)\..\..\scripts\Generate-VerifyProvenance.ps1</VerifyProvenanceGeneratorPath>
+    <VerifyProvenanceSourcePath>$(MSBuildProjectDirectory)\..\..\scripts\install\install-copilotd.ps1</VerifyProvenanceSourcePath>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
@@ -25,9 +30,13 @@
     <EmbeddedResource Include="$(IntermediateOutputPath)verify-provenance.ps1" LogicalName="verify-provenance.ps1" />
   </ItemGroup>
 
-  <Target Name="GenerateVerifyProvenance" BeforeTargets="PrepareForBuild" Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+  <Target Name="GenerateVerifyProvenance"
+          BeforeTargets="PrepareForBuild"
+          Inputs="$(VerifyProvenanceGeneratorPath);$(VerifyProvenanceSourcePath)"
+          Outputs="$(IntermediateOutputPath)verify-provenance.ps1"
+          Condition="$([MSBuild]::IsOSPlatform('Windows'))">
     <MakeDir Directories="$(IntermediateOutputPath)" />
-    <Exec Command="powershell -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildProjectDirectory)\..\..\scripts\Generate-VerifyProvenance.ps1&quot; -OutputPath &quot;$(IntermediateOutputPath)verify-provenance.ps1&quot;" />
+    <Exec Command="powershell -NoProfile -ExecutionPolicy Bypass -File &quot;$(VerifyProvenanceGeneratorPath)&quot; -OutputPath &quot;$(IntermediateOutputPath)verify-provenance.ps1&quot;" />
   </Target>
 
 </Project>


### PR DESCRIPTION
## Summary

- make GenerateVerifyProvenance incremental by declaring its MSBuild inputs and outputs
- skip rewriting the generated `verify-provenance.ps1` file when its content is unchanged
- restore no-op builds so copilotd.cmd start followed by copilotd.cmd status works while the daemon is running

## Root cause

copilotd.cmd uses dotnet run, which always enters the build graph. Our `GenerateVerifyProvenance` target rewrote `$(IntermediateOutputPath)verify-provenance.ps1` on every build with no declared inputs/outputs, so MSBuild reran compile/output steps even when the repo was unchanged. On Windows that eventually retried copying `apphost.exe` over the already-running `copilotd.exe`, which fails with a locked-file error.

Closes #109