### PR TITLE
Change session join to session connect

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,7 +28,7 @@ State converges through this loop — every inconsistency (crashed process, stal
 
 **Three truth sources** are reconciled each cycle: persisted state (`~/.copilotd/state.json`) → live OS process status → current GitHub issue matches.
 
-**Session lifecycle states:** Pending → Dispatching → Running → Completed/Failed/Orphaned, plus Joined (user-controlled interactive takeover) and WaitingForFeedback (session paused, waiting for new issue comments). `CompletedBySession` flag distinguishes explicit copilot completion from automatic (issue unmatched) completion.
+**Session lifecycle states:** Pending → Dispatching → Running → Completed/Failed/Orphaned, plus WaitingForFeedback (session paused, waiting for new issue comments) and WaitingForReview. `Joined` is a legacy compatibility state from older versions that used local interactive takeover. `CompletedBySession` flag distinguishes explicit copilot completion from automatic (issue unmatched) completion.
 
 ## Key Conventions
 
@@ -89,5 +89,5 @@ All user-facing output goes through `ConsoleOutput` (wraps Spectre.Console). Alw
 Commands follow a consistent pattern:
 - Static class with `public static Command Create(IServiceProvider services)`
 - Services resolved from DI inside the `SetAction` handler
-- Sub-commands (e.g., `rules list`, `session join`) are separate `Command` instances added to the parent's `Subcommands`
+- Sub-commands (e.g., `rules list`, `session connect`) are separate `Command` instances added to the parent's `Subcommands`
 - Shared rendering logic is extracted as public static methods (e.g., `SessionCommand.RenderSessionList`)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ An orchestration daemon that watches configured GitHub repositories for issues m
 - **PR review feedback** — sessions that create PRs can wait for review comments and automatically re-dispatch to address feedback
 - **Self-healing state** — reconciles persisted state, live process status, and GitHub issue matches on every poll cycle and at startup
 - **Crash-resilient** — dispatched `copilot` sessions run as independent processes that survive daemon restarts; state is persisted atomically
-- **Interactive takeover** — join any orchestrated session interactively with `copilotd session join`, then hand it back automatically
+- **Interactive connection** — connect to any running remote-enabled session with `copilotd session connect` without stopping the orchestrated session (requires Copilot CLI 1.0.32+)
 - **Remote control session** — hosts a `copilot --remote` session for remotely managing copilotd via the GitHub remote sessions UI (web & mobile)
 - **Cross-platform** — works on Windows, macOS, and Linux; publishes as native AOT
 
@@ -93,7 +93,7 @@ Installed copilotd binaries can self-update in the background: the daemon checks
 | `copilotd logs clear [--days <n>]` | Clear log files, optionally only those older than the supplied age |
 | `copilotd session` | List dispatched sessions with their remote session URLs (alias for `session list`) |
 | `copilotd session list` | List dispatched sessions with optional filtering and remote session URLs |
-| `copilotd session join <issue>` | Take over a session interactively |
+| `copilotd session connect <issue>` | Connect to a running remote session interactively |
 | `copilotd session comment <issue>` | Post a comment on the issue and wait for feedback (callable from within a copilot session) |
 | `copilotd session complete <issue>` | Mark a session as completed (callable from within a copilot session) |
 | `copilotd session pr <pr-number> <issue>` | Associate a PR with a session and wait for review feedback (callable from within a copilot session) |
@@ -117,7 +117,7 @@ File logs live under `~/.copilotd/logs` by default (or `COPILOTD_HOME/logs`). Ea
 ### Status & session options
 
 ```
---filter <status>   Filter by status (pending, running, joined, waitingforfeedback, waitingforreview, completed, failed, orphaned)
+--filter <status>   Filter by status (pending, dispatching, running, waitingforfeedback, waitingforreview, completed, failed, orphaned, joined [legacy])
 --all               Include ended (completed/failed) sessions
 ```
 
@@ -184,15 +184,12 @@ stateDiagram-v2
     Dispatching --> Failed : Launch failed
 
     Running --> Orphaned : Process died
-    Running --> Joined : User takes over
     Running --> Completed : Issue closed/unmatched (auto)
     Running --> WaitingForFeedback : session comment
     Running --> WaitingForReview : session pr
 
     Orphaned --> Pending : Retry (≤3 times)
     Orphaned --> Failed : Max retries exceeded
-
-    Joined --> Pending : User exits
 
     WaitingForFeedback --> Pending : New comment detected
     WaitingForFeedback --> Completed : Issue unmatched
@@ -218,11 +215,9 @@ stateDiagram-v2
 | **Running** | **WaitingForFeedback** | Copilot calls `copilotd session comment` — process exits, session waits for new issue comments |
 | **Running** | **WaitingForReview** | Copilot calls `copilotd session pr <pr-number>` — process exits, session waits for PR review feedback |
 | **Running** | **Orphaned** | Process died unexpectedly (PID gone or reused) |
-| **Running** | **Joined** | User runs `copilotd session join` — process terminated, user takes over |
 | **Orphaned** | **Pending** | Retry eligible (retry count < 3) — exponential backoff: 2^n minutes, capped at 30m |
 | **Orphaned** | **Failed** | Max retries (3) exceeded |
 | **Failed** | **Pending** | Issue still matches and retry count < 3 |
-| **Joined** | **Pending** | User exits interactive session — automatically re-queued for dispatch |
 | **WaitingForFeedback** | **Pending** | New comment detected from a trusted author (not posted by copilotd) — re-dispatched with same session ID for `--resume` context continuity. Author trust is controlled by `trust_level` rule setting |
 | **WaitingForFeedback** | **Completed** | Issue no longer matches rules while waiting |
 | **WaitingForReview** | **Pending** | New review comment or changes-requested review detected on the PR — re-dispatched with PR review prompt |
@@ -300,14 +295,16 @@ enforces trust boundaries on comment-triggered re-dispatches:
 
 Collaborator permission checks are cached for 15 minutes per user/repo pair to minimize API calls.
 
-### Interactive takeover
+### Interactive connection
 
-Use `copilotd session join <issue>` to take over any tracked session:
+Use `copilotd session connect <issue>` to connect to any tracked session whose remote task URL is available:
 
-1. If the session is currently running, the orchestrated process is gracefully terminated
-2. The session is marked as **Joined** — the daemon won't interfere
-3. An interactive `copilot --resume=<session_id>` is launched with full terminal access
-4. When you exit, the session is automatically re-queued as **Pending** for orchestrated dispatch
+1. copilotd resolves the session's remote GitHub task URL and extracts the taskId required by `copilot --connect`
+2. copilotd verifies the installed Copilot CLI is version `1.0.32` or newer
+3. An interactive `copilot --connect=<task_id>` session is launched in your terminal
+4. The orchestrated session keeps running in the background — no lifecycle state change or re-queue occurs
+
+If the remote session URL has not been discovered yet, `session connect` fails with guidance to retry after the URL appears in `copilotd session list`.
 
 ### Control remote session
 

--- a/src/copilotd/Commands/SessionCommand.cs
+++ b/src/copilotd/Commands/SessionCommand.cs
@@ -13,12 +13,16 @@ namespace Copilotd.Commands;
 
 public static class SessionCommand
 {
+    private const string MinimumCopilotConnectVersion = "1.0.32";
+    internal const string StatusFilterDescription =
+        "Filter sessions by status (pending, dispatching, running, waitingforfeedback, waitingforreview, completed, failed, orphaned, joined (legacy))";
+
     public static Command Create(IServiceProvider services)
     {
         var command = new Command("session", "Manage dispatched copilot sessions");
 
         command.Subcommands.Add(CreateListCommand(services));
-        command.Subcommands.Add(CreateJoinCommand(services));
+        command.Subcommands.Add(CreateConnectCommand(services));
         command.Subcommands.Add(CreateCommentCommand(services));
         command.Subcommands.Add(CreateCompleteCommand(services));
         command.Subcommands.Add(CreatePrCommand(services));
@@ -27,7 +31,7 @@ public static class SessionCommand
         // Default to list behavior when no subcommand is specified
         var filterOption = new Option<string?>("--filter")
         {
-            Description = "Filter sessions by status (pending, dispatching, running, joined, completed, failed, orphaned)"
+            Description = StatusFilterDescription
         };
         command.Options.Add(filterOption);
 
@@ -68,7 +72,7 @@ public static class SessionCommand
 
         var filterOption = new Option<string?>("--filter")
         {
-            Description = "Filter sessions by status (pending, dispatching, running, joined, completed, failed, orphaned)"
+            Description = StatusFilterDescription
         };
         command.Options.Add(filterOption);
 
@@ -98,13 +102,13 @@ public static class SessionCommand
         return command;
     }
 
-    // ---- join subcommand ----
+    // ---- connect subcommand ----
 
-    private static Command CreateJoinCommand(IServiceProvider services)
+    private static Command CreateConnectCommand(IServiceProvider services)
     {
-        var command = new Command("join", "Take over a copilot session interactively");
+        var command = new Command("connect", "Connect to a running remote copilot session interactively");
 
-        var issueArg = new Argument<string>("issue") { Description = "Issue key to join (e.g., owner/repo#123)" };
+        var issueArg = new Argument<string>("issue") { Description = "Issue key to connect (e.g., owner/repo#123)" };
         command.Arguments.Add(issueArg);
 
         command.SetAction(async (ParseResult parseResult, CancellationToken ct) =>
@@ -113,16 +117,18 @@ public static class SessionCommand
             return await ConsoleOutput.RunWithErrorHandling(async () =>
             {
                 var stateStore = services.GetRequiredService<StateStore>();
+                var copilotCli = services.GetRequiredService<CopilotCliService>();
                 var processManager = services.GetRequiredService<ProcessManager>();
+                var remoteSessionUrls = services.GetRequiredService<GitHubRemoteSessionUrlResolver>();
                 var config = stateStore.LoadConfig();
-                var repoResolver = services.GetRequiredService<RepoPathResolver>();
 
                 var issueKey = parseResult.GetValue(issueArg)!;
+                DispatchSession? sessionSnapshot = null;
                 string? sessionId = null;
+                int? processId = null;
+                string? taskId = null;
+                string? remoteUrl = null;
                 string? worktreePath = null;
-                string? workingDir = null;
-                var priorProcess = default(TrackedProcessRef);
-                var priorStatus = SessionStatus.Pending;
                 string? errorMessage = null;
 
                 stateStore.WithStateLock(() =>
@@ -135,30 +141,36 @@ public static class SessionCommand
                         return;
                     }
 
+                    if (session.IsTerminal)
+                    {
+                        errorMessage = $"Session for '{issueKey}' is already {session.Status.ToString().ToLowerInvariant()}.";
+                        return;
+                    }
+
+                    if (session.Status is not (SessionStatus.Running or SessionStatus.Dispatching))
+                    {
+                        errorMessage = $"Session for '{issueKey}' is not running (current status: {session.Status.ToString().ToLowerInvariant()}).";
+                        return;
+                    }
+
                     if (string.IsNullOrEmpty(session.CopilotSessionId))
                     {
                         errorMessage = $"Session for '{issueKey}' has no copilot session ID.";
                         return;
                     }
 
-                    workingDir = session.WorktreePath ?? repoResolver.ResolveRepoPath(session.Repo, config, state);
-                    if (workingDir is null || !Directory.Exists(workingDir))
-                    {
-                        errorMessage = $"Working directory not found for {session.Repo}. Ensure the repository is cloned under the configured RepoHome directory.";
-                        return;
-                    }
-
                     sessionId = session.CopilotSessionId;
+                    processId = session.ProcessId;
                     worktreePath = session.WorktreePath;
-                    priorStatus = session.Status;
-
-                    if (session.Status is SessionStatus.Running or SessionStatus.Dispatching or SessionStatus.Joined)
-                        priorProcess = CaptureTrackedProcess(session);
-
-                    session.Status = SessionStatus.Joined;
-                    ClearTrackedProcess(session);
-                    session.UpdatedAt = DateTimeOffset.UtcNow;
-                    stateStore.SaveState(state);
+                    sessionSnapshot = new DispatchSession
+                    {
+                        IssueKey = session.IssueKey,
+                        CopilotSessionId = session.CopilotSessionId,
+                        ProcessId = session.ProcessId,
+                        ProcessStartTime = session.ProcessStartTime,
+                        Status = session.Status,
+                        WorktreePath = session.WorktreePath,
+                    };
                 }, ct);
 
                 if (errorMessage is not null)
@@ -169,80 +181,93 @@ public static class SessionCommand
                     return 1;
                 }
 
-                if (priorProcess.HasProcess)
+                if (sessionSnapshot is null)
+                    throw new InvalidOperationException("Session snapshot was not captured.");
+
+                var liveness = processManager.CheckProcess(sessionSnapshot);
+                if (liveness is ProcessLivenessResult.Dead or ProcessLivenessResult.PidReused)
                 {
-                    var message = priorStatus is SessionStatus.Joined
-                        ? $"Stopping previously joined interactive session for {issueKey} (PID {priorProcess.ProcessId})..."
-                        : $"Stopping orchestrated session for {issueKey} (PID {priorProcess.ProcessId})...";
-                    ConsoleOutput.Info(message);
-                    processManager.TerminateProcess(priorProcess.Label, priorProcess.ProcessId, priorProcess.ProcessStartTime);
+                    ConsoleOutput.Error($"Session for '{issueKey}' is no longer running.");
+                    ConsoleOutput.Info("Run 'copilotd session list' to refresh the tracked session state and retry once the session is active again.");
+                    return 1;
                 }
 
-                ConsoleOutput.Success($"Joining session {sessionId} for {issueKey}");
-                if (worktreePath is not null)
+                if (!VersionHelper.TryParse(MinimumCopilotConnectVersion, out var minimumVersion))
+                    throw new InvalidOperationException($"Invalid minimum version constant: {MinimumCopilotConnectVersion}");
+
+                var copilotVersionDisplay = copilotCli.GetVersion();
+                if (copilotVersionDisplay is null)
+                {
+                    ConsoleOutput.Error("copilot CLI is not available. Install from: https://docs.github.com/copilot/how-tos/copilot-cli");
+                    return 1;
+                }
+
+                if (!copilotCli.TryGetSemanticVersion(out var installedVersion, out _))
+                {
+                    ConsoleOutput.Error($"Could not determine the installed copilot CLI version from '{copilotVersionDisplay}'. " +
+                        $"'copilotd session connect' requires version {MinimumCopilotConnectVersion} or newer.");
+                    return 1;
+                }
+
+                if (installedVersion < minimumVersion)
+                {
+                    ConsoleOutput.Error($"copilot CLI {copilotVersionDisplay} is too old. " +
+                        $"'copilotd session connect' requires version {MinimumCopilotConnectVersion} or newer.");
+                    return 1;
+                }
+
+                remoteUrl = remoteSessionUrls.TryResolve(sessionSnapshot, config.CurrentUser);
+                taskId = remoteSessionUrls.TryResolveTaskId(sessionSnapshot, config.CurrentUser);
+                if (taskId is null)
+                {
+                    if (remoteUrl is null)
+                    {
+                        ConsoleOutput.Error($"Remote task ID is not yet available for '{issueKey}'. Wait for the remote session URL to appear, then try again.");
+                    }
+                    else
+                    {
+                        ConsoleOutput.Error($"Could not extract a remote task ID from the resolved session URL for '{issueKey}': {remoteUrl}");
+                    }
+
+                    ConsoleOutput.Info("Use 'copilotd session list' to confirm the remote session URL is available.");
+                    return 1;
+                }
+
+                ConsoleOutput.Success($"Connecting to remote session {taskId} for {issueKey}");
+                if (remoteUrl is not null)
+                    ConsoleOutput.Info($"Remote session URL: {remoteUrl}");
+                if (worktreePath is not null && Directory.Exists(worktreePath))
                     ConsoleOutput.Info($"Working directory: {worktreePath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar)}");
-                ConsoleOutput.Info("Press Ctrl+C to exit the interactive session.");
+                ConsoleOutput.Info("The orchestrated session will keep running while you are connected.");
+                ConsoleOutput.Info("Press Ctrl+C to disconnect.");
                 Console.WriteLine();
 
-                // Launch copilot interactively — inherit terminal stdin/stdout/stderr
                 var psi = new ProcessStartInfo
                 {
                     FileName = "copilot",
-                    Arguments = $"--resume={sessionId}",
-                    WorkingDirectory = workingDir,
+                    Arguments = $"--connect={taskId}",
                     UseShellExecute = false,
                     RedirectStandardInput = false,
                     RedirectStandardOutput = false,
                     RedirectStandardError = false,
                 };
 
-                Process? interactiveProcess = null;
-                try
+                if (worktreePath is not null && Directory.Exists(worktreePath))
+                    psi.WorkingDirectory = worktreePath;
+
+                using var interactiveProcess = Process.Start(psi);
+                if (interactiveProcess is null)
                 {
-                    interactiveProcess = Process.Start(psi);
-                    if (interactiveProcess is null)
-                    {
-                        ConsoleOutput.Error("Failed to launch copilot.");
-                        RequeueSession(stateStore, issueKey);
-                        return 1;
-                    }
-
-                    // Track the interactive process PID so the daemon can detect
-                    // if it exits (e.g., terminal killed without cleanup)
-                    stateStore.WithStateLock(() =>
-                    {
-                        var state = stateStore.LoadState();
-                        if (state.Sessions.TryGetValue(issueKey, out var tracked))
-                        {
-                            tracked.ProcessId = interactiveProcess.Id;
-                            try { tracked.ProcessStartTime = new DateTimeOffset(interactiveProcess.StartTime.ToUniversalTime(), TimeSpan.Zero); }
-                            catch { tracked.ProcessStartTime = DateTimeOffset.UtcNow; }
-                            stateStore.SaveState(state);
-                        }
-                    }, ct);
-
-                    await interactiveProcess.WaitForExitAsync(ct);
-                    var exitCode = interactiveProcess.ExitCode;
-
-                    Console.WriteLine();
-                    ConsoleOutput.Info($"Interactive session exited (code {exitCode}).");
-                }
-                finally
-                {
-                    if (interactiveProcess is not null)
-                    {
-                        if (!interactiveProcess.HasExited)
-                        {
-                            try { interactiveProcess.Kill(entireProcessTree: true); } catch { }
-                        }
-                        interactiveProcess.Dispose();
-                    }
-
-                    // Always re-queue, even on cancellation or crash
-                    RequeueSession(stateStore, issueKey);
+                    ConsoleOutput.Error("Failed to launch copilot.");
+                    return 1;
                 }
 
-                return 0;
+                await interactiveProcess.WaitForExitAsync();
+                var exitCode = interactiveProcess.ExitCode;
+
+                Console.WriteLine();
+                ConsoleOutput.Info($"Interactive connection exited (code {exitCode}).");
+                return exitCode;
             }, logger);
         });
 
@@ -588,7 +613,7 @@ public static class SessionCommand
         {
             var currentState = stateStore.LoadState();
 
-            // Recover stale Joined sessions — no PID or process dead
+            // Recover legacy Joined sessions — no PID or process dead
             foreach (var (key, s) in currentState.Sessions)
             {
                 if (s.Status != SessionStatus.Joined)
@@ -662,7 +687,7 @@ public static class SessionCommand
 
         ConsoleOutput.Info($"{list.Count} session(s)");
         Console.WriteLine();
-        ConsoleOutput.Info("Use 'copilotd session join <issue>' to take over a session interactively.");
+        ConsoleOutput.Info("Use 'copilotd session connect <issue>' to connect to a running remote session.");
 
         return 0;
     }
@@ -738,7 +763,7 @@ public static class SessionCommand
     private static string GetUnavailableRemoteSessionUrlMessage(DispatchSession session)
         => session.Status switch
         {
-            SessionStatus.Pending or SessionStatus.Dispatching => "not yet available",
+            SessionStatus.Pending or SessionStatus.Dispatching or SessionStatus.Running => "not yet available",
             _ => "unavailable"
         };
 
@@ -768,31 +793,6 @@ public static class SessionCommand
     {
         var totalSeconds = (int)Math.Ceiling(duration.TotalSeconds);
         return totalSeconds == 1 ? "1 second" : $"{totalSeconds} seconds";
-    }
-
-    private static void RequeueSession(StateStore stateStore, string issueKey)
-    {
-        try
-        {
-            stateStore.WithStateLock(() =>
-            {
-                var state = stateStore.LoadState();
-                if (state.Sessions.TryGetValue(issueKey, out var session) &&
-                    session.Status == SessionStatus.Joined)
-                {
-                    session.Status = SessionStatus.Pending;
-                    ClearTrackedProcess(session);
-                    session.UpdatedAt = DateTimeOffset.UtcNow;
-                    stateStore.SaveState(state);
-                    ConsoleOutput.Info("Session re-queued for orchestrated dispatch.");
-                }
-            });
-        }
-        catch
-        {
-            // Best effort — if state save fails, the daemon's safety net
-            // will detect the stale Joined session and reset it
-        }
     }
 
     private static TrackedProcessRef CaptureTrackedProcess(DispatchSession session)

--- a/src/copilotd/Commands/StatusCommand.cs
+++ b/src/copilotd/Commands/StatusCommand.cs
@@ -16,7 +16,7 @@ public static class StatusCommand
 
         var filterOption = new Option<string?>("--filter")
         {
-            Description = "Filter sessions by status (pending, dispatching, running, joined, completed, failed, orphaned)"
+            Description = SessionCommand.StatusFilterDescription
         };
         command.Options.Add(filterOption);
 

--- a/src/copilotd/Infrastructure/GitHubRemoteSessionUrlResolver.cs
+++ b/src/copilotd/Infrastructure/GitHubRemoteSessionUrlResolver.cs
@@ -31,10 +31,18 @@ public sealed class GitHubRemoteSessionUrlResolver
     }
 
     public string? TryResolve(DispatchSession session, string? currentUser)
-        => TryResolve(session.CopilotSessionId, session.ProcessId, currentUser);
+        => session.ProcessId is { } pid && session.Status is SessionStatus.Dispatching or SessionStatus.Running
+            ? TryResolveFromCurrentProcess(session.CopilotSessionId, pid, currentUser)
+            : TryResolve(session.CopilotSessionId, session.ProcessId, currentUser);
 
     public string? TryResolve(ControlSessionInfo session, string? currentUser)
         => TryResolve(session.CopilotSessionId, session.ProcessId, currentUser);
+
+    public string? TryResolveTaskId(DispatchSession session, string? currentUser)
+        => TryExtractTaskId(TryResolve(session, currentUser), out var taskId) ? taskId : null;
+
+    public string? TryResolveTaskId(ControlSessionInfo session, string? currentUser)
+        => TryResolveTaskId(session.CopilotSessionId, session.ProcessId, currentUser);
 
     public string? TryResolve(string? sessionId, int? processId, string? currentUser)
     {
@@ -73,6 +81,38 @@ public sealed class GitHubRemoteSessionUrlResolver
         return null;
     }
 
+    private string? TryResolveFromCurrentProcess(string? sessionId, int processId, string? currentUser)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId) || !Directory.Exists(_logDir))
+            return null;
+
+        foreach (var logPath in EnumerateProcessLogFiles(processId))
+        {
+            try
+            {
+                var resolved = TryResolveFromLog(logPath, sessionId, currentUser);
+                if (resolved is not null)
+                    return resolved;
+            }
+            catch (IOException ex)
+            {
+                _logger.LogDebug(ex, "Failed reading Copilot log {Path}", logPath);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                _logger.LogDebug(ex, "Access denied reading Copilot log {Path}", logPath);
+            }
+        }
+
+        return null;
+    }
+
+    public string? TryResolveTaskId(string? sessionId, int? processId, string? currentUser)
+    {
+        var url = TryResolve(sessionId, processId, currentUser);
+        return TryExtractTaskId(url, out var taskId) ? taskId : null;
+    }
+
     private string? TryResolveFromSessionState(string sessionId, string? currentUser)
     {
         var eventsPath = Path.Combine(_sessionStateDir, sessionId, "events.jsonl");
@@ -95,7 +135,7 @@ public sealed class GitHubRemoteSessionUrlResolver
 
         if (processId is { } pid)
         {
-            foreach (var path in Directory.EnumerateFiles(_logDir, $"process-*-{pid}.log", SearchOption.TopDirectoryOnly))
+            foreach (var path in EnumerateProcessLogFiles(pid))
             {
                 if (yielded.Add(path))
                     yield return path;
@@ -112,6 +152,12 @@ public sealed class GitHubRemoteSessionUrlResolver
                 yield return path;
         }
     }
+
+    private IEnumerable<string> EnumerateProcessLogFiles(int processId)
+        => new DirectoryInfo(_logDir)
+            .EnumerateFiles($"process-*-{processId}.log", SearchOption.TopDirectoryOnly)
+            .OrderByDescending(file => file.LastWriteTimeUtc)
+            .Select(file => file.FullName);
 
     private string? TryResolveFromLog(string logPath, string sessionId, string? currentUser)
     {
@@ -203,6 +249,31 @@ public sealed class GitHubRemoteSessionUrlResolver
 
         url = candidate;
         return true;
+    }
+
+    private static bool TryExtractTaskId(string? url, out string? taskId)
+    {
+        taskId = null;
+        if (string.IsNullOrWhiteSpace(url) || !Uri.TryCreate(url, UriKind.Absolute, out var uri))
+            return false;
+
+        var segments = uri.AbsolutePath
+            .Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        for (var i = 0; i < segments.Length - 1; i++)
+        {
+            if (!string.Equals(segments[i], "tasks", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var candidate = Uri.UnescapeDataString(segments[i + 1]);
+            if (string.IsNullOrWhiteSpace(candidate))
+                return false;
+
+            taskId = candidate;
+            return true;
+        }
+
+        return false;
     }
 
     private static string AppendAuthorQuery(string url, string? currentUser)

--- a/src/copilotd/Models/CopilotdConfig.cs
+++ b/src/copilotd/Models/CopilotdConfig.cs
@@ -134,7 +134,7 @@ public sealed class CopilotdConfig
         AVAILABLE COMMANDS (run these in the terminal):
         - `$(copilotd.command) status`                          — Show daemon health, watched repos, and session summary
         - `$(copilotd.command) session list [--all]`             — List active sessions (--all includes completed/failed)
-        - `$(copilotd.command) session list --filter <status>`   — Filter by status: pending, running, completed, failed, orphaned, joined, waitingforfeedback, waitingforreview
+        - `$(copilotd.command) session list --filter <status>`   — Filter by status: pending, dispatching, running, waitingforfeedback, waitingforreview, completed, failed, orphaned, joined (legacy)
         - `$(copilotd.command) session reset <issue>`            — Reset a session for re-dispatch (e.g., "org/repo#42")
         - `$(copilotd.command) session complete <issue>`         — Mark a session as completed
         - `$(copilotd.command) session comment <issue> --message "text"` — Post a comment on the issue and pause the session
@@ -151,8 +151,9 @@ public sealed class CopilotdConfig
         SESSION LIFECYCLE:
         Issues matching rules are dispatched as copilot sessions that progress through:
         Pending → Dispatching → Running → Completed/Failed
-        Sessions can also be: Orphaned (process died), Joined (user took over),
-        WaitingForFeedback (paused for issue comments), or WaitingForReview (monitoring PR reviews).
+        Sessions can also be: Orphaned (process died), WaitingForFeedback (paused for issue comments),
+        or WaitingForReview (monitoring PR reviews). Joined may still appear as a legacy state from
+        older copilotd versions that used local interactive takeover.
 
         GUIDELINES:
         - Always start by running `copilotd status` to understand the current state

--- a/src/copilotd/Models/SessionState.cs
+++ b/src/copilotd/Models/SessionState.cs
@@ -56,7 +56,7 @@ public enum SessionStatus
     /// <summary>State says running but process is gone (candidate for re-dispatch).</summary>
     Orphaned,
 
-    /// <summary>User has taken over this session interactively via 'copilotd join'.</summary>
+    /// <summary>Legacy interactive takeover state retained for compatibility with older persisted state.</summary>
     Joined,
 
     /// <summary>

--- a/src/copilotd/Services/CopilotCliService.cs
+++ b/src/copilotd/Services/CopilotCliService.cs
@@ -1,5 +1,8 @@
 using System.Diagnostics;
+using System.Text.RegularExpressions;
+using Copilotd.Infrastructure;
 using Microsoft.Extensions.Logging;
+using NuGet.Versioning;
 
 namespace Copilotd.Services;
 
@@ -8,6 +11,9 @@ namespace Copilotd.Services;
 /// </summary>
 public sealed class CopilotCliService
 {
+    private static readonly Regex VersionTokenPattern = new(
+        @"\bv?\d+\.\d+\.\d+(?:-[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?\b",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private readonly ILogger<CopilotCliService> _logger;
 
     public CopilotCliService(ILogger<CopilotCliService> logger)
@@ -49,6 +55,32 @@ public sealed class CopilotCliService
         {
             return null;
         }
+    }
+
+    /// <summary>
+    /// Attempts to parse the installed copilot CLI version as SemVer, handling
+    /// decorated version strings like "GitHub Copilot CLI 1.0.32.".
+    /// </summary>
+    public bool TryGetSemanticVersion(out NuGetVersion version, out string? versionDisplay)
+    {
+        versionDisplay = GetVersion();
+        if (versionDisplay is null)
+        {
+            version = default!;
+            return false;
+        }
+
+        if (VersionHelper.TryParse(versionDisplay, out version))
+            return true;
+
+        var match = VersionTokenPattern.Match(versionDisplay);
+        if (!match.Success)
+        {
+            version = default!;
+            return false;
+        }
+
+        return VersionHelper.TryParse(match.Value, out version);
     }
 
     /// <summary>

--- a/src/copilotd/Services/ReconciliationEngine.cs
+++ b/src/copilotd/Services/ReconciliationEngine.cs
@@ -112,8 +112,8 @@ public sealed class ReconciliationEngine
             if (session.Status is SessionStatus.WaitingForFeedback or SessionStatus.WaitingForReview)
                 continue;
 
-            // For Joined sessions, check if the interactive process is still alive.
-            // If it exited (e.g., terminal killed without cleanup), reset to Pending.
+            // Legacy Joined sessions come from older copilotd versions that launched
+            // a local interactive takeover process. If that process is gone, reset to Pending.
             if (session.Status is SessionStatus.Joined)
             {
                 if (session.ProcessId is null)


### PR DESCRIPTION
## Summary
- replace `copilotd session join` with `copilotd session connect` and connect via remote GitHub task IDs instead of local resume session IDs
- add Copilot CLI 1.0.32+ version gating plus task-ID resolution safeguards for active sessions
- update docs and legacy `Joined` handling to reflect connect semantics while keeping backward compatibility for persisted state

## Verification
- `dotnet build .\src\copilotd\copilotd.csproj -nologo`
- `.\copilotd.ps1 session --help`
- `.\copilotd.ps1 session connect --help`
- `.\copilotd.ps1 status`
- `.\copilotd.ps1 session list --all`
- `.\copilotd.ps1 run --interval 15 --log-level debug`
- verified task URL resolution with a temporary `COPILOTD_HOME` fixture backed by a real remote-session artifact
- rubber-duck reviewed with Claude Opus 4.6 and GPT-5.4; fixed the stale-task and liveness/disconnect issues they surfaced

Closes #129