### PR TITLE
Improve run-from-source helper scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ artifacts/
 .vscode/
 .idea/
 .control-session/
+.copilotd-home/
 *.swp
 *~
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ Run `copilotd --help` for other commands.
 # Clone and build
 git clone https://github.com/DamianEdwards/copilotd.git
 cd copilotd
-dotnet build
+./build.sh               # macOS/Linux
+.\build.ps1              # Windows PowerShell / pwsh
+build.cmd                # Windows cmd.exe
 
 # First-run setup (checks dependencies, prompts for config)
 ./copilotd.sh init          # macOS/Linux
@@ -83,7 +85,7 @@ copilotd.cmd init           # Windows cmd.exe
 copilotd.cmd run            # Windows cmd.exe
 ```
 
-Convenience scripts `copilotd.sh`, `copilotd.ps1`, and `copilotd.cmd` run the project from source. For the long-lived `run` command they build and execute the generated apphost directly so Ctrl+C reaches `copilotd` cleanly. On Windows, use `copilotd.ps1` from PowerShell and `copilotd.cmd` from cmd.exe; other commands continue to use `dotnet run`, passing all arguments through.
+Convenience scripts `copilotd.sh`, `copilotd.ps1`, and `copilotd.cmd` run the project from source without rebuilding on every invocation. They default `COPILOTD_HOME` to a repo-local `.copilotd-home` folder so source runs stay isolated from a global install, while still honoring an explicitly configured `COPILOTD_HOME`. For the long-lived `run` command they execute the existing generated apphost directly so Ctrl+C reaches `copilotd` cleanly. Build it first with `build.sh`, `build.ps1`, or `build.cmd`. On Windows, use `copilotd.ps1` from PowerShell and `copilotd.cmd` from cmd.exe; other commands continue to use `dotnet run --no-build`, passing all arguments through.
 
 Installed copilotd binaries can self-update in the background: the daemon checks for newer releases, downloads and verifies them, then stages the new binary to be installed after the running daemon exits naturally. If an installed binary update is interrupted and you restore `copilotd.exe` by rerunning the normal install script, the next copilotd launch will reconcile any leftover `.old`, `.staged`, and `update-state.json` artifacts: it will resume a newer staged update, or discard stale staged state rather than downgrading the restored binary. When running from source or a local repo publish, copilotd suppresses automatic background self-updates by default so local scenario verification is not interrupted by GitHub releases. You can still disable them explicitly with `COPILOTD_DISABLE_SELF_UPDATES=1` or `--disable-self-updates`, and `copilotd update --check` remains available to inspect update availability.
 
@@ -356,6 +358,8 @@ To disable the control session, set `enable_control_session` to `false` in `~/.c
 ## Configuration
 
 Stored in `~/.copilotd/` by default. Set `COPILOTD_HOME` to point copilotd at a different state/config directory:
+
+When running from a source checkout via `copilotd.sh`, `copilotd.ps1`, or `copilotd.cmd`, the helper script defaults `COPILOTD_HOME` to a repo-local `.copilotd-home` directory unless you already set `COPILOTD_HOME` yourself.
 
 - `config.json` — user-managed settings (repo home, custom prompt, rules)
 - `state.json` — runtime session tracking (auto-managed, self-healing)

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,6 @@
+@echo off
+setlocal
+
+dotnet build "%~dp0src\copilotd\copilotd.csproj" --no-logo %*
+set "EXITCODE=%ERRORLEVEL%"
+endlocal & exit /b %EXITCODE%

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,7 @@
+$ErrorActionPreference = 'Stop'
+
+$scriptDir = Split-Path -Parent $PSCommandPath
+$projectFile = Join-Path $scriptDir 'src\copilotd\copilotd.csproj'
+
+& dotnet build $projectFile --no-logo @args
+exit $LASTEXITCODE

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+exec dotnet build "$SCRIPT_DIR/src/copilotd/copilotd.csproj" --no-logo "$@"

--- a/copilotd.cmd
+++ b/copilotd.cmd
@@ -4,19 +4,29 @@ if /I "%~1"=="run" goto run_direct
 setlocal
 set "SCRIPT_DIR=%~dp0"
 set "PROJECT_DIR=%SCRIPT_DIR%src\copilotd"
+if not defined COPILOTD_HOME set "COPILOTD_HOME=%SCRIPT_DIR%.copilotd-home"
 
-dotnet run --project "%PROJECT_DIR%" -- %*
+dotnet run --project "%PROJECT_DIR%" --no-build -- %*
 set "EXITCODE=%ERRORLEVEL%"
 endlocal & exit /b %EXITCODE%
 
 :run_direct
+setlocal
+set "SCRIPT_DIR=%~dp0"
+set "APP_HOST=%SCRIPT_DIR%artifacts\bin\copilotd\debug\copilotd.exe"
+if not defined COPILOTD_HOME set "COPILOTD_HOME=%SCRIPT_DIR%.copilotd-home"
 for /f %%I in ('powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "$ErrorActionPreference = 'Stop'; $me = Get-CimInstance Win32_Process -Filter ('ProcessId=' + $PID); $ancestorId = $me.ParentProcessId; $isPowerShell = $false; while ($ancestorId -gt 0) { $ancestor = Get-CimInstance Win32_Process -Filter ('ProcessId=' + $ancestorId); if ($null -eq $ancestor) { break }; if ($ancestor.Name -in @('powershell.exe', 'pwsh.exe')) { $isPowerShell = $true; break }; $ancestorId = $ancestor.ParentProcessId }; if ($isPowerShell) { '1' } else { '0' }" 2^>nul') do set "COPILOTD_PARENT_POWERSHELL=%%I"
 if "%COPILOTD_PARENT_POWERSHELL%"=="1" (
     echo copilotd.cmd run does not handle Ctrl+C reliably when launched from PowerShell.
     echo Use .\copilotd.ps1 run instead.
-    exit /b 1
+    endlocal & exit /b 1
 )
 
-dotnet build "%~dp0src\copilotd\copilotd.csproj" -nologo
-if errorlevel 1 exit /b %ERRORLEVEL%
-"%~dp0artifacts\bin\copilotd\debug\copilotd.exe" %*
+if not exist "%APP_HOST%" (
+    echo Built app host not found at "%APP_HOST%". Run build.cmd first. 1>&2
+    endlocal & exit /b 1
+)
+
+"%APP_HOST%" %*
+set "EXITCODE=%ERRORLEVEL%"
+endlocal & exit /b %EXITCODE%

--- a/copilotd.ps1
+++ b/copilotd.ps1
@@ -2,18 +2,21 @@ $ErrorActionPreference = 'Stop'
 
 $scriptDir = Split-Path -Parent $PSCommandPath
 $projectDir = Join-Path $scriptDir 'src\copilotd'
-$projectFile = Join-Path $projectDir 'copilotd.csproj'
 $appHost = Join-Path $scriptDir 'artifacts\bin\copilotd\debug\copilotd.exe'
 
+if (-not $env:COPILOTD_HOME) {
+    $env:COPILOTD_HOME = Join-Path $scriptDir '.copilotd-home'
+}
+
 if ($args.Count -gt 0 -and $args[0] -eq 'run') {
-    & dotnet build $projectFile -nologo
-    if ($LASTEXITCODE -ne 0) {
-        exit $LASTEXITCODE
+    if (-not (Test-Path $appHost -PathType Leaf)) {
+        [Console]::Error.WriteLine("Built app host not found at '$appHost'. Run .\build.ps1 first.")
+        exit 1
     }
 
     & $appHost @args
     exit $LASTEXITCODE
 }
 
-& dotnet run --project $projectDir -- @args
+& dotnet run --project $projectDir --no-build -- @args
 exit $LASTEXITCODE

--- a/copilotd.sh
+++ b/copilotd.sh
@@ -3,10 +3,19 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$SCRIPT_DIR/src/copilotd"
+APP_HOST="$SCRIPT_DIR/artifacts/bin/copilotd/debug/copilotd"
 
-if [[ "${1-}" == "run" ]]; then
-  dotnet build "$PROJECT_DIR/copilotd.csproj" -nologo
-  exec "$SCRIPT_DIR/artifacts/bin/copilotd/debug/copilotd" "$@"
+if [[ -z "${COPILOTD_HOME:-}" ]]; then
+  export COPILOTD_HOME="$SCRIPT_DIR/.copilotd-home"
 fi
 
-exec dotnet run --project "$PROJECT_DIR" -- "$@"
+if [[ "${1-}" == "run" ]]; then
+  if [[ ! -f "$APP_HOST" ]]; then
+    echo "Built app host not found at '$APP_HOST'. Run ./build.sh first." >&2
+    exit 1
+  fi
+
+  exec "$APP_HOST" "$@"
+fi
+
+exec dotnet run --project "$PROJECT_DIR" --no-build -- "$@"


### PR DESCRIPTION
## Summary

- default source helper scripts to a repo-local .copilotd-home unless COPILOTD_HOME is already set
- stop rebuilding on every helper invocation and add explicit build wrapper scripts
- update the README and ignore rules for the new source-run workflow

Fixes #146