### PR TITLE
Fix source-run convenience script behavior

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,9 +6,10 @@
 # Build
 dotnet build src/copilotd/copilotd.csproj
 
-# Run from source (passes all args through)
+# Run from source (auto-builds and passes all args through)
 ./copilotd.sh <command>          # macOS/Linux
-copilotd.cmd <command>           # Windows
+.\copilotd.ps1 <command>           # Windows (PowerShell)
+.\copilotd.cmd <command>           # Windows (CMD)
 ```
 
 No test suite exists yet. Verify changes manually via `copilotd status`, `copilotd session list`, and `copilotd run --interval 15 --log-level debug`.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ copilotd.cmd init           # Windows
 copilotd.cmd run            # Windows
 ```
 
-Convenience scripts `copilotd.sh` and `copilotd.cmd` in the repo root run the project from source via `dotnet run`, passing all arguments through.
+Convenience scripts `copilotd.sh` and `copilotd.cmd` run the project from source. For the long-lived `run` command they build and execute the generated apphost directly so Ctrl+C reaches `copilotd` cleanly; other commands continue to use `dotnet run`, passing all arguments through.
 
 Installed copilotd binaries can self-update in the background: the daemon checks for newer releases, downloads and verifies them, then stages the new binary to be installed after the running daemon exits naturally. If an installed binary update is interrupted and you restore `copilotd.exe` by rerunning the normal install script, the next copilotd launch will reconcile any leftover `.old`, `.staged`, and `update-state.json` artifacts: it will resume a newer staged update, or discard stale staged state rather than downgrading the restored binary. When running from source or a local repo publish, copilotd suppresses automatic background self-updates by default so local scenario verification is not interrupted by GitHub releases. You can still disable them explicitly with `COPILOTD_DISABLE_SELF_UPDATES=1` or `--disable-self-updates`, and `copilotd update --check` remains available to inspect update availability.
 

--- a/README.md
+++ b/README.md
@@ -67,14 +67,16 @@ dotnet build
 
 # First-run setup (checks dependencies, prompts for config)
 ./copilotd.sh init          # macOS/Linux
-copilotd.cmd init           # Windows
+.\copilotd.ps1 init         # Windows PowerShell / pwsh
+copilotd.cmd init           # Windows cmd.exe
 
 # Start the daemon
 ./copilotd.sh run           # macOS/Linux
-copilotd.cmd run            # Windows
+.\copilotd.ps1 run          # Windows PowerShell / pwsh
+copilotd.cmd run            # Windows cmd.exe
 ```
 
-Convenience scripts `copilotd.sh` and `copilotd.cmd` run the project from source. For the long-lived `run` command they build and execute the generated apphost directly so Ctrl+C reaches `copilotd` cleanly; other commands continue to use `dotnet run`, passing all arguments through.
+Convenience scripts `copilotd.sh`, `copilotd.ps1`, and `copilotd.cmd` run the project from source. For the long-lived `run` command they build and execute the generated apphost directly so Ctrl+C reaches `copilotd` cleanly. On Windows, use `copilotd.ps1` from PowerShell and `copilotd.cmd` from cmd.exe; other commands continue to use `dotnet run`, passing all arguments through.
 
 Installed copilotd binaries can self-update in the background: the daemon checks for newer releases, downloads and verifies them, then stages the new binary to be installed after the running daemon exits naturally. If an installed binary update is interrupted and you restore `copilotd.exe` by rerunning the normal install script, the next copilotd launch will reconcile any leftover `.old`, `.staged`, and `update-state.json` artifacts: it will resume a newer staged update, or discard stale staged state rather than downgrading the restored binary. When running from source or a local repo publish, copilotd suppresses automatic background self-updates by default so local scenario verification is not interrupted by GitHub releases. You can still disable them explicitly with `COPILOTD_DISABLE_SELF_UPDATES=1` or `--disable-self-updates`, and `copilotd update --check` remains available to inspect update availability.
 

--- a/copilotd.cmd
+++ b/copilotd.cmd
@@ -6,11 +6,17 @@ set "PROJECT_DIR=%SCRIPT_DIR%src\copilotd"
 if /I "%~1"=="run" goto run_direct
 
 dotnet run --project "%PROJECT_DIR%" -- %*
-exit /b %ERRORLEVEL%
+set "EXITCODE=%ERRORLEVEL%"
+endlocal & exit /b %EXITCODE%
 
 :run_direct
 dotnet build "%PROJECT_DIR%\copilotd.csproj" -nologo
-if errorlevel 1 exit /b %ERRORLEVEL%
+if errorlevel 1 (
+    set "EXITCODE=%ERRORLEVEL%"
+    endlocal & exit /b %EXITCODE%
+)
 
-"%SCRIPT_DIR%artifacts\bin\copilotd\debug\copilotd.exe" %*
-exit /b %ERRORLEVEL%
+REM Run through START /B /WAIT so Ctrl+C targets the child process rather than
+REM cmd.exe interrupting the batch job first. Keep this as the final batch
+REM command to avoid the "Terminate batch job (Y/N)?" prompt path.
+start "" /B /WAIT "%SCRIPT_DIR%artifacts\bin\copilotd\debug\copilotd.exe" %*

--- a/copilotd.cmd
+++ b/copilotd.cmd
@@ -1,22 +1,22 @@
 @echo off
+if /I "%~1"=="run" goto run_direct
+
 setlocal
 set "SCRIPT_DIR=%~dp0"
 set "PROJECT_DIR=%SCRIPT_DIR%src\copilotd"
-
-if /I "%~1"=="run" goto run_direct
 
 dotnet run --project "%PROJECT_DIR%" -- %*
 set "EXITCODE=%ERRORLEVEL%"
 endlocal & exit /b %EXITCODE%
 
 :run_direct
-dotnet build "%PROJECT_DIR%\copilotd.csproj" -nologo
-if errorlevel 1 (
-    set "EXITCODE=%ERRORLEVEL%"
-    endlocal & exit /b %EXITCODE%
+for /f %%I in ('powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "$ErrorActionPreference = 'Stop'; $me = Get-CimInstance Win32_Process -Filter ('ProcessId=' + $PID); $ancestorId = $me.ParentProcessId; $isPowerShell = $false; while ($ancestorId -gt 0) { $ancestor = Get-CimInstance Win32_Process -Filter ('ProcessId=' + $ancestorId); if ($null -eq $ancestor) { break }; if ($ancestor.Name -in @('powershell.exe', 'pwsh.exe')) { $isPowerShell = $true; break }; $ancestorId = $ancestor.ParentProcessId }; if ($isPowerShell) { '1' } else { '0' }" 2^>nul') do set "COPILOTD_PARENT_POWERSHELL=%%I"
+if "%COPILOTD_PARENT_POWERSHELL%"=="1" (
+    echo copilotd.cmd run does not handle Ctrl+C reliably when launched from PowerShell.
+    echo Use .\copilotd.ps1 run instead.
+    exit /b 1
 )
 
-REM Run through START /B /WAIT so Ctrl+C targets the child process rather than
-REM cmd.exe interrupting the batch job first. Keep this as the final batch
-REM command to avoid the "Terminate batch job (Y/N)?" prompt path.
-start "" /B /WAIT "%SCRIPT_DIR%artifacts\bin\copilotd\debug\copilotd.exe" %*
+dotnet build "%~dp0src\copilotd\copilotd.csproj" -nologo
+if errorlevel 1 exit /b %ERRORLEVEL%
+"%~dp0artifacts\bin\copilotd\debug\copilotd.exe" %*

--- a/copilotd.cmd
+++ b/copilotd.cmd
@@ -1,2 +1,16 @@
 @echo off
-dotnet run --project "%~dp0src\copilotd" -- %*
+setlocal
+set "SCRIPT_DIR=%~dp0"
+set "PROJECT_DIR=%SCRIPT_DIR%src\copilotd"
+
+if /I "%~1"=="run" goto run_direct
+
+dotnet run --project "%PROJECT_DIR%" -- %*
+exit /b %ERRORLEVEL%
+
+:run_direct
+dotnet build "%PROJECT_DIR%\copilotd.csproj" -nologo
+if errorlevel 1 exit /b %ERRORLEVEL%
+
+"%SCRIPT_DIR%artifacts\bin\copilotd\debug\copilotd.exe" %*
+exit /b %ERRORLEVEL%

--- a/copilotd.ps1
+++ b/copilotd.ps1
@@ -1,0 +1,19 @@
+$ErrorActionPreference = 'Stop'
+
+$scriptDir = Split-Path -Parent $PSCommandPath
+$projectDir = Join-Path $scriptDir 'src\copilotd'
+$projectFile = Join-Path $projectDir 'copilotd.csproj'
+$appHost = Join-Path $scriptDir 'artifacts\bin\copilotd\debug\copilotd.exe'
+
+if ($args.Count -gt 0 -and $args[0] -eq 'run') {
+    & dotnet build $projectFile -nologo
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+
+    & $appHost @args
+    exit $LASTEXITCODE
+}
+
+& dotnet run --project $projectDir -- @args
+exit $LASTEXITCODE

--- a/copilotd.sh
+++ b/copilotd.sh
@@ -1,3 +1,12 @@
 #!/usr/bin/env bash
+set -e
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-dotnet run --project "$SCRIPT_DIR/src/copilotd" -- "$@"
+PROJECT_DIR="$SCRIPT_DIR/src/copilotd"
+
+if [[ "${1-}" == "run" ]]; then
+  dotnet build "$PROJECT_DIR/copilotd.csproj" -nologo
+  exec "$SCRIPT_DIR/artifacts/bin/copilotd/debug/copilotd" "$@"
+fi
+
+exec dotnet run --project "$PROJECT_DIR" -- "$@"

--- a/src/copilotd/Commands/RunCommand.cs
+++ b/src/copilotd/Commands/RunCommand.cs
@@ -136,157 +136,172 @@ public static class RunCommand
                     }
 
                     // Main poll loop
-                    using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-                    Console.CancelKeyPress += (_, e) =>
+                    using var cts = new CancellationTokenSource();
+                    var shutdownRequested = false;
+                    ConsoleCancelEventHandler cancelHandler = (_, e) =>
                     {
                         e.Cancel = true;
+                        if (shutdownRequested)
+                            return;
+
+                        shutdownRequested = true;
                         cts.Cancel();
                         ConsoleOutput.Warning("Shutdown requested, finishing current cycle...");
                     };
 
-                    while (!cts.Token.IsCancellationRequested)
+                    Console.CancelKeyPress += cancelHandler;
+
+                    try
                     {
-                        try
+                        while (!cts.Token.IsCancellationRequested)
                         {
-                            await Task.Delay(TimeSpan.FromSeconds(interval), cts.Token);
-                        }
-                        catch (OperationCanceledException)
-                        {
-                            break;
-                        }
-
-                        try
-                        {
-                            // Reload config each cycle for live editing support
-                            config = stateStore.LoadConfig();
-                            stateStore.WithStateLock(() =>
+                            try
                             {
-                                var state = stateStore.LoadState();
+                                await Task.Delay(TimeSpan.FromSeconds(interval), cts.Token);
+                            }
+                            catch (OperationCanceledException) when (cts.Token.IsCancellationRequested)
+                            {
+                                break;
+                            }
 
-                                reconciliation.Reconcile(config, state);
-
-                                if (config.EnableControlSession)
+                            try
+                            {
+                                // Reload config each cycle for live editing support
+                                config = stateStore.LoadConfig();
+                                stateStore.WithStateLock(() =>
                                 {
-                                    var controlAlive = state.ControlSession is not null
-                                        && state.ControlSession.Status == ControlSessionStatus.Running
-                                        && processManager.CheckControlSession(state.ControlSession) == ProcessLivenessResult.Alive;
+                                    var state = stateStore.LoadState();
 
-                                    if (!controlAlive)
+                                    reconciliation.Reconcile(config, state);
+
+                                    if (config.EnableControlSession)
                                     {
-                                        if (state.ControlSession?.ProcessId is not null)
-                                            processManager.TerminateControlSession(state.ControlSession);
+                                        var controlAlive = state.ControlSession is not null
+                                            && state.ControlSession.Status == ControlSessionStatus.Running
+                                            && processManager.CheckControlSession(state.ControlSession) == ProcessLivenessResult.Alive;
 
-                                        logger.LogInformation("Relaunching control session...");
-                                        var controlSession = processManager.LaunchControlSession(config);
-                                        if (controlSession is not null)
+                                        if (!controlAlive)
                                         {
-                                            state.ControlSession = controlSession;
-                                            logger.LogInformation("Control session relaunched (PID {Pid})", controlSession.ProcessId);
-                                        }
-                                        else
-                                        {
-                                            state.ControlSession = new ControlSessionInfo
+                                            if (state.ControlSession?.ProcessId is not null)
+                                                processManager.TerminateControlSession(state.ControlSession);
+
+                                            logger.LogInformation("Relaunching control session...");
+                                            var controlSession = processManager.LaunchControlSession(config);
+                                            if (controlSession is not null)
                                             {
-                                                Status = ControlSessionStatus.Failed,
-                                                UpdatedAt = DateTimeOffset.UtcNow,
-                                            };
-                                            logger.LogWarning("Failed to relaunch control session");
-                                        }
+                                                state.ControlSession = controlSession;
+                                                logger.LogInformation("Control session relaunched (PID {Pid})", controlSession.ProcessId);
+                                            }
+                                            else
+                                            {
+                                                state.ControlSession = new ControlSessionInfo
+                                                {
+                                                    Status = ControlSessionStatus.Failed,
+                                                    UpdatedAt = DateTimeOffset.UtcNow,
+                                                };
+                                                logger.LogWarning("Failed to relaunch control session");
+                                            }
 
+                                            stateStore.SaveState(state);
+                                        }
+                                    }
+                                    else if (state.ControlSession is not null
+                                         && state.ControlSession.Status == ControlSessionStatus.Running)
+                                    {
+                                        logger.LogInformation("Control session disabled, terminating...");
+                                        processManager.TerminateControlSession(state.ControlSession);
+                                        state.ControlSession.Status = ControlSessionStatus.Stopped;
+                                        state.ControlSession.ProcessId = null;
+                                        state.ControlSession.ProcessStartTime = null;
+                                        state.ControlSession.UpdatedAt = DateTimeOffset.UtcNow;
                                         stateStore.SaveState(state);
                                     }
-                                }
-                                else if (state.ControlSession is not null
-                                     && state.ControlSession.Status == ControlSessionStatus.Running)
-                                {
-                                    logger.LogInformation("Control session disabled, terminating...");
-                                    processManager.TerminateControlSession(state.ControlSession);
-                                    state.ControlSession.Status = ControlSessionStatus.Stopped;
-                                    state.ControlSession.ProcessId = null;
-                                    state.ControlSession.ProcessStartTime = null;
-                                    state.ControlSession.UpdatedAt = DateTimeOffset.UtcNow;
-                                    stateStore.SaveState(state);
-                                }
-                            }, cts.Token);
-
-                            if (!disableSelfUpdates)
-                            {
-                                // Self-update: schedule or maintain a deferred installer for any staged update,
-                                // then fire a background check/stage task.
-                                var updateState = stateStore.LoadUpdateState();
-                                if (UpdateService.HasUsableStagedUpdate(updateState))
-                                {
-                                    if (EnsureDeferredInstallWatcher(updateService, runtimeContext, logger, updateState))
-                                    {
-                                        if (updateState.Status == UpdateStatus.Staged)
-                                            ConsoleOutput.Info($"Staged update {updateState.StagedVersion} detected. It will install after this daemon exits.");
-                                    }
-                                    else if (updateState.Status == UpdateStatus.Staged)
-                                    {
-                                        ConsoleOutput.Warning("Failed to schedule deferred update installer, will retry next cycle.");
-                                    }
-                                }
-
-                                // Fire non-blocking update check/stage (runs in background, result picked up next cycle)
-                                _ = Task.Run(async () =>
-                                {
-                                    try
-                                    {
-                                        await updateService.CheckAndStageAsync(
-                                            allowPreRelease: false,
-                                            skipProvenance: false,
-                                            cts.Token);
-                                    }
-                                    catch (OperationCanceledException) { }
-                                    catch (Exception ex)
-                                    {
-                                        logger.LogDebug(ex, "Background update check failed");
-                                    }
                                 }, cts.Token);
+
+                                if (!disableSelfUpdates)
+                                {
+                                    // Self-update: schedule or maintain a deferred installer for any staged update,
+                                    // then fire a background check/stage task.
+                                    var updateState = stateStore.LoadUpdateState();
+                                    if (UpdateService.HasUsableStagedUpdate(updateState))
+                                    {
+                                        if (EnsureDeferredInstallWatcher(updateService, runtimeContext, logger, updateState))
+                                        {
+                                            if (updateState.Status == UpdateStatus.Staged)
+                                                ConsoleOutput.Info($"Staged update {updateState.StagedVersion} detected. It will install after this daemon exits.");
+                                        }
+                                        else if (updateState.Status == UpdateStatus.Staged)
+                                        {
+                                            ConsoleOutput.Warning("Failed to schedule deferred update installer, will retry next cycle.");
+                                        }
+                                    }
+
+                                    // Fire non-blocking update check/stage (runs in background, result picked up next cycle)
+                                    _ = Task.Run(async () =>
+                                    {
+                                        try
+                                        {
+                                            await updateService.CheckAndStageAsync(
+                                                allowPreRelease: false,
+                                                skipProvenance: false,
+                                                cts.Token);
+                                        }
+                                        catch (OperationCanceledException) { }
+                                        catch (Exception ex)
+                                        {
+                                            logger.LogDebug(ex, "Background update check failed");
+                                        }
+                                    }, cts.Token);
+                                }
                             }
-                        }
-                        catch (Exception ex)
-                        {
-                            logger.LogError(ex, "Error during poll cycle");
-                            ConsoleOutput.Error($"Poll cycle error: {ex.Message}");
-                            // Continue running — only catastrophic errors should exit
+                            catch (Exception ex)
+                            {
+                                logger.LogError(ex, "Error during poll cycle");
+                                ConsoleOutput.Error($"Poll cycle error: {ex.Message}");
+                                // Continue running — only catastrophic errors should exit
+                            }
                         }
                     }
-
-                    // Gracefully terminate running sessions before exit
-                    stateStore.WithStateLock(() =>
+                    finally
                     {
-                        var state = stateStore.LoadState();
+                        Console.CancelKeyPress -= cancelHandler;
 
-                        if (state.ControlSession is not null
-                            && state.ControlSession.Status == ControlSessionStatus.Running)
+                        // Gracefully terminate running sessions before exit. This must ignore the
+                        // Ctrl+C cancellation path so cleanup can complete after shutdown is requested.
+                        stateStore.WithStateLock(() =>
                         {
-                            ConsoleOutput.Info("Shutting down control session...");
-                            processManager.TerminateControlSession(state.ControlSession);
-                            state.ControlSession.Status = ControlSessionStatus.Stopped;
-                            state.ControlSession.ProcessId = null;
-                            state.ControlSession.ProcessStartTime = null;
-                            state.ControlSession.UpdatedAt = DateTimeOffset.UtcNow;
-                        }
+                            var state = stateStore.LoadState();
 
-                        var runningSessions = state.Sessions.Values
-                            .Where(s => s.Status == SessionStatus.Running)
-                            .ToList();
-                        if (runningSessions.Count > 0)
-                        {
-                            ConsoleOutput.Info($"Shutting down {runningSessions.Count} active copilot session(s)...");
-                            foreach (var session in runningSessions)
+                            if (state.ControlSession is not null
+                                && state.ControlSession.Status == ControlSessionStatus.Running)
                             {
-                                processManager.TerminateProcess(session);
-                                session.Status = SessionStatus.Completed;
-                                session.ProcessId = null;
-                                session.ProcessStartTime = null;
-                                session.UpdatedAt = DateTimeOffset.UtcNow;
+                                ConsoleOutput.Info("Shutting down control session...");
+                                processManager.TerminateControlSession(state.ControlSession);
+                                state.ControlSession.Status = ControlSessionStatus.Stopped;
+                                state.ControlSession.ProcessId = null;
+                                state.ControlSession.ProcessStartTime = null;
+                                state.ControlSession.UpdatedAt = DateTimeOffset.UtcNow;
                             }
-                        }
 
-                        stateStore.SaveState(state);
-                    }, ct);
+                            var runningSessions = state.Sessions.Values
+                                .Where(s => s.Status == SessionStatus.Running)
+                                .ToList();
+                            if (runningSessions.Count > 0)
+                            {
+                                ConsoleOutput.Info($"Shutting down {runningSessions.Count} active copilot session(s)...");
+                                foreach (var session in runningSessions)
+                                {
+                                    processManager.TerminateProcess(session);
+                                    session.Status = SessionStatus.Completed;
+                                    session.ProcessId = null;
+                                    session.ProcessStartTime = null;
+                                    session.UpdatedAt = DateTimeOffset.UtcNow;
+                                }
+                            }
+
+                            stateStore.SaveState(state);
+                        }, CancellationToken.None);
+                    }
 
                     ConsoleOutput.Info("copilotd daemon stopped.");
                     return 0;

--- a/src/copilotd/Commands/RunCommand.cs
+++ b/src/copilotd/Commands/RunCommand.cs
@@ -1,10 +1,12 @@
 using System.CommandLine;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using Copilotd.Infrastructure;
 using Copilotd.Models;
 using Copilotd.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using static Copilotd.Infrastructure.NativeInterop;
 
 namespace Copilotd.Commands;
 
@@ -58,6 +60,12 @@ public static class RunCommand
 
                 try
                 {
+                    if (OperatingSystem.IsWindows() && !SetConsoleCtrlHandler(IntPtr.Zero, false))
+                    {
+                        logger.LogWarning("Failed to re-enable Ctrl+C handling for the daemon console (Win32 error {Error})",
+                            Marshal.GetLastWin32Error());
+                    }
+
                     ConsoleOutput.Success($"copilotd daemon started (polling every {interval}s). Press Ctrl+C to stop.");
                     if (logFileManager.GetCurrentDaemonLogDirectoryForDisplay() is { } daemonLogDirectory)
                         ConsoleOutput.Info($"Daemon logs: {daemonLogDirectory}");
@@ -138,6 +146,7 @@ public static class RunCommand
                     // Main poll loop
                     using var cts = new CancellationTokenSource();
                     var shutdownRequested = false;
+                    var processExitCleanupSuppressed = 0;
                     ConsoleCancelEventHandler cancelHandler = (_, e) =>
                     {
                         e.Cancel = true;
@@ -149,7 +158,16 @@ public static class RunCommand
                         ConsoleOutput.Warning("Shutdown requested, finishing current cycle...");
                     };
 
+                    EventHandler processExitHandler = (_, _) =>
+                    {
+                        if (Interlocked.CompareExchange(ref processExitCleanupSuppressed, 0, 0) != 0)
+                            return;
+
+                        ScheduleProcessExitCleanup(stateStore, processManager, logger);
+                    };
+
                     Console.CancelKeyPress += cancelHandler;
+                    AppDomain.CurrentDomain.ProcessExit += processExitHandler;
 
                     try
                     {
@@ -264,43 +282,13 @@ public static class RunCommand
                     }
                     finally
                     {
+                        Interlocked.Exchange(ref processExitCleanupSuppressed, 1);
                         Console.CancelKeyPress -= cancelHandler;
+                        AppDomain.CurrentDomain.ProcessExit -= processExitHandler;
 
                         // Gracefully terminate running sessions before exit. This must ignore the
                         // Ctrl+C cancellation path so cleanup can complete after shutdown is requested.
-                        stateStore.WithStateLock(() =>
-                        {
-                            var state = stateStore.LoadState();
-
-                            if (state.ControlSession is not null
-                                && state.ControlSession.Status == ControlSessionStatus.Running)
-                            {
-                                ConsoleOutput.Info("Shutting down control session...");
-                                processManager.TerminateControlSession(state.ControlSession);
-                                state.ControlSession.Status = ControlSessionStatus.Stopped;
-                                state.ControlSession.ProcessId = null;
-                                state.ControlSession.ProcessStartTime = null;
-                                state.ControlSession.UpdatedAt = DateTimeOffset.UtcNow;
-                            }
-
-                            var runningSessions = state.Sessions.Values
-                                .Where(s => s.Status == SessionStatus.Running)
-                                .ToList();
-                            if (runningSessions.Count > 0)
-                            {
-                                ConsoleOutput.Info($"Shutting down {runningSessions.Count} active copilot session(s)...");
-                                foreach (var session in runningSessions)
-                                {
-                                    processManager.TerminateProcess(session);
-                                    session.Status = SessionStatus.Completed;
-                                    session.ProcessId = null;
-                                    session.ProcessStartTime = null;
-                                    session.UpdatedAt = DateTimeOffset.UtcNow;
-                                }
-                            }
-
-                            stateStore.SaveState(state);
-                        }, CancellationToken.None);
+                        CleanupTrackedProcesses(stateStore, processManager, logger);
                     }
 
                     ConsoleOutput.Info("copilotd daemon stopped.");
@@ -314,6 +302,124 @@ public static class RunCommand
         });
 
         return command;
+    }
+
+    private static void CleanupTrackedProcesses(
+        StateStore stateStore,
+        ProcessManager processManager,
+        ILogger logger)
+    {
+        stateStore.WithStateLock(() =>
+        {
+            var state = stateStore.LoadState();
+
+            if (state.ControlSession is not null
+                && state.ControlSession.Status == ControlSessionStatus.Running)
+            {
+                ConsoleOutput.Info("Shutting down control session...");
+                if (processManager.TerminateControlSession(state.ControlSession))
+                {
+                    state.ControlSession.Status = ControlSessionStatus.Stopped;
+                    state.ControlSession.ProcessId = null;
+                    state.ControlSession.ProcessStartTime = null;
+                    state.ControlSession.UpdatedAt = DateTimeOffset.UtcNow;
+                }
+                else
+                {
+                    logger.LogWarning("Failed to terminate control session during daemon shutdown; leaving tracked state intact");
+                }
+            }
+
+            var runningSessions = state.Sessions.Values
+                .Where(s => s.Status == SessionStatus.Running)
+                .ToList();
+            if (runningSessions.Count > 0)
+            {
+                ConsoleOutput.Info($"Shutting down {runningSessions.Count} active copilot session(s)...");
+                foreach (var session in runningSessions)
+                {
+                    if (processManager.TerminateProcess(session))
+                    {
+                        session.Status = SessionStatus.Completed;
+                        session.ProcessId = null;
+                        session.ProcessStartTime = null;
+                        session.UpdatedAt = DateTimeOffset.UtcNow;
+                    }
+                    else
+                    {
+                        logger.LogWarning("Failed to terminate session {IssueKey} during daemon shutdown; leaving tracked state intact", session.IssueKey);
+                    }
+                }
+            }
+
+            stateStore.SaveState(state);
+        }, CancellationToken.None);
+    }
+
+    private static void ScheduleProcessExitCleanup(
+        StateStore stateStore,
+        ProcessManager processManager,
+        ILogger logger)
+    {
+        try
+        {
+            var state = stateStore.LoadState();
+            var stateChanged = false;
+
+            if (state.ControlSession is not null
+                && state.ControlSession.Status == ControlSessionStatus.Running)
+            {
+                logger.LogWarning("Process exit detected before normal shutdown cleanup completed; scheduling control session termination");
+                if (processManager.ScheduleTerminateProcess(
+                    "control session",
+                    state.ControlSession.ProcessId,
+                    state.ControlSession.ProcessStartTime,
+                    TimeSpan.Zero))
+                {
+                    state.ControlSession.Status = ControlSessionStatus.Stopped;
+                    state.ControlSession.ProcessId = null;
+                    state.ControlSession.ProcessStartTime = null;
+                    state.ControlSession.UpdatedAt = DateTimeOffset.UtcNow;
+                    stateChanged = true;
+                }
+                else
+                {
+                    logger.LogWarning("Failed to schedule control session termination during process exit; leaving tracked state intact");
+                }
+            }
+
+            foreach (var session in state.Sessions.Values.Where(s => s.Status == SessionStatus.Running))
+            {
+                logger.LogWarning("Process exit detected before normal shutdown cleanup completed; scheduling termination for session {IssueKey}", session.IssueKey);
+                if (processManager.ScheduleTerminateProcess(
+                    session.IssueKey,
+                    session.ProcessId,
+                    session.ProcessStartTime,
+                    TimeSpan.Zero))
+                {
+                    session.Status = SessionStatus.Completed;
+                    session.ProcessId = null;
+                    session.ProcessStartTime = null;
+                    session.UpdatedAt = DateTimeOffset.UtcNow;
+                    stateChanged = true;
+                }
+                else
+                {
+                    logger.LogWarning("Failed to schedule termination for session {IssueKey} during process exit; leaving tracked state intact", session.IssueKey);
+                }
+            }
+
+            if (stateChanged)
+                stateStore.SaveState(state);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to schedule process-exit cleanup");
+        }
+        finally
+        {
+            stateStore.ReleaseLock();
+        }
     }
 
     /// <summary>

--- a/src/copilotd/Commands/RunCommand.cs
+++ b/src/copilotd/Commands/RunCommand.cs
@@ -26,7 +26,7 @@ public static class RunCommand
         command.Options.Add(logLevelOption);
         command.Options.Add(disableSelfUpdatesOption);
 
-        command.SetAction(async (ParseResult parseResult, CancellationToken ct) =>
+        command.SetAction(async (parseResult, ct) =>
         {
             var logger = services.GetRequiredService<ILogger<Program>>();
             return await ConsoleOutput.RunWithErrorHandling(async () =>
@@ -143,20 +143,17 @@ public static class RunCommand
                         }
                     }
 
-                    // Main poll loop
-                    using var cts = new CancellationTokenSource();
-                    var shutdownRequested = false;
+                    // Main poll loop. The command action token is already wired to System.CommandLine's
+                    // Ctrl+C handling, so observe it directly instead of waiting on a separate CTS.
+                    var shutdownRequested = 0;
                     var processExitCleanupSuppressed = 0;
-                    ConsoleCancelEventHandler cancelHandler = (_, e) =>
+                    using var shutdownRegistration = ct.Register(() =>
                     {
-                        e.Cancel = true;
-                        if (shutdownRequested)
+                        if (Interlocked.Exchange(ref shutdownRequested, 1) != 0)
                             return;
 
-                        shutdownRequested = true;
-                        cts.Cancel();
                         ConsoleOutput.Warning("Shutdown requested, finishing current cycle...");
-                    };
+                    });
 
                     EventHandler processExitHandler = (_, _) =>
                     {
@@ -166,18 +163,17 @@ public static class RunCommand
                         ScheduleProcessExitCleanup(stateStore, processManager, logger);
                     };
 
-                    Console.CancelKeyPress += cancelHandler;
                     AppDomain.CurrentDomain.ProcessExit += processExitHandler;
 
                     try
                     {
-                        while (!cts.Token.IsCancellationRequested)
+                        while (!ct.IsCancellationRequested)
                         {
                             try
                             {
-                                await Task.Delay(TimeSpan.FromSeconds(interval), cts.Token);
+                                await Task.Delay(TimeSpan.FromSeconds(interval), ct);
                             }
-                            catch (OperationCanceledException) when (cts.Token.IsCancellationRequested)
+                            catch (OperationCanceledException) when (ct.IsCancellationRequested)
                             {
                                 break;
                             }
@@ -234,7 +230,7 @@ public static class RunCommand
                                         state.ControlSession.UpdatedAt = DateTimeOffset.UtcNow;
                                         stateStore.SaveState(state);
                                     }
-                                }, cts.Token);
+                                }, ct);
 
                                 if (!disableSelfUpdates)
                                 {
@@ -262,14 +258,14 @@ public static class RunCommand
                                             await updateService.CheckAndStageAsync(
                                                 allowPreRelease: false,
                                                 skipProvenance: false,
-                                                cts.Token);
+                                                ct);
                                         }
                                         catch (OperationCanceledException) { }
                                         catch (Exception ex)
                                         {
                                             logger.LogDebug(ex, "Background update check failed");
                                         }
-                                    }, cts.Token);
+                                    }, ct);
                                 }
                             }
                             catch (Exception ex)
@@ -283,7 +279,6 @@ public static class RunCommand
                     finally
                     {
                         Interlocked.Exchange(ref processExitCleanupSuppressed, 1);
-                        Console.CancelKeyPress -= cancelHandler;
                         AppDomain.CurrentDomain.ProcessExit -= processExitHandler;
 
                         // Gracefully terminate running sessions before exit. This must ignore the

--- a/src/copilotd/Commands/ShutdownInstanceCommand.cs
+++ b/src/copilotd/Commands/ShutdownInstanceCommand.cs
@@ -3,6 +3,7 @@ using System.CommandLine.Parsing;
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.InteropServices;
+using Copilotd.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -242,13 +243,13 @@ public static class ShutdownInstanceCommand
             return null;
         }
 
-        if (process.WaitForExit(waitTime))
+        if (WaitForProcessTreeExit(process, pid, waitTime))
         {
-            logger.LogInformation("PID {Pid} exited after {SignalDescription}", pid, description);
+            logger.LogInformation("PID {Pid} process tree exited after {SignalDescription}", pid, description);
             return successOutcome;
         }
 
-        logger.LogInformation("PID {Pid} was still running {WaitTime} after {SignalDescription}", pid, waitTime, description);
+        logger.LogInformation("PID {Pid} process tree was still running {WaitTime} after {SignalDescription}", pid, waitTime, description);
         return null;
     }
 
@@ -258,24 +259,100 @@ public static class ShutdownInstanceCommand
 
         try
         {
+            var killedAnyProcess = false;
+
             if (!process.HasExited)
             {
                 process.Kill(entireProcessTree: true);
                 logger.LogWarning("shutdown-instance killed PID {Pid}", pid);
+                killedAnyProcess = true;
             }
             else
             {
                 logger.LogInformation("shutdown-instance found PID {Pid} already exited during fallback", pid);
-                return ShutdownInstanceExitCode.ExitedDuringFallback;
             }
 
-            return ShutdownInstanceExitCode.FallbackKill;
+            killedAnyProcess |= KillDescendants(pid, logger);
+            return killedAnyProcess ? ShutdownInstanceExitCode.FallbackKill : ShutdownInstanceExitCode.ExitedDuringFallback;
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "shutdown-instance failed to kill PID {Pid}", pid);
             return ShutdownInstanceExitCode.Failed;
         }
+    }
+
+    private static bool WaitForProcessTreeExit(Process process, int rootPid, TimeSpan waitTime)
+    {
+        var deadline = DateTime.UtcNow + waitTime;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            if (process.HasExited && !HasDescendants(rootPid))
+                return true;
+
+            Thread.Sleep(TimeSpan.FromMilliseconds(100));
+        }
+
+        return process.HasExited && !HasDescendants(rootPid);
+    }
+
+    private static bool HasDescendants(int rootPid)
+        => EnumerateDescendantProcessIds(rootPid).Count > 0;
+
+    private static bool KillDescendants(int rootPid, ILogger logger)
+    {
+        var descendantIds = EnumerateDescendantProcessIds(rootPid);
+        var killedAny = false;
+
+        foreach (var descendantPid in descendantIds.AsEnumerable().Reverse())
+        {
+            try
+            {
+                using var descendant = Process.GetProcessById(descendantPid);
+                if (descendant.HasExited)
+                    continue;
+
+                descendant.Kill(entireProcessTree: true);
+                logger.LogWarning("shutdown-instance killed descendant PID {Pid} from root PID {RootPid}", descendantPid, rootPid);
+                killedAny = true;
+            }
+            catch (ArgumentException)
+            {
+            }
+        }
+
+        return killedAny;
+    }
+
+    private static List<int> EnumerateDescendantProcessIds(int rootPid)
+    {
+        var processes = NativeInterop.EnumerateWindowsProcesses();
+        if (processes.Count == 0)
+            return [];
+
+        var childrenByParent = processes
+            .GroupBy(process => process.ParentProcessId)
+            .ToDictionary(group => group.Key, group => group.Select(process => process.ProcessId).ToList());
+
+        var descendants = new List<int>();
+        var pending = new Stack<int>();
+        pending.Push(rootPid);
+
+        while (pending.Count > 0)
+        {
+            var currentPid = pending.Pop();
+            if (!childrenByParent.TryGetValue(currentPid, out var children))
+                continue;
+
+            foreach (var childPid in children)
+            {
+                descendants.Add(childPid);
+                pending.Push(childPid);
+            }
+        }
+
+        return descendants;
     }
 
     private static bool TryParseExpectedStart(string? text, out DateTimeOffset? expectedStart)

--- a/src/copilotd/Commands/ShutdownInstanceCommand.cs
+++ b/src/copilotd/Commands/ShutdownInstanceCommand.cs
@@ -149,7 +149,7 @@ public static class ShutdownInstanceCommand
     }
 
     /// <summary>
-    /// Windows: attach to the target's console and send Ctrl+C twice.
+    /// Windows: attach to the target's console and send Ctrl+Break, then Ctrl+C.
     /// This process was launched without the daemon's console, so FreeConsole/AttachConsole
     /// won't disrupt the daemon.
     /// </summary>
@@ -171,10 +171,10 @@ public static class ShutdownInstanceCommand
 
         try
         {
-            if (TrySendConsoleSignal(process, pid, logger, CTRL_C_EVENT, 0, "first Ctrl+C", SignalDelay, ShutdownInstanceExitCode.ExitedAfterFirstInterrupt) is { } firstOutcome)
+            if (TrySendConsoleSignal(process, pid, logger, CTRL_BREAK_EVENT, unchecked((uint)pid), "Ctrl+Break", SignalDelay, ShutdownInstanceExitCode.ExitedAfterFirstInterrupt) is { } firstOutcome)
                 return firstOutcome;
 
-            if (TrySendConsoleSignal(process, pid, logger, CTRL_C_EVENT, 0, "second Ctrl+C", GracefulTimeout, ShutdownInstanceExitCode.ExitedAfterSecondInterrupt) is { } secondOutcome)
+            if (TrySendConsoleSignal(process, pid, logger, CTRL_C_EVENT, 0, "Ctrl+C", GracefulTimeout, ShutdownInstanceExitCode.ExitedAfterSecondInterrupt) is { } secondOutcome)
                 return secondOutcome;
         }
         catch (Exception ex)
@@ -397,6 +397,7 @@ public static class ShutdownInstanceCommand
     private delegate bool ConsoleCtrlHandler(uint dwCtrlType);
 
     private const uint CTRL_C_EVENT = 0;
+    private const uint CTRL_BREAK_EVENT = 1;
 
     [DllImport("libc", EntryPoint = "kill", SetLastError = true)]
     private static extern int sys_kill(int pid, int sig);

--- a/src/copilotd/Commands/ShutdownInstanceCommand.cs
+++ b/src/copilotd/Commands/ShutdownInstanceCommand.cs
@@ -3,6 +3,7 @@ using System.CommandLine.Parsing;
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
 using Copilotd.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -17,7 +18,9 @@ namespace Copilotd.Commands;
 /// </summary>
 public static class ShutdownInstanceCommand
 {
-    private static readonly TimeSpan SignalDelay = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan DaemonSignalDelay = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan CopilotSignalDelay = TimeSpan.FromMilliseconds(500);
+    private static readonly TimeSpan CopilotGracefulTimeout = TimeSpan.FromSeconds(15) - CopilotSignalDelay;
     private static readonly TimeSpan GracefulTimeout = TimeSpan.FromSeconds(10);
 
     public static Command Create(IServiceProvider services)
@@ -30,9 +33,15 @@ public static class ShutdownInstanceCommand
         var pidOption = new Option<int>("--pid") { Description = "Process ID to shut down" };
         var expectedStartOption = new Option<string?>("--expected-start") { Description = "Expected UTC process start time in round-trip format" };
         var delaySecondsOption = new Option<int>("--delay-seconds") { Description = "Seconds to wait before beginning shutdown" };
+        var signalProfileOption = new Option<string>("--signal-profile")
+        {
+            Description = "Signal profile to use: daemon or copilot",
+            DefaultValueFactory = _ => ShutdownSignalProfile.Daemon.ToString().ToLowerInvariant()
+        };
         command.Options.Add(pidOption);
         command.Options.Add(expectedStartOption);
         command.Options.Add(delaySecondsOption);
+        command.Options.Add(signalProfileOption);
 
         command.SetAction(async (ParseResult parseResult, CancellationToken ct) =>
         {
@@ -40,6 +49,7 @@ public static class ShutdownInstanceCommand
             var pid = parseResult.GetValue(pidOption);
             var expectedStartText = parseResult.GetValue(expectedStartOption);
             var delaySeconds = parseResult.GetValue(delaySecondsOption);
+            var signalProfileText = parseResult.GetValue(signalProfileOption);
             if (delaySeconds < 0)
             {
                 logger.LogWarning("shutdown-instance received invalid negative delay {DelaySeconds} for PID {Pid}", delaySeconds, pid);
@@ -52,9 +62,15 @@ public static class ShutdownInstanceCommand
                 return (int)ShutdownInstanceExitCode.InvalidArguments;
             }
 
+            if (!TryParseSignalProfile(signalProfileText, out var signalProfile))
+            {
+                logger.LogWarning("shutdown-instance received invalid signal profile '{SignalProfile}' for PID {Pid}", signalProfileText, pid);
+                return (int)ShutdownInstanceExitCode.InvalidArguments;
+            }
+
             try
             {
-                return (int)ShutdownProcess(pid, expectedStart, TimeSpan.FromSeconds(delaySeconds), logger);
+                return (int)ShutdownProcess(pid, expectedStart, TimeSpan.FromSeconds(delaySeconds), signalProfile, logger);
             }
             catch (Exception ex)
             {
@@ -91,11 +107,16 @@ public static class ShutdownInstanceCommand
             _ => $"unknown exit code {exitCode}"
         };
 
-    private static ShutdownInstanceExitCode ShutdownProcess(int pid, DateTimeOffset? expectedStart, TimeSpan shutdownDelay, ILogger logger)
+    private static ShutdownInstanceExitCode ShutdownProcess(
+        int pid,
+        DateTimeOffset? expectedStart,
+        TimeSpan shutdownDelay,
+        ShutdownSignalProfile signalProfile,
+        ILogger logger)
     {
         var effectiveDelay = shutdownDelay < TimeSpan.Zero ? TimeSpan.Zero : shutdownDelay;
-        logger.LogInformation("shutdown-instance starting for PID {Pid} with delay {Delay} and expected start {ExpectedStart}",
-            pid, effectiveDelay, expectedStart);
+        logger.LogInformation("shutdown-instance starting for PID {Pid} with delay {Delay}, expected start {ExpectedStart}, and signal profile {SignalProfile}",
+            pid, effectiveDelay, expectedStart, signalProfile);
 
         if (effectiveDelay > TimeSpan.Zero)
         {
@@ -135,7 +156,7 @@ public static class ShutdownInstanceCommand
 
             ShutdownInstanceExitCode outcome;
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                outcome = ShutdownWindows(process, pid, logger);
+                outcome = ShutdownWindows(process, pid, signalProfile, logger);
             else
                 outcome = ShutdownUnix(process, pid, logger);
 
@@ -149,33 +170,46 @@ public static class ShutdownInstanceCommand
     }
 
     /// <summary>
-    /// Windows: attach to the target's console and send Ctrl+Break, then Ctrl+C.
+    /// Windows: attach to the target's console and send signals according to the configured profile.
     /// This process was launched without the daemon's console, so FreeConsole/AttachConsole
     /// won't disrupt the daemon.
     /// </summary>
-    private static ShutdownInstanceExitCode ShutdownWindows(Process process, int pid, ILogger logger)
+    private static ShutdownInstanceExitCode ShutdownWindows(Process process, int pid, ShutdownSignalProfile signalProfile, ILogger logger)
     {
+        var signalTargetPid = ResolveSignalTargetPid(pid, signalProfile, logger);
+
         // Detach from any inherited console
         FreeConsole();
 
-        // Protect ourselves from the signals we're about to send
+        // Protect ourselves from the signals we're about to send.
         SetConsoleCtrlHandler(null, true);
 
         // Attach to the target's console
-        if (!AttachConsole((uint)pid))
+        if (!AttachConsole((uint)signalTargetPid))
         {
             logger.LogWarning("shutdown-instance failed to attach to console for PID {Pid} (Win32 error {Error}), falling back to kill",
-                pid, Marshal.GetLastWin32Error());
+                signalTargetPid, Marshal.GetLastWin32Error());
             return FallbackKill(process, pid, logger, "attach-console-failed");
         }
 
         try
         {
-            if (TrySendConsoleSignal(process, pid, logger, CTRL_BREAK_EVENT, unchecked((uint)pid), "Ctrl+Break", SignalDelay, ShutdownInstanceExitCode.ExitedAfterFirstInterrupt) is { } firstOutcome)
-                return firstOutcome;
+            if (signalProfile == ShutdownSignalProfile.Copilot)
+            {
+                if (TrySendCtrlCInput(process, pid, signalTargetPid, logger, CopilotSignalDelay, ShutdownInstanceExitCode.ExitedAfterFirstInterrupt) is { } firstOutcome)
+                    return firstOutcome;
 
-            if (TrySendConsoleSignal(process, pid, logger, CTRL_C_EVENT, 0, "Ctrl+C", GracefulTimeout, ShutdownInstanceExitCode.ExitedAfterSecondInterrupt) is { } secondOutcome)
-                return secondOutcome;
+                if (TrySendCtrlCInput(process, pid, signalTargetPid, logger, CopilotGracefulTimeout, ShutdownInstanceExitCode.ExitedAfterSecondInterrupt) is { } secondOutcome)
+                    return secondOutcome;
+            }
+            else
+            {
+                if (TrySendConsoleSignal(process, pid, signalTargetPid, logger, CTRL_BREAK_EVENT, unchecked((uint)signalTargetPid), "Ctrl+Break", DaemonSignalDelay, ShutdownInstanceExitCode.ExitedAfterFirstInterrupt) is { } firstOutcome)
+                    return firstOutcome;
+
+                if (TrySendConsoleSignal(process, pid, signalTargetPid, logger, CTRL_C_EVENT, 0, "Ctrl+C", GracefulTimeout, ShutdownInstanceExitCode.ExitedAfterSecondInterrupt) is { } secondOutcome)
+                    return secondOutcome;
+            }
         }
         catch (Exception ex)
         {
@@ -200,7 +234,7 @@ public static class ShutdownInstanceCommand
             logger.LogInformation("shutdown-instance sending first SIGINT to PID {Pid}", pid);
             sys_kill(pid, SIGINT);
 
-            if (process.WaitForExit(SignalDelay))
+            if (process.WaitForExit(DaemonSignalDelay))
             {
                 logger.LogInformation("PID {Pid} exited after first SIGINT", pid);
                 return ShutdownInstanceExitCode.ExitedAfterFirstInterrupt;
@@ -226,7 +260,8 @@ public static class ShutdownInstanceCommand
 
     private static ShutdownInstanceExitCode? TrySendConsoleSignal(
         Process process,
-        int pid,
+        int rootPid,
+        int signalTargetPid,
         ILogger logger,
         uint signal,
         uint processGroupId,
@@ -234,23 +269,111 @@ public static class ShutdownInstanceCommand
         TimeSpan waitTime,
         ShutdownInstanceExitCode successOutcome)
     {
-        logger.LogInformation("shutdown-instance sending {SignalDescription} to PID {Pid}", description, pid);
+        logger.LogInformation("shutdown-instance sending {SignalDescription} to PID {Pid}", description, signalTargetPid);
 
         if (!GenerateConsoleCtrlEvent(signal, processGroupId))
         {
             logger.LogWarning("shutdown-instance failed to send {SignalDescription} to PID {Pid} (Win32 error {Error})",
-                description, pid, Marshal.GetLastWin32Error());
+                description, signalTargetPid, Marshal.GetLastWin32Error());
             return null;
         }
 
-        if (WaitForProcessTreeExit(process, pid, waitTime))
+        if (WaitForProcessTreeExit(process, rootPid, waitTime))
         {
-            logger.LogInformation("PID {Pid} process tree exited after {SignalDescription}", pid, description);
+            logger.LogInformation("PID {Pid} process tree exited after {SignalDescription}", rootPid, description);
             return successOutcome;
         }
 
-        logger.LogInformation("PID {Pid} process tree was still running {WaitTime} after {SignalDescription}", pid, waitTime, description);
+        logger.LogInformation("PID {Pid} process tree was still running {WaitTime} after {SignalDescription}", rootPid, waitTime, description);
         return null;
+    }
+
+    private static ShutdownInstanceExitCode? TrySendCtrlCInput(
+        Process process,
+        int rootPid,
+        int signalTargetPid,
+        ILogger logger,
+        TimeSpan waitTime,
+        ShutdownInstanceExitCode successOutcome)
+    {
+        logger.LogInformation("shutdown-instance sending Ctrl+C to PID {Pid}", signalTargetPid);
+
+        if (!WriteConsoleCtrlCInput(signalTargetPid, logger))
+            return null;
+
+        if (WaitForCopilotShutdown(process, rootPid, waitTime))
+        {
+            logger.LogInformation("PID {Pid} exited after Ctrl+C", rootPid);
+            return successOutcome;
+        }
+
+        logger.LogInformation("PID {Pid} was still running {WaitTime} after Ctrl+C", rootPid, waitTime);
+        return null;
+    }
+
+    private static bool WriteConsoleCtrlCInput(int signalTargetPid, ILogger logger)
+    {
+        using var consoleInputHandle = CreateFileW(
+            "CONIN$",
+            GENERIC_READ | GENERIC_WRITE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            IntPtr.Zero,
+            OPEN_EXISTING,
+            0,
+            IntPtr.Zero);
+
+        if (consoleInputHandle.IsInvalid)
+        {
+            logger.LogWarning("shutdown-instance failed to open console input for PID {Pid} (Win32 error {Error})",
+                signalTargetPid, Marshal.GetLastWin32Error());
+            return false;
+        }
+
+        INPUT_RECORD[] inputRecords =
+        [
+            CreateKeyInputRecord(true, VK_CONTROL, '\0', LEFT_CTRL_PRESSED),
+            CreateKeyInputRecord(true, VK_C, '\u0003', LEFT_CTRL_PRESSED),
+            CreateKeyInputRecord(false, VK_C, '\u0003', LEFT_CTRL_PRESSED),
+            CreateKeyInputRecord(false, VK_CONTROL, '\0', 0),
+        ];
+
+        if (!WriteConsoleInputW(consoleInputHandle, inputRecords, (uint)inputRecords.Length, out var eventsWritten)
+            || eventsWritten != inputRecords.Length)
+        {
+            logger.LogWarning("shutdown-instance failed to write Ctrl+C console input for PID {Pid} (Win32 error {Error})",
+                signalTargetPid, Marshal.GetLastWin32Error());
+            return false;
+        }
+
+        return true;
+    }
+
+    private static INPUT_RECORD CreateKeyInputRecord(bool keyDown, ushort virtualKeyCode, char character, uint controlKeyState) =>
+        new()
+        {
+            EventType = KEY_EVENT,
+            KeyEvent = new KEY_EVENT_RECORD
+            {
+                bKeyDown = keyDown,
+                wRepeatCount = 1,
+                wVirtualKeyCode = virtualKeyCode,
+                wVirtualScanCode = 0,
+                UnicodeChar = character,
+                dwControlKeyState = controlKeyState,
+            }
+        };
+
+    private static int ResolveSignalTargetPid(int pid, ShutdownSignalProfile signalProfile, ILogger logger)
+    {
+        if (signalProfile != ShutdownSignalProfile.Copilot || !OperatingSystem.IsWindows())
+            return pid;
+
+        var childCopilotPid = NativeInterop.FindDeepestWindowsDescendantProcessId(pid, "copilot.exe");
+        if (childCopilotPid is not { } childPid || childPid == pid)
+            return pid;
+
+        logger.LogInformation("shutdown-instance retargeting copilot signals from PID {RootPid} to child copilot PID {ChildPid}", pid, childPid);
+        return childPid;
     }
 
     private static ShutdownInstanceExitCode FallbackKill(Process process, int pid, ILogger logger, string reason)
@@ -297,8 +420,34 @@ public static class ShutdownInstanceCommand
         return process.HasExited && !HasDescendants(rootPid);
     }
 
+    private static bool WaitForCopilotShutdown(Process process, int rootPid, TimeSpan waitTime)
+    {
+        var deadline = DateTime.UtcNow + waitTime;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            if (process.HasExited && !HasRelevantDescendants(rootPid))
+                return true;
+
+            Thread.Sleep(TimeSpan.FromMilliseconds(100));
+        }
+
+        return process.HasExited && !HasRelevantDescendants(rootPid);
+    }
+
     private static bool HasDescendants(int rootPid)
         => EnumerateDescendantProcessIds(rootPid).Count > 0;
+
+    private static bool HasRelevantDescendants(int rootPid)
+    {
+        var processes = NativeInterop.EnumerateWindowsProcesses();
+        if (processes.Count == 0)
+            return false;
+
+        var descendants = EnumerateDescendantProcessIds(rootPid, processes);
+        return descendants.Any(descendant =>
+            !string.Equals(descendant.ExecutableName, "conhost.exe", StringComparison.OrdinalIgnoreCase));
+    }
 
     private static bool KillDescendants(int rootPid, ILogger logger)
     {
@@ -331,11 +480,23 @@ public static class ShutdownInstanceCommand
         if (processes.Count == 0)
             return [];
 
+        return EnumerateDescendantProcessIds(rootPid, processes)
+            .Select(process => process.ProcessId)
+            .ToList();
+    }
+
+    private static List<NativeInterop.WindowsProcessEntry> EnumerateDescendantProcessIds(
+        int rootPid,
+        IReadOnlyList<NativeInterop.WindowsProcessEntry> processes)
+    {
+        if (processes.Count == 0)
+            return [];
+
         var childrenByParent = processes
             .GroupBy(process => process.ParentProcessId)
-            .ToDictionary(group => group.Key, group => group.Select(process => process.ProcessId).ToList());
+            .ToDictionary(group => group.Key, group => group.ToList());
 
-        var descendants = new List<int>();
+        var descendants = new List<NativeInterop.WindowsProcessEntry>();
         var pending = new Stack<int>();
         pending.Push(rootPid);
 
@@ -348,7 +509,7 @@ public static class ShutdownInstanceCommand
             foreach (var childPid in children)
             {
                 descendants.Add(childPid);
-                pending.Push(childPid);
+                pending.Push(childPid.ProcessId);
             }
         }
 
@@ -366,6 +527,15 @@ public static class ShutdownInstanceCommand
 
         expectedStart = parsed;
         return true;
+    }
+
+    private static bool TryParseSignalProfile(string? text, out ShutdownSignalProfile signalProfile)
+    {
+        if (Enum.TryParse(text, ignoreCase: true, out signalProfile))
+            return true;
+
+        signalProfile = default;
+        return false;
     }
 
     private static DateTimeOffset? GetProcessStartTime(Process process)
@@ -394,15 +564,60 @@ public static class ShutdownInstanceCommand
     [DllImport("kernel32.dll", SetLastError = true)]
     private static extern bool GenerateConsoleCtrlEvent(uint dwCtrlEvent, uint dwProcessGroupId);
 
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern SafeFileHandle CreateFileW(
+        string lpFileName,
+        uint dwDesiredAccess,
+        uint dwShareMode,
+        IntPtr lpSecurityAttributes,
+        uint dwCreationDisposition,
+        uint dwFlagsAndAttributes,
+        IntPtr hTemplateFile);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool WriteConsoleInputW(
+        SafeFileHandle hConsoleInput,
+        [MarshalAs(UnmanagedType.LPArray), In] INPUT_RECORD[] lpBuffer,
+        uint nLength,
+        out uint lpNumberOfEventsWritten);
+
     private delegate bool ConsoleCtrlHandler(uint dwCtrlType);
 
     private const uint CTRL_C_EVENT = 0;
     private const uint CTRL_BREAK_EVENT = 1;
+    private const uint GENERIC_READ = 0x80000000;
+    private const uint GENERIC_WRITE = 0x40000000;
+    private const uint FILE_SHARE_READ = 0x00000001;
+    private const uint FILE_SHARE_WRITE = 0x00000002;
+    private const uint OPEN_EXISTING = 3;
+    private const ushort KEY_EVENT = 0x0001;
+    private const ushort VK_CONTROL = 0x11;
+    private const ushort VK_C = 0x43;
+    private const uint LEFT_CTRL_PRESSED = 0x0008;
 
     [DllImport("libc", EntryPoint = "kill", SetLastError = true)]
     private static extern int sys_kill(int pid, int sig);
 
     private const int SIGINT = 2;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct INPUT_RECORD
+    {
+        public ushort EventType;
+        public KEY_EVENT_RECORD KeyEvent;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct KEY_EVENT_RECORD
+    {
+        [MarshalAs(UnmanagedType.Bool)]
+        public bool bKeyDown;
+        public ushort wRepeatCount;
+        public ushort wVirtualKeyCode;
+        public ushort wVirtualScanCode;
+        public char UnicodeChar;
+        public uint dwControlKeyState;
+    }
 
     #endregion
 
@@ -416,5 +631,11 @@ public static class ShutdownInstanceCommand
         ExitedDuringFallback = 5,
         InvalidArguments = 64,
         Failed = 65
+    }
+
+    private enum ShutdownSignalProfile
+    {
+        Daemon,
+        Copilot
     }
 }

--- a/src/copilotd/Commands/StopCommand.cs
+++ b/src/copilotd/Commands/StopCommand.cs
@@ -133,7 +133,7 @@ public static class StopCommand
     /// </summary>
     private static bool StopDaemonWindows(Process process, int pid, RuntimeContext runtimeContext)
     {
-        var invocation = runtimeContext.GetSelfInvocation($"shutdown-instance --pid {pid}");
+        var invocation = runtimeContext.GetSelfInvocation($"shutdown-instance --pid {pid} --signal-profile daemon");
         if (invocation is null)
         {
             ConsoleOutput.Warning("Cannot determine copilotd path, forcing termination.");

--- a/src/copilotd/Commands/StopCommand.cs
+++ b/src/copilotd/Commands/StopCommand.cs
@@ -25,6 +25,7 @@ public static class StopCommand
             {
                 var stateStore = services.GetRequiredService<StateStore>();
                 var logFileManager = services.GetRequiredService<LogFileManager>();
+                var processManager = services.GetRequiredService<ProcessManager>();
                 var runtimeContext = services.GetRequiredService<RuntimeContext>();
 
                 // Check if daemon is running
@@ -107,6 +108,9 @@ public static class StopCommand
                     {
                         await Task.Delay(250, ct);
                     }
+
+                    if (!stateStore.IsLockHeld())
+                        CleanupStoppedDaemonState(stateStore, processManager, logger);
 
                     ConsoleOutput.Success("copilotd daemon stopped.");
                     if (daemonLogDirectory is not null)
@@ -217,6 +221,51 @@ public static class StopCommand
         catch
         {
             return false;
+        }
+    }
+
+    private static void CleanupStoppedDaemonState(
+        StateStore stateStore,
+        ProcessManager processManager,
+        ILogger logger)
+    {
+        try
+        {
+            stateStore.WithStateLock(() =>
+            {
+                var state = stateStore.LoadState();
+
+                if (state.ControlSession is not null
+                    && state.ControlSession.Status == Models.ControlSessionStatus.Running)
+                {
+                    logger.LogInformation("Stop command cleaning up tracked control session after daemon exit");
+                    if (processManager.TerminateControlSession(state.ControlSession))
+                    {
+                        state.ControlSession.Status = Models.ControlSessionStatus.Stopped;
+                        state.ControlSession.ProcessId = null;
+                        state.ControlSession.ProcessStartTime = null;
+                        state.ControlSession.UpdatedAt = DateTimeOffset.UtcNow;
+                    }
+                }
+
+                foreach (var session in state.Sessions.Values.Where(session => session.Status == Models.SessionStatus.Running))
+                {
+                    logger.LogInformation("Stop command cleaning up tracked session {IssueKey} after daemon exit", session.IssueKey);
+                    if (processManager.TerminateProcess(session))
+                    {
+                        session.Status = Models.SessionStatus.Completed;
+                        session.ProcessId = null;
+                        session.ProcessStartTime = null;
+                        session.UpdatedAt = DateTimeOffset.UtcNow;
+                    }
+                }
+
+                stateStore.SaveState(state);
+            }, CancellationToken.None);
+        }
+        finally
+        {
+            stateStore.ReleaseLock();
         }
     }
 }

--- a/src/copilotd/Infrastructure/NativeInterop.cs
+++ b/src/copilotd/Infrastructure/NativeInterop.cs
@@ -26,6 +26,9 @@ internal static class NativeInterop
     [DllImport("kernel32.dll", SetLastError = true)]
     public static extern bool CloseHandle(IntPtr hObject);
 
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern bool SetConsoleCtrlHandler(IntPtr handlerRoutine, bool add);
+
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     public struct STARTUPINFO
     {

--- a/src/copilotd/Infrastructure/NativeInterop.cs
+++ b/src/copilotd/Infrastructure/NativeInterop.cs
@@ -138,6 +138,45 @@ internal static class NativeInterop
         }
     }
 
+    public static int? FindDeepestWindowsDescendantProcessId(int rootPid, string executableName)
+    {
+        if (!OperatingSystem.IsWindows())
+            return null;
+
+        var processes = EnumerateWindowsProcesses();
+        if (processes.Count == 0)
+            return null;
+
+        var childrenByParent = processes
+            .GroupBy(process => process.ParentProcessId)
+            .ToDictionary(group => group.Key, group => group.ToList());
+
+        var bestDepth = -1;
+        int? bestPid = null;
+
+        void Walk(int parentPid, int depth)
+        {
+            if (!childrenByParent.TryGetValue(parentPid, out var children))
+                return;
+
+            foreach (var child in children)
+            {
+                var childDepth = depth + 1;
+                if (string.Equals(child.ExecutableName, executableName, StringComparison.OrdinalIgnoreCase)
+                    && childDepth > bestDepth)
+                {
+                    bestDepth = childDepth;
+                    bestPid = child.ProcessId;
+                }
+
+                Walk(child.ProcessId, childDepth);
+            }
+        }
+
+        Walk(rootPid, 0);
+        return bestPid;
+    }
+
     // --- Unix signal APIs ---
 
     [DllImport("libc", EntryPoint = "kill", SetLastError = true)]

--- a/src/copilotd/Infrastructure/NativeInterop.cs
+++ b/src/copilotd/Infrastructure/NativeInterop.cs
@@ -63,6 +63,78 @@ internal static class NativeInterop
     public const int STARTF_USESHOWWINDOW = 0x00000001;
     public const short SW_HIDE = 0;
 
+    // --- Windows process snapshot APIs ---
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    public struct PROCESSENTRY32
+    {
+        public uint dwSize;
+        public uint cntUsage;
+        public uint th32ProcessID;
+        public IntPtr th32DefaultHeapID;
+        public uint th32ModuleID;
+        public uint cntThreads;
+        public uint th32ParentProcessID;
+        public int pcPriClassBase;
+        public uint dwFlags;
+
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 260)]
+        public string szExeFile;
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern IntPtr CreateToolhelp32Snapshot(uint dwFlags, uint th32ProcessID);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    public static extern bool Process32FirstW(IntPtr hSnapshot, ref PROCESSENTRY32 lppe);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    public static extern bool Process32NextW(IntPtr hSnapshot, ref PROCESSENTRY32 lppe);
+
+    public const uint TH32CS_SNAPPROCESS = 0x00000002;
+    public static readonly IntPtr InvalidHandleValue = new(-1);
+
+    public readonly record struct WindowsProcessEntry(int ProcessId, int ParentProcessId, string ExecutableName);
+
+    public static IReadOnlyList<WindowsProcessEntry> EnumerateWindowsProcesses()
+    {
+        if (!OperatingSystem.IsWindows())
+            return [];
+
+        var snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+        if (snapshot == InvalidHandleValue)
+            return [];
+
+        try
+        {
+            var entry = new PROCESSENTRY32
+            {
+                dwSize = (uint)Marshal.SizeOf<PROCESSENTRY32>()
+            };
+
+            if (!Process32FirstW(snapshot, ref entry))
+                return [];
+
+            var processes = new List<WindowsProcessEntry>();
+            do
+            {
+                processes.Add(new WindowsProcessEntry(
+                    (int)entry.th32ProcessID,
+                    (int)entry.th32ParentProcessID,
+                    entry.szExeFile));
+
+                entry.dwSize = (uint)Marshal.SizeOf<PROCESSENTRY32>();
+            }
+            while (Process32NextW(snapshot, ref entry));
+
+            return processes;
+        }
+        finally
+        {
+            CloseHandle(snapshot);
+        }
+    }
+
     // --- Unix signal APIs ---
 
     [DllImport("libc", EntryPoint = "kill", SetLastError = true)]

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -300,8 +300,8 @@ public sealed partial class ProcessManager
     }
 
     /// <summary>
-    /// Windows: spawns 'copilotd shutdown-instance --pid PID' which handles the full
-    /// graceful shutdown lifecycle (Ctrl+C → Ctrl+C → Kill) from a separate process
+    /// Windows: spawns 'copilotd shutdown-instance --pid PID --signal-profile copilot'
+    /// which handles the full graceful shutdown lifecycle (Ctrl+C → 1s wait → Ctrl+C → Kill) from a separate process
     /// that can safely attach to the target's console.
     /// </summary>
     private bool TerminateViaShutdownInstance(Process process, int pid, DateTimeOffset? processStartTime)
@@ -378,7 +378,7 @@ public sealed partial class ProcessManager
     {
         var effectiveDelay = shutdownDelay < TimeSpan.Zero ? TimeSpan.Zero : shutdownDelay;
 
-        var arguments = $"shutdown-instance --pid {pid}";
+        var arguments = $"shutdown-instance --pid {pid} --signal-profile copilot";
         if (processStartTime is { } expectedStart)
             arguments += $" --expected-start {expectedStart:O}";
 
@@ -899,40 +899,7 @@ public sealed partial class ProcessManager
     }
 
     private static int? FindDeepestWindowsCopilotDescendant(int rootPid)
-    {
-        var processes = EnumerateWindowsProcesses();
-        if (processes.Count == 0)
-            return null;
-
-        var childrenByParent = processes
-            .GroupBy(process => process.ParentProcessId)
-            .ToDictionary(group => group.Key, group => group.ToList());
-
-        var bestDepth = -1;
-        int? bestPid = null;
-
-        void Walk(int parentPid, int depth)
-        {
-            if (!childrenByParent.TryGetValue(parentPid, out var children))
-                return;
-
-            foreach (var child in children)
-            {
-                var childDepth = depth + 1;
-                if (string.Equals(child.ExecutableName, "copilot.exe", StringComparison.OrdinalIgnoreCase)
-                    && childDepth > bestDepth)
-                {
-                    bestDepth = childDepth;
-                    bestPid = child.ProcessId;
-                }
-
-                Walk(child.ProcessId, childDepth);
-            }
-        }
-
-        Walk(rootPid, 0);
-        return bestPid;
-    }
+        => NativeInterop.FindDeepestWindowsDescendantProcessId(rootPid, "copilot.exe");
 
     // ---- Worktree lifecycle ----
 

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -15,6 +15,8 @@ public sealed partial class ProcessManager
 {
     private static readonly TimeSpan SignalDelay = TimeSpan.FromSeconds(2);
     private static readonly TimeSpan GracefulTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan WindowsCopilotChildDiscoveryTimeout = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan WindowsCopilotChildDiscoveryPollInterval = TimeSpan.FromMilliseconds(100);
 
     private readonly StateStore _stateStore;
     private readonly RepoPathResolver _repoResolver;
@@ -84,16 +86,11 @@ public sealed partial class ProcessManager
                 session.ProcessId = pi.dwProcessId;
                 CloseHandle(pi.hProcess);
                 CloseHandle(pi.hThread);
-
-                try
+                AssignTrackedWindowsCopilotProcess(session.IssueKey, pi.dwProcessId, tracked =>
                 {
-                    using var proc = Process.GetProcessById(pi.dwProcessId);
-                    session.ProcessStartTime = GetProcessStartTime(proc);
-                }
-                catch
-                {
-                    session.ProcessStartTime = DateTimeOffset.UtcNow;
-                }
+                    session.ProcessId = tracked.ProcessId;
+                    session.ProcessStartTime = tracked.ProcessStartTime;
+                });
 
                 process = null; // Already tracked via PID
             }
@@ -527,16 +524,11 @@ public sealed partial class ProcessManager
                 session.ProcessId = pi.dwProcessId;
                 CloseHandle(pi.hProcess);
                 CloseHandle(pi.hThread);
-
-                try
+                AssignTrackedWindowsCopilotProcess("control session", pi.dwProcessId, tracked =>
                 {
-                    using var proc = Process.GetProcessById(pi.dwProcessId);
-                    session.ProcessStartTime = GetProcessStartTime(proc);
-                }
-                catch
-                {
-                    session.ProcessStartTime = DateTimeOffset.UtcNow;
-                }
+                    session.ProcessId = tracked.ProcessId;
+                    session.ProcessStartTime = tracked.ProcessStartTime;
+                });
             }
             else
             {
@@ -840,6 +832,106 @@ public sealed partial class ProcessManager
         {
             return null;
         }
+    }
+
+    private void AssignTrackedWindowsCopilotProcess(
+        string processLabel,
+        int rootPid,
+        Action<(int ProcessId, DateTimeOffset ProcessStartTime)> assign)
+    {
+        var tracked = TryResolveTrackedWindowsCopilotProcess(rootPid);
+        if (tracked is { } trackedProcess)
+        {
+            assign(trackedProcess);
+
+            if (trackedProcess.ProcessId != rootPid)
+            {
+                _logger.LogDebug(
+                    "Tracking Windows child copilot PID {TrackedPid} instead of bootstrap PID {RootPid} for {ProcessLabel}",
+                    trackedProcess.ProcessId,
+                    rootPid,
+                    processLabel);
+            }
+
+            return;
+        }
+
+        try
+        {
+            using var proc = Process.GetProcessById(rootPid);
+            assign((rootPid, GetProcessStartTime(proc) ?? DateTimeOffset.UtcNow));
+        }
+        catch
+        {
+            assign((rootPid, DateTimeOffset.UtcNow));
+        }
+    }
+
+    private static (int ProcessId, DateTimeOffset ProcessStartTime)? TryResolveTrackedWindowsCopilotProcess(int rootPid)
+    {
+        if (!OperatingSystem.IsWindows())
+            return null;
+
+        var deadline = DateTime.UtcNow + WindowsCopilotChildDiscoveryTimeout;
+
+        while (true)
+        {
+            var trackedPid = FindDeepestWindowsCopilotDescendant(rootPid) ?? rootPid;
+
+            try
+            {
+                using var process = Process.GetProcessById(trackedPid);
+                var startTime = GetProcessStartTime(process) ?? DateTimeOffset.UtcNow;
+                if (trackedPid != rootPid || DateTime.UtcNow >= deadline)
+                    return (trackedPid, startTime);
+            }
+            catch
+            {
+                if (DateTime.UtcNow >= deadline)
+                    return null;
+            }
+
+            if (DateTime.UtcNow >= deadline)
+                return null;
+
+            Thread.Sleep(WindowsCopilotChildDiscoveryPollInterval);
+        }
+    }
+
+    private static int? FindDeepestWindowsCopilotDescendant(int rootPid)
+    {
+        var processes = EnumerateWindowsProcesses();
+        if (processes.Count == 0)
+            return null;
+
+        var childrenByParent = processes
+            .GroupBy(process => process.ParentProcessId)
+            .ToDictionary(group => group.Key, group => group.ToList());
+
+        var bestDepth = -1;
+        int? bestPid = null;
+
+        void Walk(int parentPid, int depth)
+        {
+            if (!childrenByParent.TryGetValue(parentPid, out var children))
+                return;
+
+            foreach (var child in children)
+            {
+                var childDepth = depth + 1;
+                if (string.Equals(child.ExecutableName, "copilot.exe", StringComparison.OrdinalIgnoreCase)
+                    && childDepth > bestDepth)
+                {
+                    bestDepth = childDepth;
+                    bestPid = child.ProcessId;
+                }
+
+                Walk(child.ProcessId, childDepth);
+            }
+        }
+
+        Walk(rootPid, 0);
+        return bestPid;
     }
 
     // ---- Worktree lifecycle ----

--- a/src/copilotd/Infrastructure/RuntimeContext.cs
+++ b/src/copilotd/Infrastructure/RuntimeContext.cs
@@ -27,13 +27,12 @@ public sealed class RuntimeContext
 
     public bool IsSourceTreeRun => SourceProjectPath is not null;
 
+    private bool UsesDotnetSourceCommand => IsSourceTreeRun && !string.IsNullOrEmpty(SourceProjectPath);
+
     public string GetCopilotdCallbackCommand()
     {
-        if (IsDotnetHosted && !string.IsNullOrEmpty(SourceProjectPath))
+        if (UsesDotnetSourceCommand)
             return $"dotnet run --project \"{SourceProjectPath}\" --";
-
-        if (IsSourceTreeRun && !string.IsNullOrEmpty(ProcessPath))
-            return $"\"{ProcessPath}\"";
 
         return "copilotd";
     }
@@ -46,7 +45,7 @@ public sealed class RuntimeContext
 
     public IEnumerable<string> GetControlSessionAllowedShellCommands()
     {
-        if (IsDotnetHosted && !string.IsNullOrEmpty(SourceProjectPath))
+        if (UsesDotnetSourceCommand)
             yield return "dotnet";
         else
             yield return "copilotd";

--- a/src/copilotd/Program.cs
+++ b/src/copilotd/Program.cs
@@ -63,12 +63,12 @@ public class Program
             rootCommand.Subcommands.Add(UpdateCommand.Create(services));
             rootCommand.Subcommands.Add(ShutdownInstanceCommand.Create(services));
 
-            var parseResult = rootCommand.Parse(args, new ParserConfiguration());
-            return await parseResult.InvokeAsync(new InvocationConfiguration());
+            var parseResult = rootCommand.Parse(args);
+            return await parseResult.InvokeAsync(new() { ProcessTerminationTimeout = TimeSpan.FromSeconds(30) });
         });
     }
 
-    private static IServiceProvider ConfigureServices(LogLevel? consoleLogLevel, string[] args)
+    private static ServiceProvider ConfigureServices(LogLevel? consoleLogLevel, string[] args)
     {
         var serviceCollection = new ServiceCollection();
         var daemonInstanceId = GetDaemonLogInstanceId(args);

--- a/src/copilotd/Services/UpdateService.cs
+++ b/src/copilotd/Services/UpdateService.cs
@@ -805,7 +805,7 @@ public sealed class UpdateService
             var psi = new System.Diagnostics.ProcessStartInfo
             {
                 FileName = copilotdPath,
-                Arguments = $"shutdown-instance --pid {pid}",
+                Arguments = $"shutdown-instance --pid {pid} --signal-profile daemon",
                 UseShellExecute = false,
                 CreateNoWindow = true,
             };

--- a/src/copilotd/copilotd.csproj
+++ b/src/copilotd/copilotd.csproj
@@ -19,11 +19,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
-    <PackageReference Include="NuGet.Versioning" Version="7.3.0" />
-    <PackageReference Include="Spectre.Console" Version="0.54.0" />
-    <PackageReference Include="System.CommandLine" Version="2.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.6" />
+    <PackageReference Include="NuGet.Versioning" Version="7.3.1" />
+    <PackageReference Include="Spectre.Console" Version="0.55.2" />
+    <PackageReference Include="System.CommandLine" Version="2.0.6" />
   </ItemGroup>
 
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">


### PR DESCRIPTION
## Summary
- make source-tree callback/control-session commands consistently use `dotnet run --project ... --`
- have `copilotd.cmd run` and `copilotd.sh run` build first, then execute the generated apphost directly so Ctrl+C reaches the daemon process
- added `copilotd.ps1` for better experience when used from PowerShell, esp. on Ctrl+C processing
- update the README source-run wording to match the new behavior

Closes #122
Closes #123