### PR TITLE
Handle Copilot trusted folders for dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The `init` command is an interactive wizard that walks you through:
 3. **Global settings** — max concurrent sessions, default model
 4. **Default rule** — author filtering, required labels, tool permissions (yolo/allow-all-tools/allow-all-urls), model override
 5. **Repository selection** — pick which repos to watch (shows clone status)
+6. **Folder trust checks** — for cloned repos, prompts to add the repo path and daemon worktree root to Copilot's trusted folders when needed for unattended dispatch
 
 After setup, a configuration summary and concrete next-step commands are displayed.
 
@@ -99,6 +100,7 @@ Installed copilotd binaries can self-update in the background: the daemon checks
 | `copilotd logs clear [--days <n>]` | Clear log files, optionally only those older than the supplied age |
 | `copilotd session` | List dispatched sessions with their remote session URLs (`copilotd sessions` also works; default alias for `session list`) |
 | `copilotd session list` | List dispatched sessions with optional filtering and remote session URLs |
+| `copilotd session info <issue>` | Show detailed diagnostic information for a tracked session, including failure details when available |
 | `copilotd session connect <issue>` | Connect to a running remote session interactively |
 | `copilotd session comment <issue>` | Post a comment on the issue and wait for feedback (callable from within a copilot session) |
 | `copilotd session complete <issue>` | Mark a session as completed (callable from within a copilot session) |
@@ -336,6 +338,7 @@ sessions, and more — all via natural language.
 |---------|-------------|
 | `copilotd status` | Show daemon health, watched repos, the control session URL, and session summary |
 | `copilotd session list [--all]` | List active sessions and remote session URLs (use `--all` to include completed/failed) |
+| `copilotd session info <issue>` | Show detailed information for one tracked session |
 | `copilotd session reset <issue>` | Reset a session for re-dispatch |
 | `copilotd session complete <issue>` | Mark a session as completed |
 | `copilotd rules list` | Show configured dispatch rules |

--- a/src/copilotd/Commands/ConfigCommand.cs
+++ b/src/copilotd/Commands/ConfigCommand.cs
@@ -1,5 +1,6 @@
 using System.CommandLine;
 using Copilotd.Infrastructure;
+using Copilotd.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
@@ -20,6 +21,9 @@ public static class ConfigCommand
             var logger = services.GetRequiredService<ILogger<Program>>();
             return await ConsoleOutput.RunWithErrorHandling(async () =>
             {
+                var copilotCli = services.GetRequiredService<CopilotCliService>();
+                var copilotTrust = services.GetRequiredService<CopilotTrustService>();
+                var repoResolver = services.GetRequiredService<RepoPathResolver>();
                 var stateStore = services.GetRequiredService<StateStore>();
                 var setValue = parseResult.GetValue(setOption);
 
@@ -91,6 +95,16 @@ public static class ConfigCommand
                             value = CopilotdPaths.ExpandUserProfile(value);
                         }
                         cfg.RepoHome = Path.GetFullPath(value);
+                        CopilotTrustCommandHelper.EnsureTrustedFoldersForRepositories(
+                            copilotTrust,
+                            repoResolver,
+                            copilotCli,
+                            cfg,
+                            stateStore.LoadState(),
+                            cfg.Rules.Values
+                                .SelectMany(rule => rule.Repos)
+                                .Distinct(StringComparer.OrdinalIgnoreCase)
+                                .ToList());
                         ConsoleOutput.Success($"repo_home set to: {cfg.RepoHome}");
                         break;
 

--- a/src/copilotd/Commands/CopilotTrustCommandHelper.cs
+++ b/src/copilotd/Commands/CopilotTrustCommandHelper.cs
@@ -1,0 +1,107 @@
+using Copilotd.Infrastructure;
+using Copilotd.Services;
+using Spectre.Console;
+
+namespace Copilotd.Commands;
+
+internal static class CopilotTrustCommandHelper
+{
+    public static void EnsureTrustedFoldersForRepositories(
+        CopilotTrustService trustService,
+        RepoPathResolver repoResolver,
+        CopilotCliService copilotCli,
+        Copilotd.Models.CopilotdConfig config,
+        Copilotd.Models.DaemonState state,
+        IEnumerable<string> repoSlugs)
+    {
+        var requiredFolders = repoSlugs
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Select(repoSlug => repoResolver.ResolveRepoPath(repoSlug, config, state))
+            .Where(path => !string.IsNullOrWhiteSpace(path) && Directory.Exists(path))
+            .SelectMany(path => trustService.GetRequiredTrustedFolders(path!))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (requiredFolders.Count == 0)
+            return;
+
+        var trustCheck = trustService.CheckTrustedFolders(requiredFolders);
+        switch (trustCheck.Status)
+        {
+            case CopilotTrustStatus.Trusted:
+                return;
+
+            case CopilotTrustStatus.Unknown:
+                RenderAutomaticTrustUnavailable(trustService, copilotCli, trustCheck);
+                return;
+
+            case CopilotTrustStatus.Untrusted:
+                RenderMissingTrustPrompt(trustService, copilotCli, trustCheck);
+                return;
+        }
+    }
+
+    private static void RenderMissingTrustPrompt(
+        CopilotTrustService trustService,
+        CopilotCliService copilotCli,
+        CopilotTrustCheckResult trustCheck)
+    {
+        ConsoleOutput.Warning("Copilot needs these folders trusted before copilotd can dispatch sessions reliably:");
+        RenderFolderList(trustCheck.MissingFolders);
+
+        if (!AnsiConsole.Confirm("Add the missing folders to Copilot trustedFolders now?", true))
+        {
+            ConsoleOutput.Warning("copilotd will keep monitoring these repositories, but dispatched sessions may fail until these folders are trusted.");
+            RenderManualTrustInstructions(trustCheck.MissingFolders, copilotCli, includeIssueReportGuidance: false);
+            return;
+        }
+
+        var updateResult = trustService.AddTrustedFolders(trustCheck.MissingFolders);
+        if (updateResult.Succeeded)
+        {
+            if (updateResult.AddedFolders.Count > 0)
+                ConsoleOutput.Success("Updated Copilot trusted folders for unattended dispatch.");
+            return;
+        }
+
+        ConsoleOutput.Warning(updateResult.Message ?? "Copilot trusted folders could not be updated automatically.");
+        RenderAutomaticTrustUnavailable(trustService, copilotCli, new CopilotTrustCheckResult
+        {
+            Status = CopilotTrustStatus.Unknown,
+            RequiredFolders = trustCheck.RequiredFolders,
+            Message = updateResult.Message,
+        });
+    }
+
+    private static void RenderAutomaticTrustUnavailable(
+        CopilotTrustService trustService,
+        CopilotCliService copilotCli,
+        CopilotTrustCheckResult trustCheck)
+    {
+        ConsoleOutput.Warning(trustCheck.Message ?? "Copilot folder trust could not be verified automatically.");
+        ConsoleOutput.Info($"copilotd could not safely verify or update {trustService.ConfigPath}.");
+        RenderManualTrustInstructions(trustCheck.RequiredFolders, copilotCli, includeIssueReportGuidance: true);
+    }
+
+    private static void RenderManualTrustInstructions(
+        IReadOnlyList<string> folders,
+        CopilotCliService copilotCli,
+        bool includeIssueReportGuidance)
+    {
+        ConsoleOutput.Info("Trust these folders manually by starting a Copilot session in each folder and choosing the option to trust it for all sessions:");
+        RenderFolderList(folders);
+
+        if (includeIssueReportGuidance)
+        {
+            var version = copilotCli.GetVersion() ?? "unknown";
+            ConsoleOutput.Info($"Please also file an issue on the copilotd repo and include your Copilot CLI version: {version}");
+        }
+    }
+
+    private static void RenderFolderList(IEnumerable<string> folders)
+    {
+        foreach (var folder in folders)
+            AnsiConsole.MarkupLine($"  [yellow]- {Markup.Escape(folder)}[/]");
+    }
+}

--- a/src/copilotd/Commands/InitCommand.cs
+++ b/src/copilotd/Commands/InitCommand.cs
@@ -22,7 +22,10 @@ public static class InitCommand
             {
                 var ghCli = services.GetRequiredService<GhCliService>();
                 var copilotCli = services.GetRequiredService<CopilotCliService>();
+                var copilotTrust = services.GetRequiredService<CopilotTrustService>();
                 var stateStore = services.GetRequiredService<StateStore>();
+                var repoResolver = services.GetRequiredService<RepoPathResolver>();
+                var state = stateStore.LoadState();
 
                 // ── Phase 1: Dependencies & Auth ──────────────────────────
                 AnsiConsole.Write(new Rule("[bold blue]Dependencies & Authentication[/]").LeftJustified());
@@ -258,7 +261,6 @@ public static class InitCommand
                 else
                 {
                     // Check which repos are cloned locally under RepoHome (single scan, not per-repo)
-                    var repoResolver = services.GetRequiredService<RepoPathResolver>();
                     var cloneStatus = repoResolver.BuildCloneStatusMap(repos, config);
 
                     var clonedCount = cloneStatus.Values.Count(v => v);
@@ -301,6 +303,13 @@ public static class InitCommand
                     }
 
                     defaultRule.Repos = selected;
+                    CopilotTrustCommandHelper.EnsureTrustedFoldersForRepositories(
+                        copilotTrust,
+                        repoResolver,
+                        copilotCli,
+                        config,
+                        state,
+                        selected);
                 }
                 AnsiConsole.WriteLine();
 

--- a/src/copilotd/Commands/RulesCommand.cs
+++ b/src/copilotd/Commands/RulesCommand.cs
@@ -2,6 +2,7 @@ using System.CommandLine;
 using System.CommandLine.Help;
 using Copilotd.Infrastructure;
 using Copilotd.Models;
+using Copilotd.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
@@ -191,8 +192,12 @@ public static class RulesCommand
             var logger = services.GetRequiredService<ILogger<Program>>();
             return await ConsoleOutput.RunWithErrorHandling(async () =>
             {
+                var copilotCli = services.GetRequiredService<CopilotCliService>();
+                var copilotTrust = services.GetRequiredService<CopilotTrustService>();
+                var repoResolver = services.GetRequiredService<RepoPathResolver>();
                 var stateStore = services.GetRequiredService<StateStore>();
                 var config = stateStore.LoadConfig();
+                var state = stateStore.LoadState();
 
                 var name = parseResult.GetValue(nameArg)!;
 
@@ -241,6 +246,13 @@ public static class RulesCommand
                 }
 
                 config.Rules[name] = rule;
+                CopilotTrustCommandHelper.EnsureTrustedFoldersForRepositories(
+                    copilotTrust,
+                    repoResolver,
+                    copilotCli,
+                    config,
+                    state,
+                    rule.Repos);
                 stateStore.SaveConfig(config);
                 ConsoleOutput.Success($"Rule '{name}' added.");
                 return 0;
@@ -299,8 +311,12 @@ public static class RulesCommand
             var logger = services.GetRequiredService<ILogger<Program>>();
             return await ConsoleOutput.RunWithErrorHandling(async () =>
             {
+                var copilotCli = services.GetRequiredService<CopilotCliService>();
+                var copilotTrust = services.GetRequiredService<CopilotTrustService>();
+                var repoResolver = services.GetRequiredService<RepoPathResolver>();
                 var stateStore = services.GetRequiredService<StateStore>();
                 var config = stateStore.LoadConfig();
+                var state = stateStore.LoadState();
 
                 var name = parseResult.GetValue(nameArg)!;
 
@@ -398,6 +414,17 @@ public static class RulesCommand
                 if (rule.Authors.Count > 0 && rule.AuthorMode == AuthorMode.Any)
                 {
                     rule.AuthorMode = AuthorMode.Allowed;
+                }
+
+                if (addRepos.Length > 0)
+                {
+                    CopilotTrustCommandHelper.EnsureTrustedFoldersForRepositories(
+                        copilotTrust,
+                        repoResolver,
+                        copilotCli,
+                        config,
+                        state,
+                        addRepos);
                 }
 
                 stateStore.SaveConfig(config);

--- a/src/copilotd/Commands/SessionCommand.cs
+++ b/src/copilotd/Commands/SessionCommand.cs
@@ -23,6 +23,7 @@ public static class SessionCommand
         command.Aliases.Add("sessions");
 
         command.Subcommands.Add(CreateListCommand(services));
+        command.Subcommands.Add(CreateInfoCommand(services));
         command.Subcommands.Add(CreateConnectCommand(services));
         command.Subcommands.Add(CreateCommentCommand(services));
         command.Subcommands.Add(CreateCompleteCommand(services));
@@ -97,6 +98,59 @@ public static class SessionCommand
                 var showAll = parseResult.GetValue(allOption);
 
                 return RenderSessionList(stateStore, processManager, remoteSessionUrls, config, filterValue, showAll);
+            }, logger);
+        });
+
+        return command;
+    }
+
+    // ---- info subcommand ----
+
+    private static Command CreateInfoCommand(IServiceProvider services)
+    {
+        var command = new Command("info", "Show detailed information for a tracked session");
+
+        var issueArg = new Argument<string>("issue") { Description = "Issue key to inspect (e.g., owner/repo#123)" };
+        command.Arguments.Add(issueArg);
+
+        command.SetAction(async (ParseResult parseResult, CancellationToken ct) =>
+        {
+            var logger = services.GetRequiredService<ILogger<Program>>();
+            return await ConsoleOutput.RunWithErrorHandling(async () =>
+            {
+                var stateStore = services.GetRequiredService<StateStore>();
+                var processManager = services.GetRequiredService<ProcessManager>();
+                var repoResolver = services.GetRequiredService<RepoPathResolver>();
+                var remoteSessionUrls = services.GetRequiredService<GitHubRemoteSessionUrlResolver>();
+                var config = stateStore.LoadConfig();
+                var issueKey = parseResult.GetValue(issueArg)!;
+
+                DispatchSession? session = null;
+                stateStore.WithStateLock(() =>
+                {
+                    var state = stateStore.LoadState();
+                    if (state.Sessions.TryGetValue(issueKey, out var existing))
+                        session = CreateSessionSnapshot(existing);
+                }, ct);
+
+                if (session is null)
+                {
+                    ConsoleOutput.Error($"No session found for '{issueKey}'.");
+                    ConsoleOutput.Info("Use 'copilotd session list --all' to see all tracked sessions.");
+                    return 1;
+                }
+
+                var liveness = session.Status is SessionStatus.Dispatching or SessionStatus.Running or SessionStatus.Joined
+                    ? processManager.CheckProcess(session)
+                    : (ProcessLivenessResult?)null;
+
+                var remoteUrl = remoteSessionUrls.TryResolve(session, config.CurrentUser);
+                var remoteTaskId = remoteSessionUrls.TryResolveTaskId(session, config.CurrentUser);
+                var state = stateStore.LoadState();
+                var repoPath = repoResolver.ResolveRepoPath(session.Repo, config, state);
+
+                RenderSessionInfo(session, repoPath, remoteUrl, remoteTaskId, liveness);
+                return 0;
             }, logger);
         });
 
@@ -363,6 +417,7 @@ public static class SessionCommand
 
                     trackedProcess = CaptureTrackedProcess(session);
                     session.Status = SessionStatus.WaitingForFeedback;
+                    session.FailureDetail = null;
                     session.WaitingSince = DateTimeOffset.UtcNow;
                     ClearTrackedProcess(session);
                     session.UpdatedAt = DateTimeOffset.UtcNow;
@@ -424,6 +479,7 @@ public static class SessionCommand
 
                     trackedProcess = CaptureTrackedProcess(session);
                     session.Status = SessionStatus.Completed;
+                    session.FailureDetail = null;
                     session.CompletedBySession = true;
                     ClearTrackedProcess(session);
                     session.UpdatedAt = DateTimeOffset.UtcNow;
@@ -502,6 +558,7 @@ public static class SessionCommand
                     trackedProcess = CaptureTrackedProcess(session);
                     session.PullRequestNumber = prNumber;
                     session.Status = SessionStatus.WaitingForReview;
+                    session.FailureDetail = null;
                     session.WaitingSince = DateTimeOffset.UtcNow;
                     ClearTrackedProcess(session);
                     session.UpdatedAt = DateTimeOffset.UtcNow;
@@ -566,6 +623,7 @@ public static class SessionCommand
                     processManager.CleanupWorktree(session, config, state);
 
                     session.Status = SessionStatus.Pending;
+                    session.FailureDetail = null;
                     session.CompletedBySession = false;
                     session.PullRequestNumber = null;
                     session.CopilotSessionId = Guid.NewGuid().ToString();
@@ -684,6 +742,7 @@ public static class SessionCommand
 
         RenderSessionTable(list);
         Console.WriteLine();
+        RenderFailedSessionHints(list);
         RenderRemoteSessionUrls(list, remoteSessionUrls, config.CurrentUser);
 
         ConsoleOutput.Info($"{list.Count} session(s)");
@@ -746,6 +805,22 @@ public static class SessionCommand
         AnsiConsole.Write(table);
     }
 
+    private static void RenderFailedSessionHints(List<DispatchSession> sessions)
+    {
+        var failedSessions = sessions
+            .Where(session => session.Status == SessionStatus.Failed)
+            .Select(session => session.IssueKey)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        if (failedSessions.Count == 0)
+            return;
+
+        foreach (var issueKey in failedSessions)
+            ConsoleOutput.Warning($"For full failure details, run: copilotd session info {issueKey}");
+
+        Console.WriteLine();
+    }
+
     private static void RenderRemoteSessionUrls(List<DispatchSession> sessions,
         GitHubRemoteSessionUrlResolver remoteSessionUrls, string? currentUser)
     {
@@ -767,6 +842,73 @@ public static class SessionCommand
             SessionStatus.Pending or SessionStatus.Dispatching or SessionStatus.Running => "not yet available",
             _ => "unavailable"
         };
+
+    private static void RenderSessionInfo(
+        DispatchSession session,
+        string? repoPath,
+        string? remoteUrl,
+        string? remoteTaskId,
+        ProcessLivenessResult? liveness)
+    {
+        var table = new Table();
+        table.Border(TableBorder.Rounded);
+        table.ShowRowSeparators = true;
+        table.AddColumn(new TableColumn("[bold]Field[/]").NoWrap());
+        table.AddColumn(new TableColumn("[bold]Value[/]"));
+
+        table.AddRow("Issue", Markup.Escape(session.IssueKey));
+        table.AddRow("Repo", Markup.Escape(session.Repo));
+        table.AddRow("Issue number", Markup.Escape(session.IssueNumber.ToString()));
+        table.AddRow("Rule", Markup.Escape(session.RuleName));
+        table.AddRow("Status", Markup.Escape(session.Status.ToString()));
+        table.AddRow("Issue author", Markup.Escape(session.IssueAuthor ?? "(unknown)"));
+        table.AddRow("Created", Markup.Escape(session.CreatedAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss zzz")));
+        table.AddRow("Updated", Markup.Escape(session.UpdatedAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss zzz")));
+        table.AddRow("Last verified", Markup.Escape(FormatOptionalTime(session.LastVerifiedAt)));
+        table.AddRow("Last failure", Markup.Escape(FormatOptionalTime(session.LastFailureAt)));
+        table.AddRow("Retry count", Markup.Escape(session.RetryCount.ToString()));
+        table.AddRow("Redispatch count", Markup.Escape(session.RedispatchCount.ToString()));
+        table.AddRow("Completed by session", Markup.Escape(session.CompletedBySession ? "yes" : "no"));
+        table.AddRow("Waiting since", Markup.Escape(FormatOptionalTime(session.WaitingSince)));
+        table.AddRow("Pull request", Markup.Escape(session.PullRequestNumber?.ToString() ?? "-"));
+        table.AddRow("Process ID", Markup.Escape(session.ProcessId?.ToString() ?? "-"));
+        table.AddRow("Process start", Markup.Escape(FormatOptionalTime(session.ProcessStartTime)));
+        table.AddRow("Process liveness", Markup.Escape(FormatOptionalLiveness(liveness)));
+        table.AddRow("Session ID", Markup.Escape(string.IsNullOrEmpty(session.CopilotSessionId) ? "-" : session.CopilotSessionId));
+        table.AddRow("Remote task ID", Markup.Escape(remoteTaskId ?? "-"));
+        table.AddRow("Remote URL", Markup.Escape(remoteUrl ?? GetUnavailableRemoteSessionUrlMessage(session)));
+        table.AddRow("Repo path", Markup.Escape(NormalizeDisplayPath(repoPath) ?? "-"));
+        table.AddRow("Worktree path", Markup.Escape(NormalizeDisplayPath(session.WorktreePath) ?? "-"));
+        table.AddRow("Branch", Markup.Escape(session.BranchName ?? "-"));
+        table.AddRow("Failure detail", Markup.Escape(session.FailureDetail ?? "(none)"));
+
+        AnsiConsole.Write(table);
+
+        if (session.Status == SessionStatus.Failed && !string.IsNullOrWhiteSpace(session.FailureDetail))
+        {
+            Console.WriteLine();
+            ConsoleOutput.Warning($"After resolving the issue above, run 'copilotd session reset {session.IssueKey}' to queue a new dispatch.");
+        }
+    }
+
+    private static string FormatOptionalTime(DateTimeOffset? time)
+        => time.HasValue
+            ? time.Value.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss zzz")
+            : "-";
+
+    private static string FormatOptionalLiveness(ProcessLivenessResult? liveness)
+        => liveness switch
+        {
+            ProcessLivenessResult.Alive => "alive",
+            ProcessLivenessResult.Dead => "dead",
+            ProcessLivenessResult.PidReused => "pid reused",
+            _ => "-",
+        };
+
+    private static string? NormalizeDisplayPath(string? path)
+        => string.IsNullOrWhiteSpace(path)
+            ? null
+            : path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
 
     public static string FormatTime(DateTimeOffset time)
     {
@@ -798,6 +940,33 @@ public static class SessionCommand
 
     private static TrackedProcessRef CaptureTrackedProcess(DispatchSession session)
         => new(session.IssueKey, session.ProcessId, session.ProcessStartTime);
+
+    private static DispatchSession CreateSessionSnapshot(DispatchSession session)
+        => new()
+        {
+            IssueKey = session.IssueKey,
+            Repo = session.Repo,
+            IssueNumber = session.IssueNumber,
+            RuleName = session.RuleName,
+            IssueAuthor = session.IssueAuthor,
+            CopilotSessionId = session.CopilotSessionId,
+            ProcessId = session.ProcessId,
+            ProcessStartTime = session.ProcessStartTime,
+            Status = session.Status,
+            CreatedAt = session.CreatedAt,
+            UpdatedAt = session.UpdatedAt,
+            LastVerifiedAt = session.LastVerifiedAt,
+            RetryCount = session.RetryCount,
+            LastFailureAt = session.LastFailureAt,
+            FailureDetail = session.FailureDetail,
+            CompletedBySession = session.CompletedBySession,
+            WaitingSince = session.WaitingSince,
+            PullRequestNumber = session.PullRequestNumber,
+            RedispatchCount = session.RedispatchCount,
+            LastRedispatchWasIssueComment = session.LastRedispatchWasIssueComment,
+            WorktreePath = session.WorktreePath,
+            BranchName = session.BranchName,
+        };
 
     private static void ClearTrackedProcess(DispatchSession session)
     {

--- a/src/copilotd/Infrastructure/CopilotTrustService.cs
+++ b/src/copilotd/Infrastructure/CopilotTrustService.cs
@@ -1,0 +1,417 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Logging;
+
+namespace Copilotd.Infrastructure;
+
+public enum CopilotTrustStatus
+{
+    Trusted,
+    Untrusted,
+    Unknown,
+}
+
+public sealed class CopilotTrustCheckResult
+{
+    public CopilotTrustStatus Status { get; init; }
+    public IReadOnlyList<string> RequiredFolders { get; init; } = [];
+    public IReadOnlyList<string> MissingFolders { get; init; } = [];
+    public string? Message { get; init; }
+}
+
+public sealed class CopilotTrustMutationResult
+{
+    public bool Succeeded { get; init; }
+    public IReadOnlyList<string> AddedFolders { get; init; } = [];
+    public string? Message { get; init; }
+}
+
+public sealed class CopilotTrustService
+{
+    private const int MaxAttempts = 3;
+    private static readonly TimeSpan RetryDelay = TimeSpan.FromMilliseconds(500);
+    private readonly string _configPath;
+    private readonly ILogger<CopilotTrustService> _logger;
+
+    public CopilotTrustService(ILogger<CopilotTrustService> logger)
+        : this(CopilotdPaths.GetCopilotConfigPath(), logger)
+    {
+    }
+
+    public CopilotTrustService(string configPath, ILogger<CopilotTrustService> logger)
+    {
+        _configPath = configPath;
+        _logger = logger;
+    }
+
+    public string ConfigPath => _configPath;
+
+    public IReadOnlyList<string> GetRequiredTrustedFolders(string repoPath)
+    {
+        var normalizedRepoPath = NormalizePath(repoPath);
+        return
+        [
+            normalizedRepoPath,
+            NormalizePath(normalizedRepoPath + "_sessions")
+        ];
+    }
+
+    public CopilotTrustCheckResult CheckTrustedFolders(IEnumerable<string> requiredFolders)
+    {
+        var normalizedRequiredFolders = NormalizeFolders(requiredFolders);
+        if (normalizedRequiredFolders.Count == 0)
+        {
+            return new CopilotTrustCheckResult
+            {
+                Status = CopilotTrustStatus.Trusted,
+                RequiredFolders = normalizedRequiredFolders,
+            };
+        }
+
+        ConfigReadResult? lastResult = null;
+        for (var attempt = 1; attempt <= MaxAttempts; attempt++)
+        {
+            lastResult = TryReadConfigOnce();
+            switch (lastResult.Status)
+            {
+                case ConfigReadStatus.Success:
+                    var missingFolders = normalizedRequiredFolders
+                        .Where(requiredFolder => !IsTrustedByAny(requiredFolder, lastResult.TrustedFolders))
+                        .ToList();
+
+                    return new CopilotTrustCheckResult
+                    {
+                        Status = missingFolders.Count == 0 ? CopilotTrustStatus.Trusted : CopilotTrustStatus.Untrusted,
+                        RequiredFolders = normalizedRequiredFolders,
+                        MissingFolders = missingFolders,
+                    };
+
+                case ConfigReadStatus.Missing:
+                case ConfigReadStatus.UnsupportedSchema:
+                    return CreateUnknownResult(normalizedRequiredFolders, lastResult.Message);
+
+                case ConfigReadStatus.RetryableFailure:
+                    if (attempt < MaxAttempts)
+                    {
+                        _logger.LogDebug("Retrying Copilot config trust check for {Path} (attempt {Attempt}/{Max})",
+                            ConfigPath, attempt + 1, MaxAttempts);
+                        Thread.Sleep(RetryDelay);
+                        continue;
+                    }
+
+                    return CreateUnknownResult(normalizedRequiredFolders, lastResult.Message);
+            }
+        }
+
+        return CreateUnknownResult(normalizedRequiredFolders,
+            lastResult?.Message ?? "Copilot folder trust could not be verified.");
+    }
+
+    public CopilotTrustMutationResult AddTrustedFolders(IEnumerable<string> folders)
+    {
+        var normalizedFolders = NormalizeFolders(folders);
+        if (normalizedFolders.Count == 0)
+        {
+            return new CopilotTrustMutationResult
+            {
+                Succeeded = true,
+            };
+        }
+
+        ConfigReadResult? lastReadResult = null;
+        for (var attempt = 1; attempt <= MaxAttempts; attempt++)
+        {
+            lastReadResult = TryReadConfigOnce();
+            switch (lastReadResult.Status)
+            {
+                case ConfigReadStatus.Success:
+                    var foldersToAdd = normalizedFolders
+                        .Where(folder => !IsTrustedByAny(folder, lastReadResult.TrustedFolders))
+                        .ToList();
+                    if (foldersToAdd.Count == 0)
+                    {
+                        return new CopilotTrustMutationResult
+                        {
+                            Succeeded = true,
+                        };
+                    }
+
+                    var trustedFolders = (JsonArray)lastReadResult.Root!["trustedFolders"]!;
+                    foreach (var folder in foldersToAdd)
+                        trustedFolders.Add((JsonNode?)JsonValue.Create(folder));
+
+                    var writeResult = TryWriteConfigOnce(lastReadResult.Root!);
+                    if (writeResult.Succeeded)
+                    {
+                        return new CopilotTrustMutationResult
+                        {
+                            Succeeded = true,
+                            AddedFolders = foldersToAdd,
+                        };
+                    }
+
+                    if (attempt < MaxAttempts)
+                    {
+                        _logger.LogDebug("Retrying Copilot config trust update for {Path} (attempt {Attempt}/{Max})",
+                            ConfigPath, attempt + 1, MaxAttempts);
+                        Thread.Sleep(RetryDelay);
+                        continue;
+                    }
+
+                    return new CopilotTrustMutationResult
+                    {
+                        Succeeded = false,
+                        Message = writeResult.Message,
+                    };
+
+                case ConfigReadStatus.Missing:
+                case ConfigReadStatus.UnsupportedSchema:
+                    return new CopilotTrustMutationResult
+                    {
+                        Succeeded = false,
+                        Message = lastReadResult.Message,
+                    };
+
+                case ConfigReadStatus.RetryableFailure:
+                    if (attempt < MaxAttempts)
+                    {
+                        _logger.LogDebug("Retrying Copilot config trust update for {Path} (attempt {Attempt}/{Max})",
+                            ConfigPath, attempt + 1, MaxAttempts);
+                        Thread.Sleep(RetryDelay);
+                        continue;
+                    }
+
+                    return new CopilotTrustMutationResult
+                    {
+                        Succeeded = false,
+                        Message = lastReadResult.Message,
+                    };
+            }
+        }
+
+        return new CopilotTrustMutationResult
+        {
+            Succeeded = false,
+            Message = lastReadResult?.Message ?? "Copilot trusted folders could not be updated.",
+        };
+    }
+
+    private ConfigReadResult TryReadConfigOnce()
+    {
+        if (!File.Exists(ConfigPath))
+        {
+            return new ConfigReadResult
+            {
+                Status = ConfigReadStatus.Missing,
+                Message = $"Copilot config file '{NormalizeDisplayPath(ConfigPath)}' does not exist yet.",
+            };
+        }
+
+        try
+        {
+            using var stream = new FileStream(ConfigPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            using var reader = new StreamReader(stream);
+            var json = reader.ReadToEnd();
+            if (string.IsNullOrWhiteSpace(json))
+                throw new JsonException("Copilot config file is empty.");
+
+            var node = JsonNode.Parse(json);
+            if (node is not JsonObject root)
+            {
+                return new ConfigReadResult
+                {
+                    Status = ConfigReadStatus.UnsupportedSchema,
+                    Message = $"Copilot config file '{NormalizeDisplayPath(ConfigPath)}' is not a JSON object.",
+                };
+            }
+
+            if (root["trustedFolders"] is not JsonArray trustedFoldersNode)
+            {
+                return new ConfigReadResult
+                {
+                    Status = ConfigReadStatus.UnsupportedSchema,
+                    Message = $"Copilot config file '{NormalizeDisplayPath(ConfigPath)}' does not contain the expected 'trustedFolders' array.",
+                };
+            }
+
+            var trustedFolders = new List<string>();
+            foreach (var item in trustedFoldersNode)
+            {
+                if (item is not JsonValue jsonValue)
+                {
+                    return new ConfigReadResult
+                    {
+                        Status = ConfigReadStatus.UnsupportedSchema,
+                        Message = $"Copilot config file '{NormalizeDisplayPath(ConfigPath)}' has a non-string entry in 'trustedFolders'.",
+                    };
+                }
+
+                string trustedFolder;
+                try
+                {
+                    trustedFolder = jsonValue.GetValue<string>();
+                }
+                catch (Exception)
+                {
+                    return new ConfigReadResult
+                    {
+                        Status = ConfigReadStatus.UnsupportedSchema,
+                        Message = $"Copilot config file '{NormalizeDisplayPath(ConfigPath)}' has a non-string entry in 'trustedFolders'.",
+                    };
+                }
+
+                if (string.IsNullOrWhiteSpace(trustedFolder))
+                {
+                    return new ConfigReadResult
+                    {
+                        Status = ConfigReadStatus.UnsupportedSchema,
+                        Message = $"Copilot config file '{NormalizeDisplayPath(ConfigPath)}' has an empty entry in 'trustedFolders'.",
+                    };
+                }
+
+                trustedFolders.Add(NormalizePath(trustedFolder));
+            }
+
+            return new ConfigReadResult
+            {
+                Status = ConfigReadStatus.Success,
+                Root = root,
+                TrustedFolders = trustedFolders,
+            };
+        }
+        catch (IOException ex)
+        {
+            _logger.LogDebug(ex, "Retryable Copilot config read failure for {Path}", ConfigPath);
+            return new ConfigReadResult
+            {
+                Status = ConfigReadStatus.RetryableFailure,
+                Message = $"Copilot config file '{NormalizeDisplayPath(ConfigPath)}' is temporarily unavailable: {ex.Message}",
+            };
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            _logger.LogDebug(ex, "Retryable Copilot config read failure for {Path}", ConfigPath);
+            return new ConfigReadResult
+            {
+                Status = ConfigReadStatus.RetryableFailure,
+                Message = $"Copilot config file '{NormalizeDisplayPath(ConfigPath)}' is temporarily unavailable: {ex.Message}",
+            };
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogDebug(ex, "Retryable Copilot config parse failure for {Path}", ConfigPath);
+            return new ConfigReadResult
+            {
+                Status = ConfigReadStatus.RetryableFailure,
+                Message = $"Copilot config file '{NormalizeDisplayPath(ConfigPath)}' could not be read as complete JSON after retries.",
+            };
+        }
+    }
+
+    private ConfigWriteResult TryWriteConfigOnce(JsonObject root)
+    {
+        var tempPath = Path.Combine(Path.GetDirectoryName(ConfigPath)!,
+            $".{Path.GetFileName(ConfigPath)}.{Guid.NewGuid():N}.tmp");
+
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(ConfigPath)!);
+            var json = root.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(tempPath, json);
+            File.Move(tempPath, ConfigPath, overwrite: true);
+
+            return new ConfigWriteResult
+            {
+                Succeeded = true,
+            };
+        }
+        catch (IOException ex)
+        {
+            _logger.LogDebug(ex, "Retryable Copilot config write failure for {Path}", ConfigPath);
+            return new ConfigWriteResult
+            {
+                Message = $"Copilot config file '{NormalizeDisplayPath(ConfigPath)}' could not be updated safely: {ex.Message}",
+            };
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            _logger.LogDebug(ex, "Retryable Copilot config write failure for {Path}", ConfigPath);
+            return new ConfigWriteResult
+            {
+                Message = $"Copilot config file '{NormalizeDisplayPath(ConfigPath)}' could not be updated safely: {ex.Message}",
+            };
+        }
+        finally
+        {
+            try
+            {
+                if (File.Exists(tempPath))
+                    File.Delete(tempPath);
+            }
+            catch
+            {
+                // Best effort cleanup only.
+            }
+        }
+    }
+
+    private static CopilotTrustCheckResult CreateUnknownResult(
+        IReadOnlyList<string> requiredFolders,
+        string? message)
+        => new()
+        {
+            Status = CopilotTrustStatus.Unknown,
+            RequiredFolders = requiredFolders,
+            Message = message,
+        };
+
+    private static List<string> NormalizeFolders(IEnumerable<string> folders)
+        => folders
+            .Where(folder => !string.IsNullOrWhiteSpace(folder))
+            .Select(NormalizePath)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(folder => folder, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+    private static string NormalizePath(string path)
+        => Path.GetFullPath(path)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+    private static string NormalizeDisplayPath(string path)
+        => NormalizePath(path).Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+
+    private static bool IsTrustedByAny(string requiredFolder, IEnumerable<string> trustedFolders)
+        => trustedFolders.Any(trustedFolder => IsSameOrAncestor(trustedFolder, requiredFolder));
+
+    private static bool IsSameOrAncestor(string candidateAncestor, string candidatePath)
+    {
+        if (string.Equals(candidateAncestor, candidatePath, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        var ancestorWithSeparator = candidateAncestor + Path.DirectorySeparatorChar;
+        var pathWithSeparator = candidatePath + Path.DirectorySeparatorChar;
+        return pathWithSeparator.StartsWith(ancestorWithSeparator, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private enum ConfigReadStatus
+    {
+        Success,
+        Missing,
+        UnsupportedSchema,
+        RetryableFailure,
+    }
+
+    private sealed class ConfigReadResult
+    {
+        public ConfigReadStatus Status { get; init; }
+        public JsonObject? Root { get; init; }
+        public IReadOnlyList<string> TrustedFolders { get; init; } = [];
+        public string? Message { get; init; }
+    }
+
+    private sealed class ConfigWriteResult
+    {
+        public bool Succeeded { get; init; }
+        public string? Message { get; init; }
+    }
+}

--- a/src/copilotd/Infrastructure/CopilotdPaths.cs
+++ b/src/copilotd/Infrastructure/CopilotdPaths.cs
@@ -35,6 +35,12 @@ public static class CopilotdPaths
             ? $"{GetCopilotdHomeDirectory()} (from {HomeEnvVar})"
             : GetCopilotdHomeDirectory();
 
+    public static string GetCopilotHomeDirectory()
+        => Path.Combine(GetUserProfileDirectory(), ".copilot");
+
+    public static string GetCopilotConfigPath()
+        => Path.Combine(GetCopilotHomeDirectory(), "config.json");
+
     public static string GetLogsDirectory()
         => Path.Combine(GetCopilotdHomeDirectory(), "logs");
 }

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -121,6 +121,7 @@ public sealed partial class ProcessManager
             }
 
             session.Status = SessionStatus.Running;
+            session.FailureDetail = null;
             session.UpdatedAt = DateTimeOffset.UtcNow;
             session.LastVerifiedAt = DateTimeOffset.UtcNow;
 

--- a/src/copilotd/Infrastructure/RuntimeContext.cs
+++ b/src/copilotd/Infrastructure/RuntimeContext.cs
@@ -32,7 +32,7 @@ public sealed class RuntimeContext
     public string GetCopilotdCallbackCommand()
     {
         if (UsesDotnetSourceCommand)
-            return $"dotnet run --project \"{SourceProjectPath}\" --";
+            return $"dotnet run --project \"{SourceProjectPath}\" --no-build --";
 
         return "copilotd";
     }

--- a/src/copilotd/Models/CopilotdConfig.cs
+++ b/src/copilotd/Models/CopilotdConfig.cs
@@ -134,6 +134,7 @@ public sealed class CopilotdConfig
         AVAILABLE COMMANDS (run these in the terminal):
         - `$(copilotd.command) status`                          — Show daemon health, watched repos, and session summary
         - `$(copilotd.command) session list [--all]`             — List active sessions (--all includes completed/failed)
+        - `$(copilotd.command) session info <issue>`             — Show detailed information for a tracked session
         - `$(copilotd.command) session list --filter <status>`   — Filter by status: pending, dispatching, running, waitingforfeedback, waitingforreview, completed, failed, orphaned, joined (legacy)
         - `$(copilotd.command) session reset <issue>`            — Reset a session for re-dispatch (e.g., "org/repo#42")
         - `$(copilotd.command) session complete <issue>`         — Mark a session as completed

--- a/src/copilotd/Models/SessionState.cs
+++ b/src/copilotd/Models/SessionState.cs
@@ -124,6 +124,12 @@ public sealed class DispatchSession
     public DateTimeOffset? LastFailureAt { get; set; }
 
     /// <summary>
+    /// Optional diagnostic detail explaining why the session most recently failed.
+    /// Shown by <c>copilotd session info</c> when available.
+    /// </summary>
+    public string? FailureDetail { get; set; }
+
+    /// <summary>
     /// True when the session was explicitly marked complete by the copilot session itself
     /// (via 'copilotd session complete'). Prevents automatic re-dispatch even if the issue
     /// still matches rules.

--- a/src/copilotd/Program.cs
+++ b/src/copilotd/Program.cs
@@ -81,6 +81,7 @@ public class Program
 
         serviceCollection.AddSingleton<StateStore>();
         serviceCollection.AddSingleton<RepoPathResolver>();
+        serviceCollection.AddSingleton<CopilotTrustService>();
         serviceCollection.AddSingleton<ProcessManager>();
         serviceCollection.AddSingleton<GitHubRemoteSessionUrlResolver>();
         serviceCollection.AddSingleton<GhCliService>();

--- a/src/copilotd/Services/ReconciliationEngine.cs
+++ b/src/copilotd/Services/ReconciliationEngine.cs
@@ -17,17 +17,23 @@ namespace Copilotd.Services;
 public sealed class ReconciliationEngine
 {
     private readonly ProcessManager _processManager;
+    private readonly RepoPathResolver _repoResolver;
+    private readonly CopilotTrustService _copilotTrustService;
     private readonly GhCliService _ghCli;
     private readonly StateStore _stateStore;
     private readonly ILogger<ReconciliationEngine> _logger;
 
     public ReconciliationEngine(
         ProcessManager processManager,
+        RepoPathResolver repoResolver,
+        CopilotTrustService copilotTrustService,
         GhCliService ghCli,
         StateStore stateStore,
         ILogger<ReconciliationEngine> logger)
     {
         _processManager = processManager;
+        _repoResolver = repoResolver;
+        _copilotTrustService = copilotTrustService;
         _ghCli = ghCli;
         _stateStore = stateStore;
         _logger = logger;
@@ -121,6 +127,7 @@ public sealed class ReconciliationEngine
                     // No PID tracked — join process never saved it or state is stale
                     _logger.LogInformation("Joined session {Key} has no tracked PID, resetting to Pending", key);
                     session.Status = SessionStatus.Pending;
+                    session.FailureDetail = null;
                     session.UpdatedAt = DateTimeOffset.UtcNow;
                     continue;
                 }
@@ -130,6 +137,7 @@ public sealed class ReconciliationEngine
                 {
                     _logger.LogInformation("Joined session {Key} interactive process is gone, resetting to Pending", key);
                     session.Status = SessionStatus.Pending;
+                    session.FailureDetail = null;
                     session.ProcessId = null;
                     session.ProcessStartTime = null;
                     session.UpdatedAt = DateTimeOffset.UtcNow;
@@ -149,12 +157,14 @@ public sealed class ReconciliationEngine
                 case ProcessLivenessResult.Dead:
                     _logger.LogInformation("Session {Key} PID {Pid} is dead, marking orphaned", key, session.ProcessId);
                     session.Status = SessionStatus.Orphaned;
+                    session.FailureDetail = null;
                     session.UpdatedAt = DateTimeOffset.UtcNow;
                     break;
 
                 case ProcessLivenessResult.PidReused:
                     _logger.LogWarning("Session {Key} PID {Pid} was reused by another process, marking orphaned", key, session.ProcessId);
                     session.Status = SessionStatus.Orphaned;
+                    session.FailureDetail = null;
                     session.ProcessId = null;
                     session.ProcessStartTime = null;
                     session.UpdatedAt = DateTimeOffset.UtcNow;
@@ -260,6 +270,7 @@ public sealed class ReconciliationEngine
                 {
                     _logger.LogInformation("Issue {Key} no longer matches rules, completing waiting session", key);
                     session.Status = SessionStatus.Completed;
+                    session.FailureDetail = null;
                     session.WaitingSince = null;
                     session.UpdatedAt = DateTimeOffset.UtcNow;
                     _processManager.CleanupWorktree(session, config, state);
@@ -271,6 +282,7 @@ public sealed class ReconciliationEngine
                 {
                     _logger.LogInformation("Issue {Key} no longer matches rules, completing PR review session", key);
                     session.Status = SessionStatus.Completed;
+                    session.FailureDetail = null;
                     session.WaitingSince = null;
                     session.UpdatedAt = DateTimeOffset.UtcNow;
                     _processManager.CleanupWorktree(session, config, state);
@@ -293,6 +305,7 @@ public sealed class ReconciliationEngine
             foreach (var session in toTerminate)
             {
                 session.Status = SessionStatus.Completed;
+                session.FailureDetail = null;
                 session.UpdatedAt = DateTimeOffset.UtcNow;
                 _processManager.CleanupWorktree(session, config, state);
             }
@@ -359,6 +372,7 @@ public sealed class ReconciliationEngine
                                     commentInfo.Author, issueKey, existing.RedispatchCount + 1, config.MaxRedispatches);
                                 // Keep same CopilotSessionId so --resume preserves context
                                 existing.Status = SessionStatus.Pending;
+                                existing.FailureDetail = null;
                                 existing.RedispatchCount++;
                                 existing.LastRedispatchWasIssueComment = true;
                                 existing.WaitingSince = null;
@@ -383,6 +397,7 @@ public sealed class ReconciliationEngine
                                 _logger.LogInformation("PR #{Pr} for {Key} is {State}, completing session",
                                     existing.PullRequestNumber, issueKey, prState);
                                 existing.Status = SessionStatus.Completed;
+                                existing.FailureDetail = null;
                                 existing.CompletedBySession = true;
                                 existing.WaitingSince = null;
                                 existing.ProcessId = null;
@@ -431,6 +446,7 @@ public sealed class ReconciliationEngine
                                         reviewInfo.Author, existing.PullRequestNumber, issueKey, existing.RedispatchCount + 1, config.MaxRedispatches);
                                     // Keep same CopilotSessionId so --resume preserves context
                                     existing.Status = SessionStatus.Pending;
+                                    existing.FailureDetail = null;
                                     existing.RedispatchCount++;
                                     existing.LastRedispatchWasIssueComment = false;
                                     existing.WaitingSince = null;
@@ -480,6 +496,7 @@ public sealed class ReconciliationEngine
                                 _logger.LogInformation("New issue comment from {Author} detected on {Key} while waiting for PR review, re-dispatching session (redispatch {N}/{Max})",
                                     issueCommentInfo.Author, issueKey, existing.RedispatchCount + 1, config.MaxRedispatches);
                                 existing.Status = SessionStatus.Pending;
+                                existing.FailureDetail = null;
                                 existing.RedispatchCount++;
                                 existing.LastRedispatchWasIssueComment = true;
                                 existing.WaitingSince = null;
@@ -499,6 +516,7 @@ public sealed class ReconciliationEngine
                             issueKey, existing.RetryCount + 1, DispatchSession.MaxRetries);
                         _processManager.CleanupWorktree(existing, config, state);
                         existing.Status = SessionStatus.Pending;
+                        existing.FailureDetail = null;
                         existing.RetryCount++;
                         existing.PullRequestNumber = null;
                         existing.RedispatchCount = 0;
@@ -516,6 +534,8 @@ public sealed class ReconciliationEngine
                         {
                             _logger.LogWarning("Session {Key} exceeded max retries, marking failed", issueKey);
                             existing.Status = SessionStatus.Failed;
+                            existing.FailureDetail ??= $"The session exceeded the maximum retry count ({DispatchSession.MaxRetries}). " +
+                                $"Resolve the underlying issue, then run 'copilotd session reset {issueKey}'.";
                             existing.UpdatedAt = DateTimeOffset.UtcNow;
                             continue;
                         }
@@ -532,6 +552,7 @@ public sealed class ReconciliationEngine
                         _logger.LogInformation("Issue {Key} re-matched after completion, re-dispatching", issueKey);
                         _processManager.CleanupWorktree(existing, config, state);
                         existing.Status = SessionStatus.Pending;
+                        existing.FailureDetail = null;
                         existing.PullRequestNumber = null;
                         existing.RedispatchCount = 0;
                         existing.LastRedispatchWasIssueComment = false;
@@ -590,17 +611,39 @@ public sealed class ReconciliationEngine
 
         foreach (var session in toDispatch)
         {
+            var mainRepoPath = _repoResolver.ResolveRepoPath(session.Repo, config, state);
+            if (!string.IsNullOrEmpty(mainRepoPath) && Directory.Exists(mainRepoPath))
+            {
+                var trustCheck = _copilotTrustService.CheckTrustedFolders(_copilotTrustService.GetRequiredTrustedFolders(mainRepoPath));
+                switch (trustCheck.Status)
+                {
+                    case CopilotTrustStatus.Unknown:
+                        _logger.LogWarning("Could not verify Copilot folder trust for {Key}: {Message}",
+                            session.IssueKey, trustCheck.Message ?? "unknown trust verification error");
+                        break;
+
+                    case CopilotTrustStatus.Untrusted:
+                        _logger.LogWarning("Copilot folder trust missing for {Key}: {Folders}",
+                            session.IssueKey, string.Join(", ", trustCheck.MissingFolders));
+                        MarkSessionFailed(session, BuildTrustFailureDetail(session, trustCheck));
+                        _stateStore.SaveState(state);
+                        continue;
+
+                    case CopilotTrustStatus.Trusted:
+                        break;
+                }
+            }
+
             session.Status = SessionStatus.Dispatching;
+            session.FailureDetail = null;
             session.UpdatedAt = DateTimeOffset.UtcNow;
 
             // Create worktree for isolated working directory
             if (!_processManager.PrepareWorktree(session, config, state))
             {
                 _logger.LogWarning("Failed to prepare worktree for {Key}", session.IssueKey);
-                session.Status = SessionStatus.Failed;
-                session.RetryCount++;
-                session.LastFailureAt = DateTimeOffset.UtcNow;
-                session.UpdatedAt = DateTimeOffset.UtcNow;
+                MarkSessionFailed(session,
+                    $"Failed to prepare the git worktree for dispatch. Verify the local clone for {session.Repo} is healthy, then run 'copilotd session reset {session.IssueKey}'.");
                 _stateStore.SaveState(state);
                 continue;
             }
@@ -616,10 +659,8 @@ public sealed class ReconciliationEngine
             if (result is null)
             {
                 _logger.LogWarning("Failed to launch copilot for {Key}", session.IssueKey);
-                session.Status = SessionStatus.Failed;
-                session.RetryCount++;
-                session.LastFailureAt = DateTimeOffset.UtcNow;
-                session.UpdatedAt = DateTimeOffset.UtcNow;
+                MarkSessionFailed(session,
+                    $"Failed to launch the Copilot CLI process. Review the copilotd logs, then run 'copilotd session reset {session.IssueKey}'.");
                 // Clean up the worktree we just created
                 _processManager.CleanupWorktree(session, config, state);
             }
@@ -692,6 +733,30 @@ public sealed class ReconciliationEngine
                 return _ghCli.HasWriteAccess(session.Repo, commentAuthor);
         }
     }
+
+    private static void MarkSessionFailed(DispatchSession session, string detail)
+    {
+        session.Status = SessionStatus.Failed;
+        session.FailureDetail = detail;
+        session.RetryCount++;
+        session.LastFailureAt = DateTimeOffset.UtcNow;
+        session.UpdatedAt = DateTimeOffset.UtcNow;
+        session.ProcessId = null;
+        session.ProcessStartTime = null;
+    }
+
+    private string BuildTrustFailureDetail(DispatchSession session, CopilotTrustCheckResult trustCheck)
+    {
+        var folders = trustCheck.MissingFolders.Count > 0
+            ? string.Join(", ", trustCheck.MissingFolders)
+            : string.Join(", ", trustCheck.RequiredFolders);
+
+        return $"Copilot cannot dispatch this session because these folders are not trusted in {NormalizeDisplayPath(_copilotTrustService.ConfigPath)}: {folders}. " +
+            $"Trust the folders for all sessions in Copilot, then run 'copilotd session reset {session.IssueKey}'.";
+    }
+
+    private static string NormalizeDisplayPath(string path)
+        => path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
 
     /// <summary>
     /// Returns true if a session should wait before retrying, using exponential backoff.


### PR DESCRIPTION
## Summary
- add Copilot trusted-folder checks and update prompts in init/rules/config flows
- persist actionable session failure details, add `copilotd session info <issue>`, and point failed session listings to it
- fail dispatch when trust is known missing, but only log and continue when Copilot trust config cannot be verified automatically

## Validation
- dotnet build .\src\copilotd\copilotd.csproj -nologo
- smoke-tested trust config handling with disposable config files (trusted, untrusted, missing, unsupported, and update path)
- smoke-tested `copilotd session list --all` and `copilotd session info <issue>` with a disposable COPILOTD_HOME state file

Fixes #137