### PR TITLE
Defer automatic self-update installs until daemon exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ copilotd.cmd run            # Windows
 
 Convenience scripts `copilotd.sh` and `copilotd.cmd` in the repo root run the project from source via `dotnet run`, passing all arguments through.
 
-Installed copilotd binaries can self-update in the background: the daemon checks for newer releases, downloads and verifies them, then stages the new binary to be installed after the running daemon exits naturally. When running from source or a local repo publish, copilotd suppresses automatic background self-updates by default so local scenario verification is not interrupted by GitHub releases. You can still disable them explicitly with `COPILOTD_DISABLE_SELF_UPDATES=1` or `--disable-self-updates`, and `copilotd update --check` remains available to inspect update availability.
+Installed copilotd binaries can self-update in the background: the daemon checks for newer releases, downloads and verifies them, then stages the new binary to be installed after the running daemon exits naturally. If an installed binary update is interrupted and you restore `copilotd.exe` by rerunning the normal install script, the next copilotd launch will reconcile any leftover `.old`, `.staged`, and `update-state.json` artifacts: it will resume a newer staged update, or discard stale staged state rather than downgrading the restored binary. When running from source or a local repo publish, copilotd suppresses automatic background self-updates by default so local scenario verification is not interrupted by GitHub releases. You can still disable them explicitly with `COPILOTD_DISABLE_SELF_UPDATES=1` or `--disable-self-updates`, and `copilotd update --check` remains available to inspect update availability.
 
 ## Commands
 
@@ -163,7 +163,7 @@ The built-in prompt supports token replacement:
 | `$(issue.milestone)` | Milestone title |
 | `$(pr.id)` | Pull request number (available in PR review re-dispatch prompts) |
 
-Custom prompt text (configured via `custom_prompt` or `~/.copilotd/prompt.md`) is appended after
+Custom prompt text (configured via `custom_prompt` or `~/.copilotd/prompt.md` by default) is appended after
 the built-in prompt with a trailer. Rules can also specify a `custom_prompt` that either appends
 to or overrides the global custom prompt (controlled by `custom_prompt_mode`). Tokens are replaced
 in both the built-in and custom prompt text. Per-rule extra prompts are appended last.
@@ -333,7 +333,7 @@ sessions, and more — all via natural language.
 | `copilotd rules list` | Show configured dispatch rules |
 | `copilotd config` | Show current configuration |
 
-To disable the control session, set `enable_control_session` to `false` in `~/.copilotd/config.json`.
+To disable the control session, set `enable_control_session` to `false` in `~/.copilotd/config.json` (or `COPILOTD_HOME\config.json` when `COPILOTD_HOME` is set).
 
 ### Terminal states and pruning
 
@@ -344,10 +344,12 @@ To disable the control session, set `enable_control_session` to `false` in `~/.c
 
 ## Configuration
 
-Stored in `~/.copilotd/`:
+Stored in `~/.copilotd/` by default. Set `COPILOTD_HOME` to point copilotd at a different state/config directory:
 
 - `config.json` — user-managed settings (repo home, custom prompt, rules)
 - `state.json` — runtime session tracking (auto-managed, self-healing)
+- `update-state.json` — self-update staging and install coordination
+- `prompt.md` — optional global custom prompt text appended to the built-in prompt
 - `.lock` — single-instance guard (present while daemon is running)
 
 ### Config options
@@ -416,7 +418,7 @@ when sessions complete, are reset, or are pruned.
 
 Custom prompt text can be provided at two levels:
 
-- **Global**: via `~/.copilotd/prompt.md` or the `prompt` config property
+- **Global**: via `~/.copilotd/prompt.md` (or `COPILOTD_HOME\prompt.md`) or the `prompt` config property
 - **Per-rule**: via the `custom_prompt` rule setting (set with `--custom-prompt`)
 
 Global custom text is **appended** to the built-in copilotd prompt (not a replacement) with a

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ copilotd.cmd run            # Windows
 
 Convenience scripts `copilotd.sh` and `copilotd.cmd` in the repo root run the project from source via `dotnet run`, passing all arguments through.
 
-When running from source or a local repo publish, copilotd suppresses automatic background self-updates by default so local scenario verification is not interrupted by GitHub releases. You can still disable them explicitly with `COPILOTD_DISABLE_SELF_UPDATES=1` or `--disable-self-updates`, and `copilotd update --check` remains available to inspect update availability.
+Installed copilotd binaries can self-update in the background: the daemon checks for newer releases, downloads and verifies them, then stages the new binary to be installed after the running daemon exits naturally. When running from source or a local repo publish, copilotd suppresses automatic background self-updates by default so local scenario verification is not interrupted by GitHub releases. You can still disable them explicitly with `COPILOTD_DISABLE_SELF_UPDATES=1` or `--disable-self-updates`, and `copilotd update --check` remains available to inspect update availability.
 
 ## Commands
 

--- a/src/copilotd/Commands/ConfigCommand.cs
+++ b/src/copilotd/Commands/ConfigCommand.cs
@@ -88,9 +88,7 @@ public static class ConfigCommand
                     case "repo_home":
                         if (value.StartsWith('~'))
                         {
-                            value = Path.Combine(
-                                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-                                value[1..].TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+                            value = CopilotdPaths.ExpandUserProfile(value);
                         }
                         cfg.RepoHome = Path.GetFullPath(value);
                         ConsoleOutput.Success($"repo_home set to: {cfg.RepoHome}");

--- a/src/copilotd/Commands/InitCommand.cs
+++ b/src/copilotd/Commands/InitCommand.cs
@@ -101,9 +101,7 @@ public static class InitCommand
                 // Expand ~ to home directory
                 if (repoHome.StartsWith('~'))
                 {
-                    repoHome = Path.Combine(
-                        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-                        repoHome[1..].TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+                    repoHome = CopilotdPaths.ExpandUserProfile(repoHome);
                 }
 
                 config.RepoHome = Path.GetFullPath(repoHome);
@@ -312,6 +310,8 @@ public static class InitCommand
                 AnsiConsole.Write(new Rule("[bold green]Configuration Saved[/]").LeftJustified());
                 AnsiConsole.WriteLine();
                 AnsiConsole.MarkupLine($"[grey]Config stored in: {Markup.Escape(stateStore.ConfigDir)}[/]");
+                if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(CopilotdPaths.HomeEnvVar)))
+                    AnsiConsole.MarkupLine($"[grey]{Markup.Escape(CopilotdPaths.HomeEnvVar)} is overriding the default ~/.copilotd location.[/]");
                 AnsiConsole.WriteLine();
 
                 // Summary table

--- a/src/copilotd/Commands/PreflightChecks.cs
+++ b/src/copilotd/Commands/PreflightChecks.cs
@@ -35,7 +35,7 @@ internal static class PreflightChecks
 
         if (!stateStore.ConfigExists())
         {
-            ConsoleOutput.Error("copilotd is not configured. Run 'copilotd init' first.");
+            ConsoleOutput.Error($"copilotd is not configured. Run 'copilotd init' first. Expected config under {CopilotdPaths.GetConfigDirDescription()}.");
             return 1;
         }
 

--- a/src/copilotd/Commands/RunCommand.cs
+++ b/src/copilotd/Commands/RunCommand.cs
@@ -195,22 +195,20 @@ public static class RunCommand
 
                             if (!disableSelfUpdates)
                             {
-                                // Self-update: check for staged update or fire background check
+                                // Self-update: schedule or maintain a deferred installer for any staged update,
+                                // then fire a background check/stage task.
                                 var updateState = stateStore.LoadUpdateState();
-                                if (updateState.Status == UpdateStatus.Staged
-                                    && !string.IsNullOrEmpty(updateState.StagedPath)
-                                    && File.Exists(updateState.StagedPath))
+                                if (UpdateService.HasUsableStagedUpdate(updateState))
                                 {
-                                    // Staged update ready — spawn install process and exit daemon
-                                    ConsoleOutput.Info($"Staged update {updateState.StagedVersion} detected, initiating install...");
-                                    logger.LogInformation("Spawning update installer for staged version {Version}", updateState.StagedVersion);
-                                    if (SpawnUpdateInstaller(runtimeContext, logger))
+                                    if (EnsureDeferredInstallWatcher(updateService, runtimeContext, logger, updateState))
                                     {
-                                        cts.Cancel();
-                                        break;
+                                        if (updateState.Status == UpdateStatus.Staged)
+                                            ConsoleOutput.Info($"Staged update {updateState.StagedVersion} detected. It will install after this daemon exits.");
                                     }
-
-                                    ConsoleOutput.Warning("Failed to spawn update installer, will retry next cycle.");
+                                    else if (updateState.Status == UpdateStatus.Staged)
+                                    {
+                                        ConsoleOutput.Warning("Failed to schedule deferred update installer, will retry next cycle.");
+                                    }
                                 }
 
                                 // Fire non-blocking update check/stage (runs in background, result picked up next cycle)
@@ -287,19 +285,68 @@ public static class RunCommand
     }
 
     /// <summary>
+    /// Ensures a detached <c>copilotd update --install-staged</c> helper is waiting for the
+    /// tracked daemon instance to exit naturally before installing the staged binary.
+    /// If the helper is already running, this is a no-op.
+    /// </summary>
+    private static bool EnsureDeferredInstallWatcher(
+        UpdateService updateService,
+        RuntimeContext runtimeContext,
+        ILogger logger,
+        UpdateState updateState)
+    {
+        if (updateState.Status == UpdateStatus.WaitingForExit
+            && IsTrackedProcessAlive(updateState.WatcherPid, updateState.WatcherStartTime))
+        {
+            return true;
+        }
+
+        var waitTarget = updateState.Status == UpdateStatus.WaitingForExit
+                         && updateState.WaitForPid is { } waitPid
+                         && updateState.WaitForStartTime is { } waitStartTime
+            ? new TrackedProcess(waitPid, waitStartTime)
+            : new TrackedProcess(Environment.ProcessId, GetCurrentProcessStartTime());
+
+        var installer = SpawnUpdateInstaller(runtimeContext, logger, waitTarget.ProcessId, waitTarget.ProcessStartTime);
+        if (installer is null)
+            return false;
+
+        if (!updateService.TryScheduleDeferredInstall(
+                waitTarget.ProcessId,
+                waitTarget.ProcessStartTime,
+                installer.Value.ProcessId,
+                installer.Value.ProcessStartTime))
+        {
+            TryTerminateTrackedProcess(installer.Value, logger);
+            logger.LogWarning(
+                "Deferred installer PID {WatcherPid} was terminated because the update state could not be recorded for daemon PID {WaitPid}",
+                installer.Value.ProcessId,
+                waitTarget.ProcessId);
+            return false;
+        }
+
+        logger.LogInformation(
+            "Deferred installer PID {WatcherPid} is waiting for daemon PID {WaitPid} to exit naturally",
+            installer.Value.ProcessId,
+            waitTarget.ProcessId);
+        return true;
+    }
+
+    /// <summary>
     /// Spawns a detached <c>copilotd update --install-staged</c> process
-    /// that will wait for this daemon to exit, then perform the binary replacement.
+    /// that will wait for the specified daemon PID/start-time pair to exit, then perform the binary replacement.
     /// Windows: CreateProcessW with CREATE_NEW_CONSOLE for proper console isolation.
     /// Unix: setsid for session detachment, with fallback to direct Process.Start.
-    /// Returns true if the process was successfully spawned.
+    /// Returns the spawned installer's PID and start time on success.
     /// </summary>
-    private static bool SpawnUpdateInstaller(RuntimeContext runtimeContext, ILogger logger)
+    private static TrackedProcess? SpawnUpdateInstaller(RuntimeContext runtimeContext, ILogger logger, int waitForPid, DateTimeOffset waitForStartTime)
     {
-        var invocation = runtimeContext.GetSelfInvocation("update --install-staged");
+        var invocation = runtimeContext.GetSelfInvocation(
+            $"update --install-staged --wait-for-pid {waitForPid} --wait-for-start-time {waitForStartTime:O} --passive-wait");
         if (invocation is null)
         {
             logger.LogError("Cannot determine executable path for update installer");
-            return false;
+            return null;
         }
 
         var commandLine = invocation.GetCommandLine();
@@ -311,7 +358,7 @@ public static class RunCommand
         return SpawnUpdateInstallerUnix(invocation, logger);
     }
 
-    private static bool SpawnUpdateInstallerWindows(CommandInvocation invocation, ILogger logger)
+    private static TrackedProcess? SpawnUpdateInstallerWindows(CommandInvocation invocation, ILogger logger)
     {
         var commandLine = invocation.GetCommandLine();
 
@@ -333,21 +380,32 @@ public static class RunCommand
 
         if (success)
         {
+            var startTime = default(DateTimeOffset?);
+            try
+            {
+                using var process = Process.GetProcessById(pi.dwProcessId);
+                startTime = GetProcessStartTime(process);
+            }
+            catch
+            {
+                startTime = DateTimeOffset.UtcNow;
+            }
+
             NativeInterop.CloseHandle(pi.hProcess);
             NativeInterop.CloseHandle(pi.hThread);
             logger.LogInformation("Update installer spawned (PID {Pid})", pi.dwProcessId);
-            return true;
+            return new TrackedProcess(pi.dwProcessId, startTime ?? DateTimeOffset.UtcNow);
         }
 
         logger.LogError("Failed to spawn update installer via CreateProcessW");
-        return false;
+        return null;
     }
 
     /// <summary>
     /// Spawns the update installer as a detached process on Unix using setsid,
     /// mirroring the pattern used by <see cref="StartCommand"/>.
     /// </summary>
-    private static bool SpawnUpdateInstallerUnix(CommandInvocation invocation, ILogger logger)
+    private static TrackedProcess? SpawnUpdateInstallerUnix(CommandInvocation invocation, ILogger logger)
     {
         // Try setsid first for full session detachment
         var psi = new ProcessStartInfo
@@ -366,9 +424,10 @@ public static class RunCommand
             var process = Process.Start(psi);
             if (process is not null)
             {
+                var startTime = GetProcessStartTime(process) ?? DateTimeOffset.UtcNow;
                 process.StandardInput.Close();
                 logger.LogInformation("Update installer spawned via setsid (PID {Pid})", process.Id);
-                return true;
+                return new TrackedProcess(process.Id, startTime);
             }
         }
         catch
@@ -394,9 +453,10 @@ public static class RunCommand
             var process = Process.Start(fallbackPsi);
             if (process is not null)
             {
+                var startTime = GetProcessStartTime(process) ?? DateTimeOffset.UtcNow;
                 process.StandardInput.Close();
                 logger.LogInformation("Update installer spawned (PID {Pid})", process.Id);
-                return true;
+                return new TrackedProcess(process.Id, startTime);
             }
         }
         catch (Exception ex)
@@ -404,6 +464,78 @@ public static class RunCommand
             logger.LogError(ex, "Failed to spawn update installer");
         }
 
-        return false;
+        return null;
     }
+
+    private static bool IsTrackedProcessAlive(int? pid, DateTimeOffset? expectedStartTime)
+    {
+        if (pid is not { } trackedPid || expectedStartTime is not { } expectedStart)
+            return false;
+
+        try
+        {
+            using var process = Process.GetProcessById(trackedPid);
+            var actualStart = GetProcessStartTime(process);
+            if (actualStart is not null && Math.Abs((actualStart.Value - expectedStart).TotalSeconds) > 5)
+                return false;
+
+            return !process.HasExited;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static void TryTerminateTrackedProcess(TrackedProcess trackedProcess, ILogger logger)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(trackedProcess.ProcessId);
+            var actualStart = GetProcessStartTime(process);
+            if (actualStart is not null && Math.Abs((actualStart.Value - trackedProcess.ProcessStartTime).TotalSeconds) > 5)
+                return;
+
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+        }
+        catch (ArgumentException)
+        {
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Failed to terminate deferred installer PID {Pid}", trackedProcess.ProcessId);
+        }
+    }
+
+    private static DateTimeOffset GetCurrentProcessStartTime()
+    {
+        try
+        {
+            using var process = Process.GetCurrentProcess();
+            return GetProcessStartTime(process) ?? DateTimeOffset.UtcNow;
+        }
+        catch
+        {
+            return DateTimeOffset.UtcNow;
+        }
+    }
+
+    private static DateTimeOffset? GetProcessStartTime(Process process)
+    {
+        try
+        {
+            return new DateTimeOffset(process.StartTime.ToUniversalTime(), TimeSpan.Zero);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private readonly record struct TrackedProcess(int ProcessId, DateTimeOffset ProcessStartTime);
 }

--- a/src/copilotd/Commands/UpdateCommand.cs
+++ b/src/copilotd/Commands/UpdateCommand.cs
@@ -40,12 +40,27 @@ public static class UpdateCommand
             Description = "Install a previously staged update binary",
             Hidden = true
         };
+        var waitForPidOption = new Option<int?>("--wait-for-pid")
+        {
+            Hidden = true
+        };
+        var waitForStartTimeOption = new Option<string?>("--wait-for-start-time")
+        {
+            Hidden = true
+        };
+        var passiveWaitOption = new Option<bool>("--passive-wait")
+        {
+            Hidden = true
+        };
 
         command.Options.Add(checkOption);
         command.Options.Add(preReleaseOption);
         command.Options.Add(skipProvenanceOption);
         command.Options.Add(dryRunOption);
         command.Options.Add(installStagedOption);
+        command.Options.Add(waitForPidOption);
+        command.Options.Add(waitForStartTimeOption);
+        command.Options.Add(passiveWaitOption);
 
         command.SetAction(async (ParseResult parseResult, CancellationToken ct) =>
         {
@@ -61,6 +76,33 @@ public static class UpdateCommand
                 var skipProvenance = parseResult.GetValue(skipProvenanceOption);
                 var dryRun = parseResult.GetValue(dryRunOption);
                 var installStaged = parseResult.GetValue(installStagedOption);
+                var waitForPid = parseResult.GetValue(waitForPidOption);
+                var waitForStartTimeRaw = parseResult.GetValue(waitForStartTimeOption);
+                var passiveWait = parseResult.GetValue(passiveWaitOption);
+
+                DateTimeOffset? waitForStartTime = null;
+                if (!string.IsNullOrWhiteSpace(waitForStartTimeRaw))
+                {
+                    if (!DateTimeOffset.TryParse(waitForStartTimeRaw, out var parsedStartTime))
+                    {
+                        ConsoleOutput.Error($"Invalid --wait-for-start-time value: {waitForStartTimeRaw}");
+                        return 1;
+                    }
+
+                    waitForStartTime = parsedStartTime;
+                }
+
+                if ((waitForPid is null) != (waitForStartTime is null))
+                {
+                    ConsoleOutput.Error("--wait-for-pid and --wait-for-start-time must be provided together.");
+                    return 1;
+                }
+
+                if (passiveWait && waitForPid is null)
+                {
+                    ConsoleOutput.Error("--passive-wait requires --wait-for-pid and --wait-for-start-time.");
+                    return 1;
+                }
 
                 var localSource = Environment.GetEnvironmentVariable(UpdateSourceEnvVar);
                 if (!string.IsNullOrEmpty(localSource))
@@ -86,7 +128,7 @@ public static class UpdateCommand
                         ConsoleOutput.Info("[dry-run] Would install staged update.");
                         return 0;
                     }
-                    return await HandleInstallStaged(updateService, stateStore, skipProvenance, ct);
+                    return await HandleInstallStaged(updateService, stateStore, skipProvenance, waitForPid, waitForStartTime, passiveWait, ct);
                 }
 
                 if (check)
@@ -107,10 +149,22 @@ public static class UpdateCommand
         return command;
     }
 
-    private static async Task<int> HandleInstallStaged(UpdateService updateService, StateStore stateStore, bool skipProvenance, CancellationToken ct)
+    private static async Task<int> HandleInstallStaged(
+        UpdateService updateService,
+        StateStore stateStore,
+        bool skipProvenance,
+        int? waitForPid,
+        DateTimeOffset? waitForStartTime,
+        bool passiveWait,
+        CancellationToken ct)
     {
         ConsoleOutput.Info("Installing staged update...");
-        var success = await updateService.InstallStagedAsync(skipProvenance, ct);
+        var success = await updateService.InstallStagedAsync(
+            skipProvenance,
+            waitForPid,
+            waitForStartTime,
+            allowDaemonShutdown: !passiveWait,
+            ct);
         if (success)
         {
             ConsoleOutput.Success("Update installed successfully.");
@@ -191,7 +245,12 @@ public static class UpdateCommand
         // Install directly (for manual invocation, we do it in-process)
         // InstallStagedAsync acquires and releases its own update lock
         ConsoleOutput.Info("Installing update...");
-        var installed = await updateService.InstallStagedAsync(skipProvenance, ct);
+        var installed = await updateService.InstallStagedAsync(
+            skipProvenance,
+            waitForPid: null,
+            waitForStartTime: null,
+            allowDaemonShutdown: true,
+            ct);
         if (!installed)
         {
             var state = stateStore.LoadUpdateState();

--- a/src/copilotd/Infrastructure/CopilotdPaths.cs
+++ b/src/copilotd/Infrastructure/CopilotdPaths.cs
@@ -1,0 +1,37 @@
+namespace Copilotd.Infrastructure;
+
+public static class CopilotdPaths
+{
+    public const string HomeEnvVar = "COPILOTD_HOME";
+
+    public static string GetUserProfileDirectory()
+        => Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+    /// <summary>
+    /// Gets the root directory copilotd uses for its own persisted files.
+    /// Defaults to ~/.copilotd but can be overridden by COPILOTD_HOME.
+    /// </summary>
+    public static string GetCopilotdHomeDirectory()
+    {
+        var configuredHome = Environment.GetEnvironmentVariable(HomeEnvVar);
+        if (!string.IsNullOrWhiteSpace(configuredHome))
+            return Path.GetFullPath(ExpandUserProfile(configuredHome));
+
+        return Path.Combine(GetUserProfileDirectory(), ".copilotd");
+    }
+
+    public static string ExpandUserProfile(string path)
+    {
+        if (!path.StartsWith('~'))
+            return path;
+
+        return Path.Combine(
+            GetUserProfileDirectory(),
+            path[1..].TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+    }
+
+    public static string GetConfigDirDescription()
+        => Environment.GetEnvironmentVariable(HomeEnvVar) is { Length: > 0 }
+            ? $"{GetCopilotdHomeDirectory()} (from {HomeEnvVar})"
+            : GetCopilotdHomeDirectory();
+}

--- a/src/copilotd/Infrastructure/StateStore.cs
+++ b/src/copilotd/Infrastructure/StateStore.cs
@@ -5,7 +5,8 @@ using Microsoft.Extensions.Logging;
 namespace Copilotd.Infrastructure;
 
 /// <summary>
-/// Handles atomic read/write of config.json and state.json under ~/.copilotd.
+/// Handles atomic read/write of config.json and state.json under copilotd's home
+/// directory (defaults to ~/.copilotd, overrideable with COPILOTD_HOME).
 /// Writes use temp-then-rename for crash safety. Corrupt/missing files are
 /// treated as empty (self-healing).
 /// </summary>
@@ -28,8 +29,7 @@ public sealed class StateStore
     public StateStore(ILogger<StateStore> logger)
     {
         _logger = logger;
-        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        _configDir = Path.Combine(home, ".copilotd");
+        _configDir = CopilotdPaths.GetCopilotdHomeDirectory();
         _configPath = Path.Combine(_configDir, "config.json");
         _statePath = Path.Combine(_configDir, "state.json");
         _updateStatePath = Path.Combine(_configDir, "update-state.json");
@@ -122,7 +122,7 @@ public sealed class StateStore
     // --- Prompt ---
 
     /// <summary>
-    /// Loads the user's custom prompt addition from ~/.copilotd/prompt.md if it exists
+    /// Loads the user's custom prompt addition from the copilotd home directory's prompt.md if it exists
     /// and contains non-default content, falling back to the config's inline Prompt property.
     /// Returns empty string if no custom prompt is configured.
     /// </summary>
@@ -273,7 +273,7 @@ public sealed class StateStore
     // --- Daemon PID tracking ---
 
     /// <summary>
-    /// Writes the current process ID and start time to ~/.copilotd/.pid.
+    /// Writes the current process ID and start time to the copilotd home directory's .pid file.
     /// Used by the stop command to locate and verify the daemon process.
     /// </summary>
     private void WriteDaemonPid()
@@ -441,6 +441,22 @@ public sealed class StateStore
         _updateLockStream?.Dispose();
         _updateLockStream = null;
         try { File.Delete(_updateLockPath); } catch { /* best effort */ }
+    }
+
+    public bool IsUpdateLockHeld()
+    {
+        if (!File.Exists(_updateLockPath))
+            return false;
+
+        try
+        {
+            using var fs = new FileStream(_updateLockPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+            return false;
+        }
+        catch (IOException)
+        {
+            return !IsUpdateLockStale();
+        }
     }
 
     private void WriteUpdateLockInfo()

--- a/src/copilotd/Infrastructure/StateStore.cs
+++ b/src/copilotd/Infrastructure/StateStore.cs
@@ -253,6 +253,23 @@ public sealed class StateStore
         }
     }
 
+    /// <summary>
+    /// Attempts to acquire the daemon lock file without writing daemon PID metadata.
+    /// Used by the staged installer to prevent a new daemon from starting while the
+    /// binary replacement is in progress.
+    /// </summary>
+    public FileStream? TryAcquireInstallWindowLock()
+    {
+        try
+        {
+            return new FileStream(_lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+    }
+
     // --- Daemon PID tracking ---
 
     /// <summary>

--- a/src/copilotd/Models/CopilotdConfig.cs
+++ b/src/copilotd/Models/CopilotdConfig.cs
@@ -3,7 +3,8 @@ using System.Text.Json.Serialization;
 namespace Copilotd.Models;
 
 /// <summary>
-/// Top-level user-managed configuration persisted to ~/.copilotd/config.json.
+/// Top-level user-managed configuration persisted under copilotd's home directory
+/// (defaults to ~/.copilotd/config.json, overrideable with COPILOTD_HOME).
 /// </summary>
 public sealed class CopilotdConfig
 {

--- a/src/copilotd/Models/SessionState.cs
+++ b/src/copilotd/Models/SessionState.cs
@@ -3,7 +3,8 @@ using System.Text.Json.Serialization;
 namespace Copilotd.Models;
 
 /// <summary>
-/// Top-level runtime state persisted to ~/.copilotd/state.json.
+/// Top-level runtime state persisted under copilotd's home directory
+/// (defaults to ~/.copilotd/state.json, overrideable with COPILOTD_HOME).
 /// Self-healing: a missing or corrupt file is treated as empty state.
 /// </summary>
 public sealed class DaemonState

--- a/src/copilotd/Models/UpdateState.cs
+++ b/src/copilotd/Models/UpdateState.cs
@@ -20,6 +20,9 @@ public enum UpdateStatus
     /// <summary>Update binary is downloaded, verified, and staged for install.</summary>
     Staged,
 
+    /// <summary>Install is deferred until the tracked daemon instance exits naturally.</summary>
+    WaitingForExit,
+
     /// <summary>Install of the staged binary is in progress.</summary>
     Installing,
 
@@ -44,6 +47,18 @@ public sealed class UpdateState
 
     /// <summary>Full path to the staged binary (e.g. copilotd.exe.staged).</summary>
     public string? StagedPath { get; set; }
+
+    /// <summary>Daemon PID that a deferred installer should wait for before installing.</summary>
+    public int? WaitForPid { get; set; }
+
+    /// <summary>Expected start time for <see cref="WaitForPid"/>, used to detect PID reuse.</summary>
+    public DateTimeOffset? WaitForStartTime { get; set; }
+
+    /// <summary>PID of the detached deferred installer process, if one is currently tracking the update.</summary>
+    public int? WatcherPid { get; set; }
+
+    /// <summary>Expected start time for <see cref="WatcherPid"/>, used to detect PID reuse.</summary>
+    public DateTimeOffset? WatcherStartTime { get; set; }
 
     /// <summary>GitHub release tag of the release being processed.</summary>
     public string? CurrentReleaseTag { get; set; }

--- a/src/copilotd/Models/UpdateState.cs
+++ b/src/copilotd/Models/UpdateState.cs
@@ -31,7 +31,8 @@ public enum UpdateStatus
 }
 
 /// <summary>
-/// Persisted update state stored at ~/.copilotd/update-state.json.
+/// Persisted update state stored under copilotd's home directory
+/// (defaults to ~/.copilotd/update-state.json, overrideable with COPILOTD_HOME).
 /// Tracks the current self-update lifecycle so the daemon and update command
 /// can coordinate across process boundaries.
 /// </summary>

--- a/src/copilotd/Program.cs
+++ b/src/copilotd/Program.cs
@@ -15,6 +15,39 @@ public class Program
         {
             var consoleLogLevel = ParseLogLevel(args);
             var services = ConfigureServices(consoleLogLevel);
+            var runtimeContext = services.GetRequiredService<RuntimeContext>();
+            var stateStore = services.GetRequiredService<StateStore>();
+            var updateService = services.GetRequiredService<UpdateService>();
+
+            if (IsStartupRepairCommand(args) && stateStore.IsUpdateLockHeld())
+            {
+                ConsoleOutput.Error("A self-update is already in progress. Wait for it to finish before starting copilotd.");
+                return 1;
+            }
+
+            if (ShouldRunStartupRepair(args, runtimeContext, stateStore)
+                && await updateService.RepairInterruptedInstallAsync(skipProvenance: false, CancellationToken.None) is { } repairResult)
+            {
+                if (!repairResult.Succeeded)
+                {
+                    ConsoleOutput.Error(repairResult.Message);
+                    return 1;
+                }
+
+                ConsoleOutput.Info(repairResult.Message);
+
+                if (repairResult.RelaunchRequired)
+                {
+                    var relaunchExitCode = await RelaunchWithCurrentArgumentsAsync(args, CancellationToken.None);
+                    if (relaunchExitCode is null)
+                    {
+                        ConsoleOutput.Error("Startup repair installed a newer binary, but copilotd could not relaunch the requested command automatically.");
+                        return 1;
+                    }
+
+                    return relaunchExitCode.Value;
+                }
+            }
 
             var rootCommand = new RootCommand("copilotd - GitHub issue dispatch daemon for Copilot CLI");
 
@@ -101,4 +134,68 @@ public class Program
         "error" => LogLevel.Error,
         _ => LogLevel.Information,
     };
+
+    private static bool ShouldRunStartupRepair(string[] args, RuntimeContext runtimeContext, StateStore stateStore)
+    {
+        if (!runtimeContext.SupportsInPlaceSelfUpdate())
+            return false;
+
+        if (stateStore.IsLockHeld())
+            return false;
+
+        if (!IsStartupRepairCommand(args))
+            return false;
+
+        return true;
+    }
+
+    private static bool IsStartupRepairCommand(string[] args)
+    {
+        if (args.Any(IsHelpOrVersionArgument))
+            return false;
+
+        var command = args.FirstOrDefault(a => !a.StartsWith('-'));
+        return string.Equals(command, "run", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(command, "start", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsHelpOrVersionArgument(string arg)
+        => string.Equals(arg, "--help", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(arg, "-h", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(arg, "-?", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(arg, "/?", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(arg, "--version", StringComparison.OrdinalIgnoreCase);
+
+    private static async Task<int?> RelaunchWithCurrentArgumentsAsync(string[] args, CancellationToken ct)
+    {
+        var processPath = Environment.ProcessPath;
+        if (string.IsNullOrWhiteSpace(processPath))
+            return null;
+
+        try
+        {
+            var psi = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = processPath,
+                UseShellExecute = false,
+            };
+
+            foreach (var arg in args)
+                psi.ArgumentList.Add(arg);
+
+            var process = System.Diagnostics.Process.Start(psi);
+            if (process is null)
+                return null;
+
+            using (process)
+            {
+                await process.WaitForExitAsync(ct);
+                return process.ExitCode;
+            }
+        }
+        catch
+        {
+            return null;
+        }
+    }
 }

--- a/src/copilotd/Services/UpdateService.cs
+++ b/src/copilotd/Services/UpdateService.cs
@@ -333,6 +333,7 @@ public sealed class UpdateService
                             _logger.LogInformation("A daemon started before deferred install could begin, retrying wait for the active instance");
                         }
 
+                        await Task.Delay(TimeSpan.FromSeconds(1), ct);
                         continue;
                     }
                 }
@@ -748,7 +749,7 @@ public sealed class UpdateService
     {
         try
         {
-            var proc = System.Diagnostics.Process.GetProcessById(pid);
+            using var proc = System.Diagnostics.Process.GetProcessById(pid);
 
             // Verify PID hasn't been reused by comparing start time
             var actualStart = proc.StartTime.ToUniversalTime();

--- a/src/copilotd/Services/UpdateService.cs
+++ b/src/copilotd/Services/UpdateService.cs
@@ -14,6 +14,11 @@ public sealed record UpdateCheckResult(
     string ReleaseTag,
     bool IsDevBuild);
 
+public sealed record StartupRepairResult(
+    bool Succeeded,
+    string Message,
+    bool RelaunchRequired = false);
+
 /// <summary>
 /// Orchestrates the self-update lifecycle: check → download → verify → stage → install.
 /// </summary>
@@ -75,6 +80,125 @@ public sealed class UpdateService
             state.ErrorMessage = null;
             _stateStore.SaveUpdateState(state);
             return true;
+        }
+        finally
+        {
+            _stateStore.ReleaseUpdateLock();
+        }
+    }
+
+    public async Task<StartupRepairResult?> RepairInterruptedInstallAsync(bool skipProvenance, CancellationToken ct)
+    {
+        if (!_stateStore.TryAcquireUpdateLock())
+        {
+            return new StartupRepairResult(
+                false,
+                "A self-update is already in progress. Wait for it to finish before starting copilotd.");
+        }
+
+        try
+        {
+        var currentExePath = Environment.ProcessPath;
+        if (string.IsNullOrEmpty(currentExePath))
+            return null;
+
+        var installDir = Path.GetDirectoryName(currentExePath)!;
+        var binaryName = OperatingSystem.IsWindows() ? "copilotd.exe" : "copilotd";
+        var oldPath = Path.Combine(installDir, $"{binaryName}.old");
+        var defaultStagedPath = Path.Combine(installDir, $"{binaryName}.staged");
+
+        var state = _stateStore.LoadUpdateState();
+        if (state.Status != UpdateStatus.Installing)
+        {
+            if (!File.Exists(oldPath))
+                return null;
+
+            CleanupOldBinary();
+            return File.Exists(oldPath)
+                ? null
+                : new StartupRepairResult(true, "Cleaned up leftover backup binary from a previous self-update.");
+        }
+
+        if (string.IsNullOrWhiteSpace(state.StagedPath))
+        {
+            ClearInterruptedInstallArtifactsCore(defaultStagedPath);
+            CleanupOldBinary();
+            return new StartupRepairResult(
+                true,
+                "Cleared interrupted self-update state because the staged path metadata was missing.");
+        }
+
+        var stagedPath = state.StagedPath;
+        if (!File.Exists(stagedPath))
+        {
+            ClearInterruptedInstallArtifactsCore(stagedPath);
+            CleanupOldBinary();
+            return new StartupRepairResult(
+                true,
+                "Cleared interrupted self-update state because the staged binary was missing.");
+        }
+
+        var currentVersionString = VersionHelper.GetCurrentVersion();
+        if (currentVersionString is null || !VersionHelper.TryParse(currentVersionString, out var currentVersion))
+        {
+            ClearInterruptedInstallArtifactsCore(stagedPath);
+            CleanupOldBinary();
+            return new StartupRepairResult(
+                true,
+                "Cleared interrupted self-update state because the current binary version could not be determined safely.");
+        }
+
+        if (string.IsNullOrWhiteSpace(state.StagedVersion)
+            || !VersionHelper.TryParse(state.StagedVersion, out var stagedVersion))
+        {
+            ClearInterruptedInstallArtifactsCore(stagedPath);
+            CleanupOldBinary();
+            return new StartupRepairResult(
+                true,
+                "Cleared interrupted self-update state because the staged version metadata was invalid.");
+        }
+
+        if (stagedVersion.CompareTo(currentVersion) <= 0)
+        {
+            ClearInterruptedInstallArtifactsCore(stagedPath);
+            CleanupOldBinary();
+            return new StartupRepairResult(
+                true,
+                $"Discarded stale staged update {state.StagedVersion} because the current binary is already {currentVersionString} or newer.");
+        }
+
+        _logger.LogWarning(
+            "Resuming interrupted self-update install of {StagedVersion} over current binary {CurrentVersion}",
+            state.StagedVersion,
+            currentVersionString);
+
+        using var installWindowLock = _stateStore.TryAcquireInstallWindowLock();
+        if (installWindowLock is null)
+        {
+            return new StartupRepairResult(
+                false,
+                "Another copilotd instance started while startup repair was running. Retry the command after it exits.");
+        }
+
+        var installed = await InstallStagedCoreAsync(
+            skipProvenance,
+            waitForPid: null,
+            waitForStartTime: null,
+            allowDaemonShutdown: true,
+            ct);
+
+        if (installed)
+        {
+            return new StartupRepairResult(
+                true,
+                $"Recovered interrupted self-update install and applied staged version {state.StagedVersion}.",
+                RelaunchRequired: true);
+        }
+
+        var failedState = _stateStore.LoadUpdateState();
+        return new StartupRepairResult(
+            false,
+            $"Detected interrupted self-update install but automatic recovery failed: {failedState.ErrorMessage ?? "unknown error"}.");
         }
         finally
         {
@@ -356,7 +480,9 @@ public sealed class UpdateService
         CancellationToken ct)
     {
         var state = _stateStore.LoadUpdateState();
-        if ((state.Status != UpdateStatus.Staged && state.Status != UpdateStatus.WaitingForExit)
+        if ((state.Status != UpdateStatus.Staged
+             && state.Status != UpdateStatus.WaitingForExit
+             && state.Status != UpdateStatus.Installing)
             || string.IsNullOrEmpty(state.StagedPath))
         {
             _logger.LogWarning("No staged update found to install");
@@ -574,6 +700,49 @@ public sealed class UpdateService
         state.LastAttemptTime = DateTimeOffset.UtcNow;
         _stateStore.SaveUpdateState(state);
         _logger.LogWarning("Update failed (attempt #{Count}): {Message}", state.FailureCount, message);
+    }
+
+    private void ClearInterruptedInstallArtifacts(string stagedPath)
+    {
+        if (!_stateStore.TryAcquireUpdateLock())
+        {
+            _logger.LogWarning("Could not acquire the update lock to clear interrupted install artifacts");
+            return;
+        }
+
+        try
+        {
+            try
+            {
+                if (File.Exists(stagedPath))
+                    File.Delete(stagedPath);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Failed to delete stale staged binary '{Path}'", stagedPath);
+            }
+
+            _stateStore.ClearUpdateState();
+        }
+        finally
+        {
+            _stateStore.ReleaseUpdateLock();
+        }
+    }
+
+    private void ClearInterruptedInstallArtifactsCore(string stagedPath)
+    {
+        try
+        {
+            if (File.Exists(stagedPath))
+                File.Delete(stagedPath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to delete stale staged binary '{Path}'", stagedPath);
+        }
+
+        _stateStore.ClearUpdateState();
     }
 
     private async Task<bool> WaitForDaemonChainToExitAsync(int initialPid, DateTimeOffset initialStartTime, CancellationToken ct)

--- a/src/copilotd/Services/UpdateService.cs
+++ b/src/copilotd/Services/UpdateService.cs
@@ -45,6 +45,43 @@ public sealed class UpdateService
         _logger = logger;
     }
 
+    public static bool HasUsableStagedUpdate(UpdateState state)
+        => (state.Status == UpdateStatus.Staged || state.Status == UpdateStatus.WaitingForExit)
+           && !string.IsNullOrEmpty(state.StagedPath)
+           && File.Exists(state.StagedPath);
+
+    public bool TryScheduleDeferredInstall(int waitForPid, DateTimeOffset waitForStartTime, int watcherPid, DateTimeOffset? watcherStartTime)
+    {
+        if (!_stateStore.TryAcquireUpdateLock())
+        {
+            _logger.LogDebug("Another update operation is in progress, cannot record deferred installer state");
+            return false;
+        }
+
+        try
+        {
+            var state = _stateStore.LoadUpdateState();
+            if (!HasUsableStagedUpdate(state))
+            {
+                _logger.LogDebug("No staged update is available to defer");
+                return false;
+            }
+
+            state.Status = UpdateStatus.WaitingForExit;
+            state.WaitForPid = waitForPid;
+            state.WaitForStartTime = waitForStartTime;
+            state.WatcherPid = watcherPid;
+            state.WatcherStartTime = watcherStartTime;
+            state.ErrorMessage = null;
+            _stateStore.SaveUpdateState(state);
+            return true;
+        }
+        finally
+        {
+            _stateStore.ReleaseUpdateLock();
+        }
+    }
+
     /// <summary>
     /// Checks whether an update is available from GitHub Releases.
     /// </summary>
@@ -215,6 +252,7 @@ public sealed class UpdateService
             state.Status = UpdateStatus.Staged;
             state.StagedVersion = update.AvailableVersion;
             state.StagedPath = stagedPath;
+            ClearDeferredInstallMetadata(state);
             state.LastCheckTime = DateTimeOffset.UtcNow;
             state.ErrorMessage = null;
             state.FailureCount = 0;
@@ -241,28 +279,84 @@ public sealed class UpdateService
     /// Installs a previously staged binary. Called by <c>copilotd update --install-staged</c>.
     /// Waits for any running daemon to exit, then performs atomic binary replacement with rollback.
     /// </summary>
-    public async Task<bool> InstallStagedAsync(bool skipProvenance, CancellationToken ct)
+    public async Task<bool> InstallStagedAsync(
+        bool skipProvenance,
+        int? waitForPid,
+        DateTimeOffset? waitForStartTime,
+        bool allowDaemonShutdown,
+        CancellationToken ct)
     {
-        if (!_stateStore.TryAcquireUpdateLock())
+        var passiveWaitTarget = default((int Pid, DateTimeOffset StartTime)?);
+        if (!allowDaemonShutdown)
         {
-            _logger.LogWarning("Another update operation is in progress, cannot install staged update");
-            return false;
+            if (waitForPid is null || waitForStartTime is null)
+            {
+                _logger.LogWarning("Passive staged install requires an explicit daemon PID and start time");
+                return false;
+            }
+
+            passiveWaitTarget = (waitForPid.Value, waitForStartTime.Value);
         }
 
-        try
+        while (true)
         {
-            return await InstallStagedCoreAsync(skipProvenance, ct);
-        }
-        finally
-        {
-            _stateStore.ReleaseUpdateLock();
+            if (passiveWaitTarget is { } waitTarget
+                && !await WaitForDaemonChainToExitAsync(waitTarget.Pid, waitTarget.StartTime, ct))
+            {
+                return false;
+            }
+
+            if (!_stateStore.TryAcquireUpdateLock())
+            {
+                _logger.LogWarning("Another update operation is in progress, cannot install staged update");
+                return false;
+            }
+
+            FileStream? installWindowLock = null;
+            try
+            {
+                if (passiveWaitTarget is not null)
+                {
+                    installWindowLock = _stateStore.TryAcquireInstallWindowLock();
+                    if (installWindowLock is null)
+                    {
+                        var activeDaemon = _stateStore.ReadDaemonPid();
+                        if (activeDaemon is { } nextTarget)
+                        {
+                            _logger.LogInformation(
+                                "Daemon PID {Pid} started before deferred install could begin, continuing to wait for it to exit naturally",
+                                nextTarget.Pid);
+                            passiveWaitTarget = nextTarget;
+                        }
+                        else
+                        {
+                            _logger.LogInformation("A daemon started before deferred install could begin, retrying wait for the active instance");
+                        }
+
+                        continue;
+                    }
+                }
+
+                return await InstallStagedCoreAsync(skipProvenance, waitForPid, waitForStartTime, allowDaemonShutdown, ct);
+            }
+            finally
+            {
+                installWindowLock?.Dispose();
+                _stateStore.ReleaseUpdateLock();
+            }
         }
     }
 
-    private async Task<bool> InstallStagedCoreAsync(bool skipProvenance, CancellationToken ct)
+    private async Task<bool> InstallStagedCoreAsync(
+        bool skipProvenance,
+        int? waitForPid,
+        DateTimeOffset? waitForStartTime,
+        bool allowDaemonShutdown,
+        CancellationToken ct)
     {
         var state = _stateStore.LoadUpdateState();
-        if (state.Status != UpdateStatus.Staged || string.IsNullOrEmpty(state.StagedPath))
+        if ((state.Status != UpdateStatus.Staged && state.Status != UpdateStatus.WaitingForExit)
+            || string.IsNullOrEmpty(state.StagedPath))
         {
             _logger.LogWarning("No staged update found to install");
             return false;
@@ -275,8 +369,41 @@ public sealed class UpdateService
             return false;
         }
 
+        if (allowDaemonShutdown)
+        {
+            var daemonPid = waitForPid is not null && waitForStartTime is not null
+                ? (Pid: waitForPid.Value, StartTime: waitForStartTime.Value)
+                : _stateStore.ReadDaemonPid();
+
+            if (daemonPid is not null)
+            {
+                _logger.LogInformation("Waiting for daemon (PID {Pid}) to exit...", daemonPid.Value.Pid);
+                if (!await WaitForProcessExitAsync(daemonPid.Value.Pid, daemonPid.Value.StartTime, DaemonExitTimeout, ct))
+                {
+                    // Try graceful shutdown first
+                    _logger.LogWarning("Daemon did not exit within timeout, attempting graceful shutdown");
+                    if (!TryGracefulShutdown(daemonPid.Value.Pid))
+                    {
+                        // Final fallback: force kill
+                        _logger.LogWarning("Graceful shutdown failed, force-killing daemon");
+                        try
+                        {
+                            var proc = System.Diagnostics.Process.GetProcessById(daemonPid.Value.Pid);
+                            proc.Kill(entireProcessTree: true);
+                            proc.WaitForExit(5000);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogDebug(ex, "Failed to terminate daemon process");
+                        }
+                    }
+                }
+            }
+        }
+
         state.Status = UpdateStatus.Installing;
         state.LastAttemptTime = DateTimeOffset.UtcNow;
+        ClearDeferredInstallMetadata(state);
         _stateStore.SaveUpdateState(state);
 
         // Re-verify provenance of staged binary before install
@@ -289,33 +416,6 @@ public sealed class UpdateService
                 {
                     RecordFailure(state, $"Pre-install provenance check failed: {trustErr}");
                     return false;
-                }
-            }
-        }
-
-        // Wait for daemon to exit
-        var daemonPid = _stateStore.ReadDaemonPid();
-        if (daemonPid is not null)
-        {
-            _logger.LogInformation("Waiting for daemon (PID {Pid}) to exit...", daemonPid.Value.Pid);
-            if (!await WaitForProcessExitAsync(daemonPid.Value.Pid, daemonPid.Value.StartTime, DaemonExitTimeout, ct))
-            {
-                // Try graceful shutdown first
-                _logger.LogWarning("Daemon did not exit within timeout, attempting graceful shutdown");
-                if (!TryGracefulShutdown(daemonPid.Value.Pid))
-                {
-                    // Final fallback: force kill
-                    _logger.LogWarning("Graceful shutdown failed, force-killing daemon");
-                    try
-                    {
-                        var proc = System.Diagnostics.Process.GetProcessById(daemonPid.Value.Pid);
-                        proc.Kill(entireProcessTree: true);
-                        proc.WaitForExit(5000);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogDebug(ex, "Failed to terminate daemon process");
-                    }
                 }
             }
         }
@@ -384,8 +484,8 @@ public sealed class UpdateService
     {
         var state = _stateStore.LoadUpdateState();
 
-        // Don't re-check if already staged
-        if (state.Status == UpdateStatus.Staged && !string.IsNullOrEmpty(state.StagedPath) && File.Exists(state.StagedPath))
+        // Don't re-check if already staged or waiting for a deferred install
+        if (HasUsableStagedUpdate(state))
         {
             _logger.LogDebug("Update already staged, skipping check");
             return true;
@@ -467,11 +567,48 @@ public sealed class UpdateService
     private void RecordFailure(UpdateState state, string message)
     {
         state.Status = UpdateStatus.Failed;
+        ClearDeferredInstallMetadata(state);
         state.ErrorMessage = message;
         state.FailureCount++;
         state.LastAttemptTime = DateTimeOffset.UtcNow;
         _stateStore.SaveUpdateState(state);
         _logger.LogWarning("Update failed (attempt #{Count}): {Message}", state.FailureCount, message);
+    }
+
+    private async Task<bool> WaitForDaemonChainToExitAsync(int initialPid, DateTimeOffset initialStartTime, CancellationToken ct)
+    {
+        var currentTarget = (Pid: initialPid, StartTime: initialStartTime);
+
+        while (true)
+        {
+            _logger.LogInformation("Waiting for daemon (PID {Pid}) to exit naturally before installing staged update...", currentTarget.Pid);
+            if (!await WaitForProcessExitAsync(currentTarget.Pid, currentTarget.StartTime, timeout: null, ct))
+                return false;
+
+            while (_stateStore.IsLockHeld())
+            {
+                var activeDaemon = _stateStore.ReadDaemonPid();
+                if (activeDaemon is null)
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(1), ct);
+                    continue;
+                }
+
+                if (IsSameTrackedProcess(activeDaemon.Value.Pid, activeDaemon.Value.StartTime, currentTarget.Pid, currentTarget.StartTime))
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(1), ct);
+                    continue;
+                }
+
+                currentTarget = activeDaemon.Value;
+                goto ContinueWaiting;
+            }
+
+            return true;
+
+        ContinueWaiting:
+            continue;
+        }
     }
 
     /// <summary>
@@ -607,7 +744,7 @@ public sealed class UpdateService
         return false;
     }
 
-    private static async Task<bool> WaitForProcessExitAsync(int pid, DateTimeOffset expectedStartTime, TimeSpan timeout, CancellationToken ct)
+    private static async Task<bool> WaitForProcessExitAsync(int pid, DateTimeOffset expectedStartTime, TimeSpan? timeout, CancellationToken ct)
     {
         try
         {
@@ -622,9 +759,16 @@ public sealed class UpdateService
                 return true;
             }
 
-            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-            cts.CancelAfter(timeout);
-            await proc.WaitForExitAsync(cts.Token);
+            if (timeout is { } finiteTimeout)
+            {
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                cts.CancelAfter(finiteTimeout);
+                await proc.WaitForExitAsync(cts.Token);
+            }
+            else
+            {
+                await proc.WaitForExitAsync(ct);
+            }
             return true;
         }
         catch (ArgumentException)
@@ -636,6 +780,17 @@ public sealed class UpdateService
         {
             return false;
         }
+    }
+
+    private static bool IsSameTrackedProcess(int pid, DateTimeOffset startTime, int expectedPid, DateTimeOffset expectedStartTime)
+        => pid == expectedPid && Math.Abs((startTime - expectedStartTime).TotalSeconds) <= 5;
+
+    private static void ClearDeferredInstallMetadata(UpdateState state)
+    {
+        state.WaitForPid = null;
+        state.WaitForStartTime = null;
+        state.WatcherPid = null;
+        state.WatcherStartTime = null;
     }
 
     private static string? GetExpectedHash(string checksumsPath, string assetName)


### PR DESCRIPTION
## Summary
- defer automatic self-update installs by spawning a detached watcher that waits for the daemon chain to exit naturally
- keep explicit `copilotd update` installs immediate, including the existing daemon shutdown behavior when needed
- persist watcher/target PID metadata, guard the install window against daemon restarts, and document the background self-update behavior in README

## Root cause
The existing daemon self-update path treated a staged update as an immediate install trigger. `copilotd run` spawned `update --install-staged`, cancelled its own loop, and then shut down the daemon and active sessions so the binary replacement could proceed. That behavior was the opposite of the intended design for automatic updates, which should stage the binary and install it only after the daemon exits naturally.

## Notes
- automatic installs now use a `WaitingForExit` update state and a detached watcher process keyed by PID + start time
- the passive install path follows daemon restarts and acquires the daemon lock during the install window so a new daemon cannot start mid-replacement
- rubber-duck review completed with GPT-5.4 and Claude Opus 4.6; GPT surfaced two concurrency issues that were fixed, and the final review passes were clean

Closes #112