### PR TITLE
Fix issue comment resumption prompts

### DIFF
--- a/src/copilotd/Commands/SessionCommand.cs
+++ b/src/copilotd/Commands/SessionCommand.cs
@@ -546,6 +546,7 @@ public static class SessionCommand
                     ClearTrackedProcess(session);
                     session.RetryCount = 0;
                     session.RedispatchCount = 0;
+                    session.LastRedispatchWasIssueComment = false;
                     session.LastFailureAt = null;
                     session.WaitingSince = null;
                     session.UpdatedAt = DateTimeOffset.UtcNow;

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -684,9 +684,10 @@ public sealed partial class ProcessManager
 
     private static string BuildPrompt(string globalCustomPrompt, GitHubIssue issue, DispatchSession session, CopilotdConfig config, string copilotdCommand)
     {
-        // Use a PR-specific prompt when re-dispatching for review feedback
-        var prompt = session.PullRequestNumber is not null
-            ? BuildPrReviewPrompt(issue, session)
+        var prompt = session.RedispatchCount > 0
+            ? session.PullRequestNumber is not null && !session.LastRedispatchWasIssueComment
+                ? BuildPrReviewPrompt(issue, session)
+                : CopilotdConfig.IssueFeedbackPrompt
             : CopilotdConfig.DefaultPrompt;
 
         var rule = config.Rules.GetValueOrDefault(session.RuleName);

--- a/src/copilotd/Models/CopilotdConfig.cs
+++ b/src/copilotd/Models/CopilotdConfig.cs
@@ -112,6 +112,19 @@ public sealed class CopilotdConfig
         - This will pause your session until a response is posted on the issue, at which point your session will automatically resume.
         """;
 
+    public const string IssueFeedbackPrompt =
+        """
+        You are resuming work on issue #$(issue.id) in the $(issue.repo) repository because new comments were posted on the issue.
+        Read the new issue comments carefully and continue from where this session left off.
+
+        Important:
+        - You are resuming the same session on the same branch. Continue the existing work rather than starting over.
+        - Focus on the new issue feedback and make any necessary code or documentation changes.
+        - If you now have enough information to finish the work, commit your changes, push the branch, and create or update the pull request for issue #$(issue.id).
+        - If you need more clarification, post another issue comment with `$(copilotd.command) session comment $(issue.repo)#$(issue.id) --message "Your question or findings here"`.
+        - If you create a pull request, run `$(copilotd.command) session pr <pr-number> $(issue.repo)#$(issue.id)` to switch into PR review monitoring.
+        """;
+
     public const string ControlSessionPrompt =
         """
         You are the copilotd control session — a remote management interface for the copilotd daemon.

--- a/src/copilotd/Models/SessionState.cs
+++ b/src/copilotd/Models/SessionState.cs
@@ -149,6 +149,13 @@ public sealed class DispatchSession
     public int RedispatchCount { get; set; }
 
     /// <summary>
+    /// True when the most recent feedback-triggered re-dispatch was caused by an issue comment
+    /// rather than a PR review comment. Used to choose the correct resume prompt when the
+    /// session is associated with a pull request.
+    /// </summary>
+    public bool LastRedispatchWasIssueComment { get; set; }
+
+    /// <summary>
     /// Path to the git worktree directory for this session. Null if using the main repo checkout.
     /// </summary>
     public string? WorktreePath { get; set; }

--- a/src/copilotd/Services/ReconciliationEngine.cs
+++ b/src/copilotd/Services/ReconciliationEngine.cs
@@ -360,6 +360,7 @@ public sealed class ReconciliationEngine
                                 // Keep same CopilotSessionId so --resume preserves context
                                 existing.Status = SessionStatus.Pending;
                                 existing.RedispatchCount++;
+                                existing.LastRedispatchWasIssueComment = true;
                                 existing.WaitingSince = null;
                                 existing.ProcessId = null;
                                 existing.ProcessStartTime = null;
@@ -431,6 +432,7 @@ public sealed class ReconciliationEngine
                                     // Keep same CopilotSessionId so --resume preserves context
                                     existing.Status = SessionStatus.Pending;
                                     existing.RedispatchCount++;
+                                    existing.LastRedispatchWasIssueComment = false;
                                     existing.WaitingSince = null;
                                     existing.ProcessId = null;
                                     existing.ProcessStartTime = null;
@@ -479,6 +481,7 @@ public sealed class ReconciliationEngine
                                     issueCommentInfo.Author, issueKey, existing.RedispatchCount + 1, config.MaxRedispatches);
                                 existing.Status = SessionStatus.Pending;
                                 existing.RedispatchCount++;
+                                existing.LastRedispatchWasIssueComment = true;
                                 existing.WaitingSince = null;
                                 existing.ProcessId = null;
                                 existing.ProcessStartTime = null;
@@ -499,6 +502,7 @@ public sealed class ReconciliationEngine
                         existing.RetryCount++;
                         existing.PullRequestNumber = null;
                         existing.RedispatchCount = 0;
+                        existing.LastRedispatchWasIssueComment = false;
                         existing.CopilotSessionId = Guid.NewGuid().ToString();
                         existing.ProcessId = null;
                         existing.ProcessStartTime = null;
@@ -530,6 +534,7 @@ public sealed class ReconciliationEngine
                         existing.Status = SessionStatus.Pending;
                         existing.PullRequestNumber = null;
                         existing.RedispatchCount = 0;
+                        existing.LastRedispatchWasIssueComment = false;
                         existing.CopilotSessionId = Guid.NewGuid().ToString();
                         existing.ProcessId = null;
                         existing.ProcessStartTime = null;


### PR DESCRIPTION
## Summary
- add a dedicated issue-feedback resumption prompt instead of replaying the initial dispatch prompt
- track whether redispatch was triggered by an issue comment or PR review so PR-backed sessions choose the right prompt
- reset the feedback-source marker when sessions are fully reset

Closes #118