### PR TITLE
Fix init repo-home prompt wording

### DIFF
--- a/src/copilotd/Commands/InitCommand.cs
+++ b/src/copilotd/Commands/InitCommand.cs
@@ -86,7 +86,7 @@ public static class InitCommand
                 AnsiConsole.WriteLine();
 
                 var examplePath = OperatingSystem.IsWindows() ? @"C:\source" : "~/repos";
-                AnsiConsole.MarkupLine($"[grey]This is the root directory where your repos are cloned.[/]");
+                AnsiConsole.MarkupLine("[grey]This is the root directory where your GitHub repos are cloned.[/]");
                 var repoHomePrompt = new TextPrompt<string>($"Enter repo home directory (e.g., {Markup.Escape(examplePath)}):");
                 if (config.RepoHome is not null)
                     repoHomePrompt.DefaultValue(config.RepoHome);


### PR DESCRIPTION
## Summary
- update the init repo-home prompt to refer to GitHub repos
- leave the repo-home prompt behavior unchanged

Fixes #100