### PR TITLE
Improve shutdown-instance observability

### DIFF
--- a/src/copilotd/Commands/ShutdownInstanceCommand.cs
+++ b/src/copilotd/Commands/ShutdownInstanceCommand.cs
@@ -70,6 +70,7 @@ public static class ShutdownInstanceCommand
             || exitCode == (int)ShutdownInstanceExitCode.ExitedAfterFirstInterrupt
             || exitCode == (int)ShutdownInstanceExitCode.ExitedAfterSecondInterrupt
             || exitCode == (int)ShutdownInstanceExitCode.FallbackKill
+            || exitCode == (int)ShutdownInstanceExitCode.ExitedDuringFallback
             || exitCode == (int)ShutdownInstanceExitCode.StartTimeMismatch;
 
     public static bool UsedFallbackKillExitCode(int exitCode)
@@ -82,6 +83,7 @@ public static class ShutdownInstanceCommand
             (int)ShutdownInstanceExitCode.ExitedAfterFirstInterrupt => "exited after first interrupt",
             (int)ShutdownInstanceExitCode.ExitedAfterSecondInterrupt => "exited after second interrupt",
             (int)ShutdownInstanceExitCode.FallbackKill => "fallback kill",
+            (int)ShutdownInstanceExitCode.ExitedDuringFallback => "exited during fallback",
             (int)ShutdownInstanceExitCode.StartTimeMismatch => "start time mismatch",
             (int)ShutdownInstanceExitCode.InvalidArguments => "invalid arguments",
             (int)ShutdownInstanceExitCode.Failed => "failed",
@@ -263,7 +265,8 @@ public static class ShutdownInstanceCommand
             }
             else
             {
-                logger.LogInformation("shutdown-instance fallback kill found PID {Pid} already exited", pid);
+                logger.LogInformation("shutdown-instance found PID {Pid} already exited during fallback", pid);
+                return ShutdownInstanceExitCode.ExitedDuringFallback;
             }
 
             return ShutdownInstanceExitCode.FallbackKill;
@@ -332,6 +335,7 @@ public static class ShutdownInstanceCommand
         ExitedAfterSecondInterrupt = 2,
         FallbackKill = 3,
         StartTimeMismatch = 4,
+        ExitedDuringFallback = 5,
         InvalidArguments = 64,
         Failed = 65
     }

--- a/src/copilotd/Commands/ShutdownInstanceCommand.cs
+++ b/src/copilotd/Commands/ShutdownInstanceCommand.cs
@@ -3,6 +3,8 @@ using System.CommandLine.Parsing;
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.InteropServices;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Copilotd.Commands;
 
@@ -17,7 +19,7 @@ public static class ShutdownInstanceCommand
     private static readonly TimeSpan SignalDelay = TimeSpan.FromSeconds(2);
     private static readonly TimeSpan GracefulTimeout = TimeSpan.FromSeconds(10);
 
-    public static Command Create()
+    public static Command Create(IServiceProvider services)
     {
         var command = new Command("shutdown-instance", "Internal: gracefully shut down a copilot process")
         {
@@ -33,26 +35,70 @@ public static class ShutdownInstanceCommand
 
         command.SetAction(async (ParseResult parseResult, CancellationToken ct) =>
         {
+            var logger = services.GetRequiredService<ILoggerFactory>().CreateLogger(typeof(ShutdownInstanceCommand).FullName!);
             var pid = parseResult.GetValue(pidOption);
             var expectedStartText = parseResult.GetValue(expectedStartOption);
             var delaySeconds = parseResult.GetValue(delaySecondsOption);
             if (delaySeconds < 0)
-                return 1;
+            {
+                logger.LogWarning("shutdown-instance received invalid negative delay {DelaySeconds} for PID {Pid}", delaySeconds, pid);
+                return (int)ShutdownInstanceExitCode.InvalidArguments;
+            }
 
             if (!TryParseExpectedStart(expectedStartText, out var expectedStart))
-                return 1;
+            {
+                logger.LogWarning("shutdown-instance received invalid expected start '{ExpectedStart}' for PID {Pid}", expectedStartText, pid);
+                return (int)ShutdownInstanceExitCode.InvalidArguments;
+            }
 
-            return ShutdownProcess(pid, expectedStart, TimeSpan.FromSeconds(delaySeconds));
+            try
+            {
+                return (int)ShutdownProcess(pid, expectedStart, TimeSpan.FromSeconds(delaySeconds), logger);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "shutdown-instance failed unexpectedly for PID {Pid}", pid);
+                return (int)ShutdownInstanceExitCode.Failed;
+            }
         });
 
         return command;
     }
 
-    private static int ShutdownProcess(int pid, DateTimeOffset? expectedStart, TimeSpan shutdownDelay)
+    public static bool IsSuccessExitCode(int exitCode)
+        => exitCode == (int)ShutdownInstanceExitCode.AlreadyExited
+            || exitCode == (int)ShutdownInstanceExitCode.ExitedAfterFirstInterrupt
+            || exitCode == (int)ShutdownInstanceExitCode.ExitedAfterSecondInterrupt
+            || exitCode == (int)ShutdownInstanceExitCode.FallbackKill
+            || exitCode == (int)ShutdownInstanceExitCode.StartTimeMismatch;
+
+    public static bool UsedFallbackKillExitCode(int exitCode)
+        => exitCode == (int)ShutdownInstanceExitCode.FallbackKill;
+
+    public static string DescribeExitCode(int exitCode)
+        => exitCode switch
+        {
+            (int)ShutdownInstanceExitCode.AlreadyExited => "already exited",
+            (int)ShutdownInstanceExitCode.ExitedAfterFirstInterrupt => "exited after first interrupt",
+            (int)ShutdownInstanceExitCode.ExitedAfterSecondInterrupt => "exited after second interrupt",
+            (int)ShutdownInstanceExitCode.FallbackKill => "fallback kill",
+            (int)ShutdownInstanceExitCode.StartTimeMismatch => "start time mismatch",
+            (int)ShutdownInstanceExitCode.InvalidArguments => "invalid arguments",
+            (int)ShutdownInstanceExitCode.Failed => "failed",
+            _ => $"unknown exit code {exitCode}"
+        };
+
+    private static ShutdownInstanceExitCode ShutdownProcess(int pid, DateTimeOffset? expectedStart, TimeSpan shutdownDelay, ILogger logger)
     {
         var effectiveDelay = shutdownDelay < TimeSpan.Zero ? TimeSpan.Zero : shutdownDelay;
+        logger.LogInformation("shutdown-instance starting for PID {Pid} with delay {Delay} and expected start {ExpectedStart}",
+            pid, effectiveDelay, expectedStart);
+
         if (effectiveDelay > TimeSpan.Zero)
+        {
+            logger.LogInformation("shutdown-instance waiting {Delay} before signaling PID {Pid}", effectiveDelay, pid);
             Thread.Sleep(effectiveDelay);
+        }
 
         Process process;
         try
@@ -61,8 +107,8 @@ public static class ShutdownInstanceCommand
         }
         catch (ArgumentException)
         {
-            // Already dead
-            return 0;
+            logger.LogInformation("shutdown-instance found PID {Pid} already exited before signaling", pid);
+            return ShutdownInstanceExitCode.AlreadyExited;
         }
 
         try
@@ -71,16 +117,27 @@ public static class ShutdownInstanceCommand
             {
                 var actualStart = GetProcessStartTime(process);
                 if (actualStart is not null && Math.Abs((actualStart.Value - expectedStartTime).TotalSeconds) > 5)
-                    return 0;
+                {
+                    logger.LogWarning("shutdown-instance skipped PID {Pid} due to start time mismatch. Expected {ExpectedStart}, actual {ActualStart}",
+                        pid, expectedStartTime, actualStart);
+                    return ShutdownInstanceExitCode.StartTimeMismatch;
+                }
             }
 
             if (process.HasExited)
-                return 0;
+            {
+                logger.LogInformation("shutdown-instance found PID {Pid} already exited after validation", pid);
+                return ShutdownInstanceExitCode.AlreadyExited;
+            }
 
+            ShutdownInstanceExitCode outcome;
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                return ShutdownWindows(process, pid);
+                outcome = ShutdownWindows(process, pid, logger);
             else
-                return ShutdownUnix(process, pid);
+                outcome = ShutdownUnix(process, pid, logger);
+
+            logger.LogInformation("shutdown-instance completed for PID {Pid} with outcome {Outcome}", pid, outcome);
+            return outcome;
         }
         finally
         {
@@ -89,11 +146,11 @@ public static class ShutdownInstanceCommand
     }
 
     /// <summary>
-    /// Windows: attach to the target's console and send Ctrl+Break, then Ctrl+C.
+    /// Windows: attach to the target's console and send Ctrl+C twice.
     /// This process was launched without the daemon's console, so FreeConsole/AttachConsole
     /// won't disrupt the daemon.
     /// </summary>
-    private static int ShutdownWindows(Process process, int pid)
+    private static ShutdownInstanceExitCode ShutdownWindows(Process process, int pid, ILogger logger)
     {
         // Detach from any inherited console
         FreeConsole();
@@ -103,68 +160,118 @@ public static class ShutdownInstanceCommand
 
         // Attach to the target's console
         if (!AttachConsole((uint)pid))
-            return FallbackKill(process, pid);
+        {
+            logger.LogWarning("shutdown-instance failed to attach to console for PID {Pid} (Win32 error {Error}), falling back to kill",
+                pid, Marshal.GetLastWin32Error());
+            return FallbackKill(process, pid, logger, "attach-console-failed");
+        }
 
         try
         {
-            // First try: Ctrl+Break targeted at the process group (PID)
-            GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, (uint)pid);
+            if (TrySendConsoleSignal(process, pid, logger, CTRL_C_EVENT, 0, "first Ctrl+C", SignalDelay, ShutdownInstanceExitCode.ExitedAfterFirstInterrupt) is { } firstOutcome)
+                return firstOutcome;
 
-            if (process.WaitForExit(SignalDelay))
-                return 0;
-
-            // Second try: Ctrl+C broadcast to all on the console
-            GenerateConsoleCtrlEvent(CTRL_C_EVENT, 0);
-
-            if (process.WaitForExit(GracefulTimeout))
-                return 0;
+            if (TrySendConsoleSignal(process, pid, logger, CTRL_C_EVENT, 0, "second Ctrl+C", GracefulTimeout, ShutdownInstanceExitCode.ExitedAfterSecondInterrupt) is { } secondOutcome)
+                return secondOutcome;
         }
-        catch
+        catch (Exception ex)
         {
-            // Fall through to kill
+            logger.LogWarning(ex, "shutdown-instance signal sequence failed for PID {Pid}, falling back to kill", pid);
+        }
+        finally
+        {
+            FreeConsole();
         }
 
-        return FallbackKill(process, pid);
+        return FallbackKill(process, pid, logger, "signals-exhausted");
     }
 
     /// <summary>
     /// Unix: send SIGINT, wait, then SIGKILL if needed.
     /// Note: on Unix the daemon calls this logic directly (no helper process needed).
     /// </summary>
-    private static int ShutdownUnix(Process process, int pid)
+    private static ShutdownInstanceExitCode ShutdownUnix(Process process, int pid, ILogger logger)
     {
         try
         {
+            logger.LogInformation("shutdown-instance sending first SIGINT to PID {Pid}", pid);
             sys_kill(pid, SIGINT);
 
             if (process.WaitForExit(SignalDelay))
-                return 0;
+            {
+                logger.LogInformation("PID {Pid} exited after first SIGINT", pid);
+                return ShutdownInstanceExitCode.ExitedAfterFirstInterrupt;
+            }
 
             // Second SIGINT
+            logger.LogInformation("shutdown-instance sending second SIGINT to PID {Pid}", pid);
             sys_kill(pid, SIGINT);
 
             if (process.WaitForExit(GracefulTimeout))
-                return 0;
+            {
+                logger.LogInformation("PID {Pid} exited after second SIGINT", pid);
+                return ShutdownInstanceExitCode.ExitedAfterSecondInterrupt;
+            }
         }
-        catch
+        catch (Exception ex)
         {
-            // Fall through to kill
+            logger.LogWarning(ex, "shutdown-instance SIGINT sequence failed for PID {Pid}, falling back to kill", pid);
         }
 
-        return FallbackKill(process, pid);
+        return FallbackKill(process, pid, logger, "signals-exhausted");
     }
 
-    private static int FallbackKill(Process process, int pid)
+    private static ShutdownInstanceExitCode? TrySendConsoleSignal(
+        Process process,
+        int pid,
+        ILogger logger,
+        uint signal,
+        uint processGroupId,
+        string description,
+        TimeSpan waitTime,
+        ShutdownInstanceExitCode successOutcome)
     {
+        logger.LogInformation("shutdown-instance sending {SignalDescription} to PID {Pid}", description, pid);
+
+        if (!GenerateConsoleCtrlEvent(signal, processGroupId))
+        {
+            logger.LogWarning("shutdown-instance failed to send {SignalDescription} to PID {Pid} (Win32 error {Error})",
+                description, pid, Marshal.GetLastWin32Error());
+            return null;
+        }
+
+        if (process.WaitForExit(waitTime))
+        {
+            logger.LogInformation("PID {Pid} exited after {SignalDescription}", pid, description);
+            return successOutcome;
+        }
+
+        logger.LogInformation("PID {Pid} was still running {WaitTime} after {SignalDescription}", pid, waitTime, description);
+        return null;
+    }
+
+    private static ShutdownInstanceExitCode FallbackKill(Process process, int pid, ILogger logger, string reason)
+    {
+        logger.LogWarning("shutdown-instance falling back to kill for PID {Pid} ({Reason})", pid, reason);
+
         try
         {
             if (!process.HasExited)
+            {
                 process.Kill(entireProcessTree: true);
-            return 0;
+                logger.LogWarning("shutdown-instance killed PID {Pid}", pid);
+            }
+            else
+            {
+                logger.LogInformation("shutdown-instance fallback kill found PID {Pid} already exited", pid);
+            }
+
+            return ShutdownInstanceExitCode.FallbackKill;
         }
-        catch
+        catch (Exception ex)
         {
-            return 1;
+            logger.LogError(ex, "shutdown-instance failed to kill PID {Pid}", pid);
+            return ShutdownInstanceExitCode.Failed;
         }
     }
 
@@ -210,7 +317,6 @@ public static class ShutdownInstanceCommand
     private delegate bool ConsoleCtrlHandler(uint dwCtrlType);
 
     private const uint CTRL_C_EVENT = 0;
-    private const uint CTRL_BREAK_EVENT = 1;
 
     [DllImport("libc", EntryPoint = "kill", SetLastError = true)]
     private static extern int sys_kill(int pid, int sig);
@@ -218,4 +324,15 @@ public static class ShutdownInstanceCommand
     private const int SIGINT = 2;
 
     #endregion
+
+    private enum ShutdownInstanceExitCode
+    {
+        AlreadyExited = 0,
+        ExitedAfterFirstInterrupt = 1,
+        ExitedAfterSecondInterrupt = 2,
+        FallbackKill = 3,
+        StartTimeMismatch = 4,
+        InvalidArguments = 64,
+        Failed = 65
+    }
 }

--- a/src/copilotd/Commands/StopCommand.cs
+++ b/src/copilotd/Commands/StopCommand.cs
@@ -119,7 +119,7 @@ public static class StopCommand
 
     /// <summary>
     /// Windows: use the shutdown-instance helper to attach to the daemon's console
-    /// and send Ctrl+Break/Ctrl+C, triggering Console.CancelKeyPress in the daemon.
+    /// and send Ctrl+C twice, triggering Console.CancelKeyPress in the daemon.
     /// </summary>
     private static bool StopDaemonWindows(Process process, int pid, RuntimeContext runtimeContext)
     {
@@ -149,8 +149,12 @@ public static class StopCommand
 
             if (helper.WaitForExit(TimeSpan.FromSeconds(20)))
             {
-                if (helper.ExitCode == 0)
+                if (ShutdownInstanceCommand.IsSuccessExitCode(helper.ExitCode))
+                {
+                    if (ShutdownInstanceCommand.UsedFallbackKillExitCode(helper.ExitCode))
+                        ConsoleOutput.Warning("Daemon required forced termination after graceful shutdown timed out.");
                     return true;
+                }
             }
             else
             {

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using Copilotd.Commands;
 using Copilotd.Models;
 using Microsoft.Extensions.Logging;
 using static Copilotd.Infrastructure.NativeInterop;
@@ -63,7 +64,7 @@ public sealed partial class ProcessManager
             {
                 // Use CreateProcessW directly to set CREATE_NEW_CONSOLE and
                 // CREATE_NEW_PROCESS_GROUP, ensuring the copilot process gets its own
-                // console and process group. This is required for graceful Ctrl+Break/C
+                // console and process group. This is required for graceful console-control
                 // termination to work without affecting the daemon's console.
                 var si = new STARTUPINFO { cb = Marshal.SizeOf<STARTUPINFO>() };
                 si.dwFlags = STARTF_USESHOWWINDOW;
@@ -303,7 +304,7 @@ public sealed partial class ProcessManager
 
     /// <summary>
     /// Windows: spawns 'copilotd shutdown-instance --pid PID' which handles the full
-    /// graceful shutdown lifecycle (Ctrl+Break → Ctrl+C → Kill) from a separate process
+    /// graceful shutdown lifecycle (Ctrl+C → Ctrl+C → Kill) from a separate process
     /// that can safely attach to the target's console.
     /// </summary>
     private bool TerminateViaShutdownInstance(Process process, int pid, DateTimeOffset? processStartTime)
@@ -340,13 +341,18 @@ public sealed partial class ProcessManager
             // so we just need to wait for it to complete
             if (helper.WaitForExit(TimeSpan.FromSeconds(20)))
             {
-                if (helper.ExitCode == 0)
+                if (ShutdownInstanceCommand.IsSuccessExitCode(helper.ExitCode))
                 {
-                    _logger.LogInformation("Process {Pid} terminated via shutdown-instance", pid);
+                    var outcome = ShutdownInstanceCommand.DescribeExitCode(helper.ExitCode);
+                    if (ShutdownInstanceCommand.UsedFallbackKillExitCode(helper.ExitCode))
+                        _logger.LogWarning("Process {Pid} terminated after shutdown-instance {Outcome}", pid, outcome);
+                    else
+                        _logger.LogInformation("Process {Pid} terminated via shutdown-instance ({Outcome})", pid, outcome);
                     return true;
                 }
 
-                _logger.LogWarning("shutdown-instance exited with code {Code} for PID {Pid}", helper.ExitCode, pid);
+                _logger.LogWarning("shutdown-instance exited with code {Code} ({Outcome}) for PID {Pid}",
+                    helper.ExitCode, ShutdownInstanceCommand.DescribeExitCode(helper.ExitCode), pid);
             }
             else
             {

--- a/src/copilotd/Program.cs
+++ b/src/copilotd/Program.cs
@@ -60,7 +60,7 @@ public class Program
             rootCommand.Subcommands.Add(StatusCommand.Create(services));
             rootCommand.Subcommands.Add(SessionCommand.Create(services));
             rootCommand.Subcommands.Add(UpdateCommand.Create(services));
-            rootCommand.Subcommands.Add(ShutdownInstanceCommand.Create());
+            rootCommand.Subcommands.Add(ShutdownInstanceCommand.Create(services));
 
             var parseResult = rootCommand.Parse(args, new ParserConfiguration());
             return await parseResult.InvokeAsync(new InvocationConfiguration());

--- a/src/copilotd/Services/UpdateService.cs
+++ b/src/copilotd/Services/UpdateService.cs
@@ -1,5 +1,6 @@
 using Copilotd.Infrastructure;
 using Copilotd.Models;
+using Copilotd.Commands;
 using Microsoft.Extensions.Logging;
 using NuGet.Versioning;
 
@@ -818,13 +819,18 @@ public sealed class UpdateService
 
             if (helper.WaitForExit(TimeSpan.FromSeconds(20)))
             {
-                if (helper.ExitCode == 0)
+                if (ShutdownInstanceCommand.IsSuccessExitCode(helper.ExitCode))
                 {
-                    _logger.LogInformation("Daemon PID {Pid} terminated via graceful shutdown", pid);
+                    var outcome = ShutdownInstanceCommand.DescribeExitCode(helper.ExitCode);
+                    if (ShutdownInstanceCommand.UsedFallbackKillExitCode(helper.ExitCode))
+                        _logger.LogWarning("Daemon PID {Pid} terminated after shutdown-instance {Outcome}", pid, outcome);
+                    else
+                        _logger.LogInformation("Daemon PID {Pid} terminated via graceful shutdown ({Outcome})", pid, outcome);
                     return true;
                 }
 
-                _logger.LogDebug("shutdown-instance exited with code {Code}", helper.ExitCode);
+                _logger.LogDebug("shutdown-instance exited with code {Code} ({Outcome})",
+                    helper.ExitCode, ShutdownInstanceCommand.DescribeExitCode(helper.ExitCode));
             }
             else
             {


### PR DESCRIPTION
## Summary
- add structured shutdown-instance outcome logging so daemon logs show the helper delay, signal attempts, and whether fallback kill was needed
- switch Windows copilot process shutdown from Ctrl+Break/Ctrl+C to Ctrl+C twice and surface helper outcomes to callers
- distinguish an actual fallback kill from a process that exits on its own during the fallback window so warnings stay accurate

## Verification
- `dotnet build .\src\copilotd\copilotd.csproj -nologo`
- ran `copilotd.cmd run --interval 15 --log-level debug`
- created verification issue DamianEdwards/kusto-cli#55, let copilotd dispatch and create PR DamianEdwards/kusto-cli#56, then closed the PR
- confirmed in `%TEMP%\copilotd\logs\copilotd-2026-04-16.log` that `shutdown-instance` logged `sending first Ctrl+C` and `PID 1003824 exited after first Ctrl+C`
- confirmed in `C:\Users\dedward\.copilot\logs\process-1776302153591-1003824.log` that Copilot CLI ran the normal `[shutdown] ... Shutdown complete` path with `RemoteSessionExporter: stopped`

## Review
- code review with Claude Opus 4.6: no substantive issues found
- code review with GPT-5.4: found one real issue around false fallback-kill warnings; fixed in follow-up commit `Refine shutdown fallback outcomes`