### PR TITLE
Fix Windows update provenance verification

### DIFF
--- a/src/copilotd/Infrastructure/ProvenanceVerifier.cs
+++ b/src/copilotd/Infrastructure/ProvenanceVerifier.cs
@@ -156,13 +156,16 @@ public sealed class ProvenanceVerifier
 
             var psi = new ProcessStartInfo
             {
-                FileName = "powershell.exe",
+                FileName = GetWindowsPowerShellPath(),
                 Arguments = $"-NoProfile -NonInteractive -ExecutionPolicy Bypass -File \"{scriptPath}\" -BinaryPath \"{binaryPath}\"",
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,
                 CreateNoWindow = true,
             };
+            // When copilotd is launched from pwsh, the parent process can carry PowerShell 7
+            // module paths that make Windows PowerShell 5.1 autoload the wrong security module.
+            psi.Environment["PSModulePath"] = GetWindowsPowerShellModulePath();
 
             using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             timeoutCts.CancelAfter(VerifyTimeout);
@@ -326,6 +329,34 @@ public sealed class ProvenanceVerifier
             _logger.LogError(ex, "Failed to read embedded verification script");
             return null;
         }
+    }
+
+    private static string GetWindowsPowerShellPath()
+    {
+        var candidatePath = Path.Combine(Environment.SystemDirectory, "WindowsPowerShell", "v1.0", "powershell.exe");
+        return File.Exists(candidatePath) ? candidatePath : "powershell.exe";
+    }
+
+    private static string GetWindowsPowerShellModulePath()
+    {
+        var modulePaths = new List<string>();
+
+        var documentsPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+        if (!string.IsNullOrWhiteSpace(documentsPath))
+            modulePaths.Add(Path.Combine(documentsPath, "WindowsPowerShell", "Modules"));
+
+        var programFilesPath = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+        if (!string.IsNullOrWhiteSpace(programFilesPath))
+            modulePaths.Add(Path.Combine(programFilesPath, "WindowsPowerShell", "Modules"));
+
+        if (!string.IsNullOrWhiteSpace(Environment.SystemDirectory))
+            modulePaths.Add(Path.Combine(Environment.SystemDirectory, "WindowsPowerShell", "v1.0", "Modules"));
+
+        return string.Join(
+            Path.PathSeparator,
+            modulePaths
+                .Where(path => !string.IsNullOrWhiteSpace(path))
+                .Distinct(StringComparer.OrdinalIgnoreCase));
     }
 
     private static string ParseExpectedHash(string[] lines, string assetName)

--- a/src/copilotd/Services/UpdateService.cs
+++ b/src/copilotd/Services/UpdateService.cs
@@ -334,8 +334,9 @@ public sealed class UpdateService
                 }
             }
 
-            // Verify provenance of archive before extraction (skip for dev builds)
-            if (!update.IsDevBuild && !skipProvenance)
+            // On Windows, Authenticode applies to the extracted executable rather than the ZIP container.
+            // Keep archive verification for Unix platforms where provenance is tied to the downloaded asset.
+            if (!OperatingSystem.IsWindows() && !update.IsDevBuild && !skipProvenance)
             {
                 var (archiveTrustOk, archiveTrustErr) = await _provenanceVerifier.VerifyBinaryTrustAsync(archivePath, ct);
                 if (!archiveTrustOk)


### PR DESCRIPTION
## Summary
- sanitize the Windows PowerShell child environment used for Authenticode verification
- avoid Authenticode verification of the Windows ZIP container before extraction
- keep provenance verification on the extracted Windows executable

## Root cause
When copilotd is launched from PowerShell 7, the inherited `PSModulePath` can cause `powershell.exe` to autoload the PowerShell 7 `Microsoft.PowerShell.Security` module in Windows PowerShell 5.1, which breaks `Get-AuthenticodeSignature`. After correcting that, the updater was still attempting to verify the ZIP archive instead of the signed extracted executable.

Fixes #142