### PR TITLE
Add aliases for pluralized and rule subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ Installed copilotd binaries can self-update in the background: the daemon checks
 | `copilotd start` | Start the daemon in the background and print the current daemon log folder |
 | `copilotd stop` | Stop the daemon and print the current daemon log folder |
 | `copilotd status` | Show daemon health, watched repos, the active daemon log folder, and the session list |
-| `copilotd logs` | Print the copilotd logs directory |
+| `copilotd logs` | Print the copilotd logs directory (`copilotd log` also works) |
 | `copilotd logs clear [--days <n>]` | Clear log files, optionally only those older than the supplied age |
-| `copilotd session` | List dispatched sessions with their remote session URLs (alias for `session list`) |
+| `copilotd session` | List dispatched sessions with their remote session URLs (`copilotd sessions` also works; default alias for `session list`) |
 | `copilotd session list` | List dispatched sessions with optional filtering and remote session URLs |
 | `copilotd session connect <issue>` | Connect to a running remote session interactively |
 | `copilotd session comment <issue>` | Post a comment on the issue and wait for feedback (callable from within a copilot session) |
@@ -106,9 +106,9 @@ Installed copilotd binaries can self-update in the background: the daemon checks
 | `copilotd session reset <issue>` | Reset a completed/failed session to pending for re-dispatch |
 | `copilotd config` | Display current configuration |
 | `copilotd config --set key=value` | Set a config value (`repo_home`, `default_model`, `custom_prompt`, `max_instances`, `session_shutdown_delay_seconds`) |
-| `copilotd rules list` | List all dispatch rules |
-| `copilotd rules add <name>` | Add a new dispatch rule |
-| `copilotd rules update <name>` | Update an existing rule |
+| `copilotd rules list` | List all dispatch rules (`copilotd rule list` also works) |
+| `copilotd rules add <name>` | Add a new dispatch rule (`copilotd rule create <name>` and `copilotd rule new <name>` also work) |
+| `copilotd rules update <name>` | Update an existing rule (`copilotd rule edit <name>` also works) |
 | `copilotd rules delete <name>` | Delete a rule (the `Default` rule cannot be deleted) |
 
 File logs live under `~/.copilotd/logs` by default (or `COPILOTD_HOME/logs`). Each daemon `run` instance gets its own `daemon_<uuid>` subfolder so its log files stay grouped together, while non-daemon commands log directly in the root logs directory with the same rolling-file behavior.
@@ -130,6 +130,8 @@ File logs live under `~/.copilotd/logs` by default (or `COPILOTD_HOME/logs`). Ea
 ### Rules options
 
 Rules support conditions (`--assignee`, `--label`, `--milestone`, `--type`) and launch options (`--yolo`, `--allow-all-tools`, `--allow-all-urls`, `--model`, `--prompt`, `--custom-prompt`, `--custom-prompt-mode`, `--repo`). All conditions are logical AND.
+
+Aliases: `rule` for `rules`, `create`/`new` for `add`, and `edit` for `update`.
 
 ```bash
 # Add a rule

--- a/src/copilotd/Commands/LogsCommand.cs
+++ b/src/copilotd/Commands/LogsCommand.cs
@@ -12,6 +12,7 @@ public static class LogsCommand
     public static Command Create(IServiceProvider services)
     {
         var command = new Command("logs", "Show or clear copilotd log files");
+        command.Aliases.Add("log");
         command.Subcommands.Add(CreateClearCommand(services));
 
         command.SetAction(async (ParseResult parseResult, CancellationToken ct) =>

--- a/src/copilotd/Commands/RulesCommand.cs
+++ b/src/copilotd/Commands/RulesCommand.cs
@@ -13,6 +13,7 @@ public static class RulesCommand
     public static Command Create(IServiceProvider services)
     {
         var command = new Command("rules", "Manage dispatch rules");
+        command.Aliases.Add("rule");
         command.Subcommands.Add(CreateList(services));
         command.Subcommands.Add(CreateAdd(services));
         command.Subcommands.Add(CreateUpdate(services));
@@ -149,6 +150,8 @@ public static class RulesCommand
     private static Command CreateAdd(IServiceProvider services)
     {
         var command = new Command("add", "Add a new dispatch rule");
+        command.Aliases.Add("new");
+        command.Aliases.Add("create");
         var nameArg = new Argument<string>("name");
         var assigneeOption = new Option<string?>("--assignee") { Description = "Assignee condition" };
         var labelOption = new Option<string[]>("--label") { Description = "Label condition (can be specified multiple times)", AllowMultipleArgumentsPerToken = true };
@@ -250,6 +253,7 @@ public static class RulesCommand
     private static Command CreateUpdate(IServiceProvider services)
     {
         var command = new Command("update", "Update an existing dispatch rule");
+        command.Aliases.Add("edit");
         var nameArg = new Argument<string>("name");
         var assigneeOption = new Option<string?>("--assignee") { Description = "Update assignee condition" };
         var addLabelOption = new Option<string[]>("--add-label") { Description = "Add a label condition", AllowMultipleArgumentsPerToken = true };

--- a/src/copilotd/Commands/SessionCommand.cs
+++ b/src/copilotd/Commands/SessionCommand.cs
@@ -20,6 +20,7 @@ public static class SessionCommand
     public static Command Create(IServiceProvider services)
     {
         var command = new Command("session", "Manage dispatched copilot sessions");
+        command.Aliases.Add("sessions");
 
         command.Subcommands.Add(CreateListCommand(services));
         command.Subcommands.Add(CreateConnectCommand(services));


### PR DESCRIPTION
## Summary
- add session/sessions, rules/rule, and logs/log aliases
- add create/new aliases for rules add and edit alias for rules update
- document the new spellings in the README

Fixes #134