### PR TITLE
Fix control session status, remote URLs, and Windows shutdown

### DIFF
--- a/src/copilotd/Commands/RunCommand.cs
+++ b/src/copilotd/Commands/RunCommand.cs
@@ -62,13 +62,44 @@ public static class RunCommand
                     return 1;
                 }
 
+                using var daemonCancellation = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                ConsoleCtrlHandler? consoleCtrlHandler = null;
+
                 try
                 {
-                    if (OperatingSystem.IsWindows() && !SetConsoleCtrlHandler(IntPtr.Zero, false))
+                    if (OperatingSystem.IsWindows())
                     {
-                        logger.LogWarning("Failed to re-enable Ctrl+C handling for the daemon console (Win32 error {Error})",
-                            Marshal.GetLastWin32Error());
+                        if (!SetConsoleCtrlHandler(IntPtr.Zero, false))
+                        {
+                            logger.LogWarning("Failed to re-enable Ctrl+C handling for the daemon console (Win32 error {Error})",
+                                Marshal.GetLastWin32Error());
+                        }
+
+                        consoleCtrlHandler = ctrlType =>
+                        {
+                            if (ctrlType is not (CTRL_C_EVENT or CTRL_BREAK_EVENT or CTRL_CLOSE_EVENT or CTRL_LOGOFF_EVENT or CTRL_SHUTDOWN_EVENT))
+                                return false;
+
+                            try
+                            {
+                                daemonCancellation.Cancel();
+                            }
+                            catch (ObjectDisposedException)
+                            {
+                            }
+
+                            return true;
+                        };
+
+                        if (!SetConsoleCtrlHandler(consoleCtrlHandler, true))
+                        {
+                            logger.LogWarning("Failed to register Windows shutdown handler for the daemon console (Win32 error {Error})",
+                                Marshal.GetLastWin32Error());
+                            consoleCtrlHandler = null;
+                        }
                     }
+
+                    var daemonCancellationToken = daemonCancellation.Token;
 
                     ConsoleOutput.Success($"copilotd daemon started (polling every {interval}s). Press Ctrl+C to stop.");
                     if (logFileManager.GetCurrentDaemonLogDirectoryForDisplay() is { } daemonLogDirectory)
@@ -83,7 +114,7 @@ public static class RunCommand
                     {
                         var state = stateStore.LoadState();
                         reconciliation.Reconcile(config, state);
-                    }, ct);
+                    }, daemonCancellationToken);
                     ConsoleOutput.Success("Startup reconciliation complete.");
 
                     // Launch control session if enabled
@@ -135,7 +166,7 @@ public static class RunCommand
                             }
 
                             stateStore.SaveState(state);
-                        }, ct);
+                        }, daemonCancellationToken);
 
                         if (existingControlPid is not null)
                         {
@@ -167,7 +198,7 @@ public static class RunCommand
                     // Ctrl+C handling, so observe it directly instead of waiting on a separate CTS.
                     var shutdownRequested = 0;
                     var processExitCleanupSuppressed = 0;
-                    using var shutdownRegistration = ct.Register(() =>
+                    using var shutdownRegistration = daemonCancellationToken.Register(() =>
                     {
                         if (Interlocked.Exchange(ref shutdownRequested, 1) != 0)
                             return;
@@ -187,13 +218,13 @@ public static class RunCommand
 
                     try
                     {
-                        while (!ct.IsCancellationRequested)
+                        while (!daemonCancellationToken.IsCancellationRequested)
                         {
                             try
                             {
-                                await Task.Delay(TimeSpan.FromSeconds(interval), ct);
+                                await Task.Delay(TimeSpan.FromSeconds(interval), daemonCancellationToken);
                             }
-                            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                            catch (OperationCanceledException) when (daemonCancellationToken.IsCancellationRequested)
                             {
                                 break;
                             }
@@ -262,7 +293,7 @@ public static class RunCommand
                                         state.ControlSession.UpdatedAt = DateTimeOffset.UtcNow;
                                         stateStore.SaveState(state);
                                     }
-                                }, ct);
+                                }, daemonCancellationToken);
 
                                 if (!disableSelfUpdates)
                                 {
@@ -287,17 +318,17 @@ public static class RunCommand
                                     {
                                         try
                                         {
-                                            await updateService.CheckAndStageAsync(
-                                                allowPreRelease: false,
-                                                skipProvenance: false,
-                                                ct);
-                                        }
-                                        catch (OperationCanceledException) { }
-                                        catch (Exception ex)
-                                        {
-                                            logger.LogDebug(ex, "Background update check failed");
-                                        }
-                                    }, ct);
+                                                await updateService.CheckAndStageAsync(
+                                                    allowPreRelease: false,
+                                                    skipProvenance: false,
+                                                    daemonCancellationToken);
+                                            }
+                                            catch (OperationCanceledException) { }
+                                            catch (Exception ex)
+                                            {
+                                                logger.LogDebug(ex, "Background update check failed");
+                                            }
+                                    }, daemonCancellationToken);
                                 }
                             }
                             catch (Exception ex)

--- a/src/copilotd/Commands/RunCommand.cs
+++ b/src/copilotd/Commands/RunCommand.cs
@@ -12,6 +12,9 @@ namespace Copilotd.Commands;
 
 public static class RunCommand
 {
+    private static readonly TimeSpan RemoteUrlResolveTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan RemoteUrlResolvePollInterval = TimeSpan.FromMilliseconds(500);
+
     public static Command Create(IServiceProvider services)
     {
         var command = new Command("run", "Start the copilotd daemon");
@@ -38,6 +41,7 @@ public static class RunCommand
                 var processManager = services.GetRequiredService<ProcessManager>();
                 var runtimeContext = services.GetRequiredService<RuntimeContext>();
                 var logFileManager = services.GetRequiredService<LogFileManager>();
+                var remoteSessionUrls = services.GetRequiredService<GitHubRemoteSessionUrlResolver>();
 
                 var interval = parseResult.GetValue(intervalOption);
                 var disableSelfUpdates = runtimeContext.IsAutomaticSelfUpdateDisabled(parseResult.GetValue(disableSelfUpdatesOption));
@@ -96,8 +100,12 @@ public static class RunCommand
                             var state = stateStore.LoadState();
 
                             var existingAlive = state.ControlSession is not null
-                                && state.ControlSession.Status == ControlSessionStatus.Running
-                                && processManager.CheckControlSession(state.ControlSession) == ProcessLivenessResult.Alive;
+                                && IsControlSessionHealthy(
+                                    state.ControlSession,
+                                    processManager,
+                                    remoteSessionUrls,
+                                    config.CurrentUser,
+                                    DateTimeOffset.UtcNow);
 
                             if (existingAlive)
                             {
@@ -132,10 +140,22 @@ public static class RunCommand
                         if (existingControlPid is not null)
                         {
                             ConsoleOutput.Success($"Control session already running (PID {existingControlPid}).");
+                            await WriteControlSessionRemoteUrlAsync(
+                                remoteSessionUrls,
+                                existingControlSessionId,
+                                existingControlPid,
+                                config.CurrentUser,
+                                ct);
                         }
                         else if (launchedControlPid is not null)
                         {
                             ConsoleOutput.Success($"Control session launched (PID {launchedControlPid}).");
+                            await WriteControlSessionRemoteUrlAsync(
+                                remoteSessionUrls,
+                                launchedControlSessionId,
+                                launchedControlPid,
+                                config.CurrentUser,
+                                ct);
                         }
                         else if (launchFailed)
                         {
@@ -191,13 +211,25 @@ public static class RunCommand
                                     if (config.EnableControlSession)
                                     {
                                         var controlAlive = state.ControlSession is not null
-                                            && state.ControlSession.Status == ControlSessionStatus.Running
-                                            && processManager.CheckControlSession(state.ControlSession) == ProcessLivenessResult.Alive;
+                                            && IsControlSessionHealthy(
+                                                state.ControlSession,
+                                                processManager,
+                                                remoteSessionUrls,
+                                                config.CurrentUser,
+                                                DateTimeOffset.UtcNow);
 
                                         if (!controlAlive)
                                         {
                                             if (state.ControlSession?.ProcessId is not null)
+                                            {
+                                                if (state.ControlSession.Status == ControlSessionStatus.Running
+                                                    && processManager.CheckControlSession(state.ControlSession) == ProcessLivenessResult.Alive)
+                                                {
+                                                    logger.LogWarning("Control session is alive but has no resolvable remote URL; relaunching");
+                                                }
+
                                                 processManager.TerminateControlSession(state.ControlSession);
+                                            }
 
                                             logger.LogInformation("Relaunching control session...");
                                             var controlSession = processManager.LaunchControlSession(config);
@@ -297,6 +329,62 @@ public static class RunCommand
         });
 
         return command;
+    }
+
+    private static async Task WriteControlSessionRemoteUrlAsync(
+        GitHubRemoteSessionUrlResolver remoteSessionUrls,
+        string? sessionId,
+        int? processId,
+        string? currentUser,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId))
+            return;
+
+        var url = remoteSessionUrls.TryResolve(sessionId, processId, currentUser);
+        var deadline = DateTimeOffset.UtcNow + RemoteUrlResolveTimeout;
+
+        while (url is null && DateTimeOffset.UtcNow < deadline && !ct.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(RemoteUrlResolvePollInterval, ct);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+
+            url = remoteSessionUrls.TryResolve(sessionId, processId, currentUser);
+        }
+
+        ConsoleOutput.Info("Remote:");
+        ConsoleOutput.Info($"  {url ?? "unavailable"}");
+    }
+
+    private static bool IsControlSessionHealthy(
+        ControlSessionInfo session,
+        ProcessManager processManager,
+        GitHubRemoteSessionUrlResolver remoteSessionUrls,
+        string? currentUser,
+        DateTimeOffset now)
+    {
+        if (session.Status != ControlSessionStatus.Running)
+            return false;
+
+        if (processManager.CheckControlSession(session) != ProcessLivenessResult.Alive)
+            return false;
+
+        if (remoteSessionUrls.TryResolve(session, currentUser) is not null)
+            return true;
+
+        return !HasRemoteUrlResolutionTimedOut(session, now);
+    }
+
+    private static bool HasRemoteUrlResolutionTimedOut(ControlSessionInfo session, DateTimeOffset now)
+    {
+        var startedAt = session.StartedAt ?? session.UpdatedAt;
+        return startedAt is { } started && now - started >= RemoteUrlResolveTimeout;
     }
 
     private static void CleanupTrackedProcesses(

--- a/src/copilotd/Commands/ShutdownInstanceCommand.cs
+++ b/src/copilotd/Commands/ShutdownInstanceCommand.cs
@@ -411,13 +411,13 @@ public static class ShutdownInstanceCommand
 
         while (DateTime.UtcNow < deadline)
         {
-            if (process.HasExited && !HasDescendants(rootPid))
+            if (process.HasExited && !HasRelevantDescendants(rootPid))
                 return true;
 
             Thread.Sleep(TimeSpan.FromMilliseconds(100));
         }
 
-        return process.HasExited && !HasDescendants(rootPid);
+        return process.HasExited && !HasRelevantDescendants(rootPid);
     }
 
     private static bool WaitForCopilotShutdown(Process process, int rootPid, TimeSpan waitTime)
@@ -434,9 +434,6 @@ public static class ShutdownInstanceCommand
 
         return process.HasExited && !HasRelevantDescendants(rootPid);
     }
-
-    private static bool HasDescendants(int rootPid)
-        => EnumerateDescendantProcessIds(rootPid).Count > 0;
 
     private static bool HasRelevantDescendants(int rootPid)
     {

--- a/src/copilotd/Commands/StatusCommand.cs
+++ b/src/copilotd/Commands/StatusCommand.cs
@@ -39,7 +39,28 @@ public static class StatusCommand
                 // Daemon status header
                 var daemonRunning = stateStore.IsLockHeld();
                 var daemonInfo = daemonRunning ? stateStore.ReadDaemonPid() : null;
-                var state = stateStore.LoadState();
+                var recoveredStaleControlSession = false;
+                var controlLiveness = ProcessLivenessResult.Dead;
+                var state = stateStore.WithStateLock(() =>
+                {
+                    var currentState = stateStore.LoadState();
+
+                    if (currentState.ControlSession?.Status == ControlSessionStatus.Running)
+                    {
+                        controlLiveness = processManager.CheckControlSession(currentState.ControlSession);
+                        if (controlLiveness is ProcessLivenessResult.Dead or ProcessLivenessResult.PidReused)
+                        {
+                            currentState.ControlSession.Status = ControlSessionStatus.Stopped;
+                            currentState.ControlSession.ProcessId = null;
+                            currentState.ControlSession.ProcessStartTime = null;
+                            currentState.ControlSession.UpdatedAt = DateTimeOffset.UtcNow;
+                            stateStore.SaveState(currentState);
+                            recoveredStaleControlSession = true;
+                        }
+                    }
+
+                    return currentState;
+                }, ct);
                 var config = stateStore.LoadConfig();
 
                 AnsiConsole.MarkupLine(daemonRunning
@@ -67,9 +88,8 @@ public static class StatusCommand
                 // Control session status
                 if (state.ControlSession is not null)
                 {
-                    var controlLiveness = state.ControlSession.Status == ControlSessionStatus.Running
-                        ? processManager.CheckControlSession(state.ControlSession)
-                        : ProcessLivenessResult.Dead;
+                    if (recoveredStaleControlSession)
+                        ConsoleOutput.Warning("Recovered stale control session -> Stopped");
 
                     var controlStatus = state.ControlSession.Status switch
                     {

--- a/src/copilotd/Infrastructure/GitHubRemoteSessionUrlResolver.cs
+++ b/src/copilotd/Infrastructure/GitHubRemoteSessionUrlResolver.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using Copilotd.Models;
 using Microsoft.Extensions.Logging;
@@ -16,6 +17,7 @@ public sealed class GitHubRemoteSessionUrlResolver
         @"^\d{4}-\d{2}-\d{2}T\S+\s\[(?:INFO|DEBUG)\]\s(?:RemoteSessionExporter: active with session [^:]+:\s+|Remote session active \(steerable\):\s+|Remote session export active \(not steerable\):\s+)(https://github\.com/\S+)$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private readonly string _logDir;
+    private readonly string _sessionStateDir;
     private readonly ILogger<GitHubRemoteSessionUrlResolver> _logger;
 
     public const string ControlSessionRepo = "DamianEdwards/copilotd";
@@ -25,6 +27,7 @@ public sealed class GitHubRemoteSessionUrlResolver
         _logger = logger;
         var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         _logDir = Path.Combine(home, ".copilot", "logs");
+        _sessionStateDir = Path.Combine(home, ".copilot", "session-state");
     }
 
     public string? TryResolve(DispatchSession session, string? currentUser)
@@ -35,7 +38,14 @@ public sealed class GitHubRemoteSessionUrlResolver
 
     public string? TryResolve(string? sessionId, int? processId, string? currentUser)
     {
-        if (string.IsNullOrWhiteSpace(sessionId) || !Directory.Exists(_logDir))
+        if (string.IsNullOrWhiteSpace(sessionId))
+            return null;
+
+        var sessionStateUrl = TryResolveFromSessionState(sessionId, currentUser);
+        if (sessionStateUrl is not null)
+            return sessionStateUrl;
+
+        if (!Directory.Exists(_logDir))
             return null;
 
         foreach (var logPath in EnumerateCandidateLogFiles(processId))
@@ -54,9 +64,29 @@ public sealed class GitHubRemoteSessionUrlResolver
             {
                 _logger.LogDebug(ex, "Access denied reading Copilot log {Path}", logPath);
             }
+            catch (JsonException ex)
+            {
+                _logger.LogDebug(ex, "Failed parsing Copilot session state from {Path}", logPath);
+            }
         }
 
         return null;
+    }
+
+    private string? TryResolveFromSessionState(string sessionId, string? currentUser)
+    {
+        var eventsPath = Path.Combine(_sessionStateDir, sessionId, "events.jsonl");
+        if (!File.Exists(eventsPath))
+            return null;
+
+        string? resolvedUrl = null;
+        foreach (var line in ReadLinesShared(eventsPath))
+        {
+            if (TryExtractRemoteTaskUrlFromEvent(line, out var url))
+                resolvedUrl = AppendAuthorQuery(url!, currentUser);
+        }
+
+        return resolvedUrl;
     }
 
     private IEnumerable<string> EnumerateCandidateLogFiles(int? processId)
@@ -87,7 +117,7 @@ public sealed class GitHubRemoteSessionUrlResolver
     {
         var matchedSession = false;
 
-        foreach (var line in File.ReadLines(logPath, Encoding.UTF8))
+        foreach (var line in ReadLinesShared(logPath))
         {
             if (!matchedSession && LineReferencesSession(line, sessionId))
             {
@@ -100,6 +130,19 @@ public sealed class GitHubRemoteSessionUrlResolver
         }
 
         return null;
+    }
+
+    private static IEnumerable<string> ReadLinesShared(string path)
+    {
+        using var stream = new FileStream(
+            path,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.ReadWrite | FileShare.Delete);
+        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+
+        while (reader.ReadLine() is { } line)
+            yield return line;
     }
 
     private static bool LineReferencesSession(string line, string sessionId)
@@ -132,6 +175,34 @@ public sealed class GitHubRemoteSessionUrlResolver
 
         url = match.Groups[1].Value;
         return url.Contains("/tasks/", StringComparison.Ordinal);
+    }
+
+    private static bool TryExtractRemoteTaskUrlFromEvent(string line, out string? url)
+    {
+        url = null;
+
+        using var document = JsonDocument.Parse(line);
+        var root = document.RootElement;
+        if (!root.TryGetProperty("type", out var typeElement)
+            || !string.Equals(typeElement.GetString(), "session.info", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (!root.TryGetProperty("data", out var dataElement)
+            || !dataElement.TryGetProperty("infoType", out var infoTypeElement)
+            || !string.Equals(infoTypeElement.GetString(), "remote", StringComparison.Ordinal)
+            || !dataElement.TryGetProperty("url", out var urlElement))
+        {
+            return false;
+        }
+
+        var candidate = urlElement.GetString();
+        if (string.IsNullOrWhiteSpace(candidate) || !candidate.Contains("/tasks/", StringComparison.Ordinal))
+            return false;
+
+        url = candidate;
+        return true;
     }
 
     private static string AppendAuthorQuery(string url, string? currentUser)

--- a/src/copilotd/Infrastructure/NativeInterop.cs
+++ b/src/copilotd/Infrastructure/NativeInterop.cs
@@ -29,6 +29,9 @@ internal static class NativeInterop
     [DllImport("kernel32.dll", SetLastError = true)]
     public static extern bool SetConsoleCtrlHandler(IntPtr handlerRoutine, bool add);
 
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern bool SetConsoleCtrlHandler(ConsoleCtrlHandler? handlerRoutine, bool add);
+
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     public struct STARTUPINFO
     {
@@ -65,6 +68,13 @@ internal static class NativeInterop
     public const uint CREATE_NEW_PROCESS_GROUP = 0x00000200;
     public const int STARTF_USESHOWWINDOW = 0x00000001;
     public const short SW_HIDE = 0;
+    public const uint CTRL_C_EVENT = 0;
+    public const uint CTRL_BREAK_EVENT = 1;
+    public const uint CTRL_CLOSE_EVENT = 2;
+    public const uint CTRL_LOGOFF_EVENT = 5;
+    public const uint CTRL_SHUTDOWN_EVENT = 6;
+
+    public delegate bool ConsoleCtrlHandler(uint dwCtrlType);
 
     // --- Windows process snapshot APIs ---
 


### PR DESCRIPTION
## Summary
- fix stale control-session state in `status` so dead tracked control sessions are repaired to `Stopped`
- show control-session remote URLs in `run` and `status`, including resolving URLs from structured Copilot session-state events
- fix Windows background daemon shutdown so `stop` shuts down the control session and daemon cleanly without spurious forced-termination warnings

## Validation
- dotnet build src/copilotd/copilotd.csproj
- manual isolated `start` / `status` / `stop` repros with and without a running control session

Closes #127
Closes #128