### PR TITLE
Fix control session working directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ artifacts/
 .vs/
 .vscode/
 .idea/
+.control-session/
 *.swp
 *~
 

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -479,12 +479,13 @@ public sealed partial class ProcessManager
     /// </summary>
     public ControlSessionInfo? LaunchControlSession(CopilotdConfig config)
     {
-        // Clone the copilotd repo to <RepoHome>/DamianEdwards/copilotd if needed.
-        // copilot --remote requires a cloned GitHub repo as the working directory.
-        var workingDir = EnsureControlSessionRepo(config);
+        // Clone the copilotd repo to <RepoHome>/DamianEdwards/copilotd if needed, then
+        // launch from a dedicated subdirectory so repo-root wrapper scripts don't shadow
+        // the installed copilotd command inside the remote session harness.
+        var workingDir = EnsureControlSessionWorkingDirectory(config);
         if (workingDir is null)
         {
-            _logger.LogError("Cannot launch control session: failed to set up copilotd repo clone");
+            _logger.LogError("Cannot launch control session: failed to set up control session working directory");
             return null;
         }
 
@@ -608,8 +609,38 @@ public sealed partial class ProcessManager
     private const string ControlSessionRepo = GitHubRemoteSessionUrlResolver.ControlSessionRepo;
 
     /// <summary>
-    /// Ensures the copilotd repo is cloned to <c>&lt;RepoHome&gt;/DamianEdwards/copilotd</c>
-    /// for use as the control session's working directory. Clones it if not already present.
+    /// Dedicated subdirectory under the control-session repo clone used as the cwd for the
+    /// remote session, avoiding repo-root wrapper scripts like copilotd.ps1.
+    /// </summary>
+    private const string ControlSessionWorkingDirectoryName = ".control-session";
+
+    /// <summary>
+    /// Ensures the control session repo exists locally and returns a dedicated working
+    /// directory within that repo for launching the remote session.
+    /// </summary>
+    private string? EnsureControlSessionWorkingDirectory(CopilotdConfig config)
+    {
+        var repoPath = EnsureControlSessionRepo(config);
+        if (repoPath is null)
+            return null;
+
+        var workingDir = Path.Combine(repoPath, ControlSessionWorkingDirectoryName);
+
+        try
+        {
+            Directory.CreateDirectory(workingDir);
+            return workingDir;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception creating control session working directory at {Path}", workingDir);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Ensures the copilotd repo is cloned to <c>&lt;RepoHome&gt;/DamianEdwards/copilotd</c>.
+    /// Clones it if not already present.
     /// </summary>
     private string? EnsureControlSessionRepo(CopilotdConfig config)
     {


### PR DESCRIPTION
## Summary

- launch the control remote session from a dedicated .control-session subdirectory inside the cloned repo
- avoid repo-root wrapper scripts like copilotd.ps1 being picked up instead of the installed copilotd command
- ignore the control-session working directory in git

Fixes #140