### PR TITLE
Fix trusted folder verification failing on JSONC comments in config.json

### DIFF
--- a/src/copilotd/Infrastructure/CopilotTrustService.cs
+++ b/src/copilotd/Infrastructure/CopilotTrustService.cs
@@ -215,7 +215,11 @@ public sealed class CopilotTrustService
             if (string.IsNullOrWhiteSpace(json))
                 throw new JsonException("Copilot config file is empty.");
 
-            var node = JsonNode.Parse(json);
+            var node = JsonNode.Parse(json, nodeOptions: null, new JsonDocumentOptions
+            {
+                CommentHandling = JsonCommentHandling.Skip,
+                AllowTrailingCommas = true,
+            });
             if (node is not JsonObject root)
             {
                 return new ConfigReadResult


### PR DESCRIPTION
The Copilot CLI now writes comments (e.g. `// User settings belong in settings.json.`) at the top of `~/.copilot/config.json`. `JsonNode.Parse()` rejects these by default, causing `TryReadConfigOnce()` to throw `JsonReaderException` on every retry attempt, ultimately logging a warning and returning `Unknown` trust status.

### Fix

Pass `JsonDocumentOptions` with `CommentHandling = Skip` and `AllowTrailingCommas = true` so the parser tolerates JSONC content.

Fixes #159