### PR TITLE
Add emoji reactions on issues for session lifecycle

### DIFF
--- a/src/copilotd/Commands/SessionCommand.cs
+++ b/src/copilotd/Commands/SessionCommand.cs
@@ -362,6 +362,8 @@ public static class SessionCommand
                 var issueNumber = 0;
                 string? expectedSessionId = null;
                 string? errorMessage = null;
+                long? oldReactionId = null;
+                string? ruleName = null;
 
                 stateStore.WithStateLock(() =>
                 {
@@ -380,6 +382,8 @@ public static class SessionCommand
                     repo = session.Repo;
                     issueNumber = session.IssueNumber;
                     expectedSessionId = session.CopilotSessionId;
+                    oldReactionId = session.IssueReactionId;
+                    ruleName = session.RuleName;
                 }, ct);
 
                 if (errorMessage is not null)
@@ -432,6 +436,12 @@ public static class SessionCommand
 
                 ConsoleOutput.Success($"Comment posted on {issueKey}. Session is now waiting for feedback.");
                 ScheduleSessionShutdown(processManager, trackedProcess, config);
+
+                // Best-effort reaction transition: 🚀 → 👀 (waiting for feedback)
+                TransitionReactionBestEffort(stateStore, ghCli, config, issueKey, expectedSessionId!,
+                    repo!, issueNumber, ruleName!, oldReactionId,
+                    GhCliService.ReactionEyes, ct);
+
                 return 0;
             }, logger);
         });
@@ -454,6 +464,7 @@ public static class SessionCommand
             return await ConsoleOutput.RunWithErrorHandling(async () =>
             {
                 var stateStore = services.GetRequiredService<StateStore>();
+                var ghCli = services.GetRequiredService<GhCliService>();
                 var processManager = services.GetRequiredService<ProcessManager>();
                 var config = stateStore.LoadConfig();
 
@@ -461,6 +472,13 @@ public static class SessionCommand
                 var trackedProcess = default(TrackedProcessRef);
                 string? terminalStatus = null;
                 string? errorMessage = null;
+
+                // Reaction state captured inside lock, API calls made outside
+                string? reactionRepo = null;
+                int reactionIssueNumber = 0;
+                long? oldReactionId = null;
+                string? reactionSessionId = null;
+                string? reactionRuleName = null;
 
                 stateStore.WithStateLock(() =>
                 {
@@ -483,6 +501,13 @@ public static class SessionCommand
                     session.CompletedBySession = true;
                     ClearTrackedProcess(session);
                     session.UpdatedAt = DateTimeOffset.UtcNow;
+
+                    reactionRepo = session.Repo;
+                    reactionIssueNumber = session.IssueNumber;
+                    oldReactionId = session.IssueReactionId;
+                    reactionSessionId = session.CopilotSessionId;
+                    reactionRuleName = session.RuleName;
+
                     stateStore.SaveState(state);
                 }, ct);
 
@@ -500,6 +525,12 @@ public static class SessionCommand
 
                 ConsoleOutput.Success($"Session for {issueKey} marked as completed.");
                 ScheduleSessionShutdown(processManager, trackedProcess, config);
+
+                // Best-effort reaction transition: 🚀 → 👍
+                TransitionReactionBestEffort(stateStore, ghCli, config, issueKey, reactionSessionId!,
+                    reactionRepo!, reactionIssueNumber, reactionRuleName!, oldReactionId,
+                    GhCliService.ReactionThumbsUp, ct);
+
                 return 0;
             }, logger);
         });
@@ -525,6 +556,7 @@ public static class SessionCommand
             return await ConsoleOutput.RunWithErrorHandling(async () =>
             {
                 var stateStore = services.GetRequiredService<StateStore>();
+                var ghCli = services.GetRequiredService<GhCliService>();
                 var processManager = services.GetRequiredService<ProcessManager>();
                 var config = stateStore.LoadConfig();
 
@@ -539,6 +571,13 @@ public static class SessionCommand
 
                 var trackedProcess = default(TrackedProcessRef);
                 string? errorMessage = null;
+
+                // Reaction state captured inside lock, API calls made outside
+                string? reactionRepo = null;
+                int reactionIssueNumber = 0;
+                long? oldReactionId = null;
+                string? reactionSessionId = null;
+                string? reactionRuleName = null;
 
                 stateStore.WithStateLock(() =>
                 {
@@ -562,6 +601,13 @@ public static class SessionCommand
                     session.WaitingSince = DateTimeOffset.UtcNow;
                     ClearTrackedProcess(session);
                     session.UpdatedAt = DateTimeOffset.UtcNow;
+
+                    reactionRepo = session.Repo;
+                    reactionIssueNumber = session.IssueNumber;
+                    oldReactionId = session.IssueReactionId;
+                    reactionSessionId = session.CopilotSessionId;
+                    reactionRuleName = session.RuleName;
+
                     stateStore.SaveState(state);
                 }, ct);
 
@@ -573,6 +619,12 @@ public static class SessionCommand
 
                 ConsoleOutput.Success($"PR #{prNumber} associated with session for {issueKey}. Session is now waiting for review feedback.");
                 ScheduleSessionShutdown(processManager, trackedProcess, config);
+
+                // Best-effort reaction transition: 🚀 → 👀 (waiting for review)
+                TransitionReactionBestEffort(stateStore, ghCli, config, issueKey, reactionSessionId!,
+                    reactionRepo!, reactionIssueNumber, reactionRuleName!, oldReactionId,
+                    GhCliService.ReactionEyes, ct);
+
                 return 0;
             }, logger);
         });
@@ -595,6 +647,7 @@ public static class SessionCommand
             return await ConsoleOutput.RunWithErrorHandling(async () =>
             {
                 var stateStore = services.GetRequiredService<StateStore>();
+                var ghCli = services.GetRequiredService<GhCliService>();
                 var processManager = services.GetRequiredService<ProcessManager>();
                 var config = stateStore.LoadConfig();
 
@@ -602,6 +655,12 @@ public static class SessionCommand
                 var pending = false;
                 string? errorMessage = null;
                 string? newSessionId = null;
+
+                // Reaction state captured inside lock, API calls made outside
+                string? reactionRepo = null;
+                int reactionIssueNumber = 0;
+                long? oldReactionId = null;
+                string? reactionRuleName = null;
 
                 stateStore.WithStateLock(() =>
                 {
@@ -619,6 +678,11 @@ public static class SessionCommand
                         return;
                     }
 
+                    reactionRepo = session.Repo;
+                    reactionIssueNumber = session.IssueNumber;
+                    oldReactionId = session.IssueReactionId;
+                    reactionRuleName = session.RuleName;
+
                     processManager.TerminateProcess(session.IssueKey, session.ProcessId, session.ProcessStartTime);
                     processManager.CleanupWorktree(session, config, state);
 
@@ -633,6 +697,7 @@ public static class SessionCommand
                     session.LastRedispatchWasIssueComment = false;
                     session.LastFailureAt = null;
                     session.WaitingSince = null;
+                    session.IssueReactionId = null;
                     session.UpdatedAt = DateTimeOffset.UtcNow;
                     newSessionId = session.CopilotSessionId;
                     stateStore.SaveState(state);
@@ -651,6 +716,12 @@ public static class SessionCommand
                 }
 
                 ConsoleOutput.Success($"Session for {issueKey} reset to pending (new session {newSessionId}).");
+
+                // Best-effort: transition to 👀 (queued) for the reset session
+                TransitionReactionBestEffort(stateStore, ghCli, config, issueKey, newSessionId!,
+                    reactionRepo!, reactionIssueNumber, reactionRuleName!, oldReactionId,
+                    GhCliService.ReactionEyes, ct);
+
                 return 0;
             }, logger);
         });
@@ -977,5 +1048,48 @@ public static class SessionCommand
     private readonly record struct TrackedProcessRef(string Label, int? ProcessId, DateTimeOffset? ProcessStartTime)
     {
         public bool HasProcess => ProcessId is not null;
+    }
+
+    /// <summary>
+    /// Checks whether reactions are enabled for a session based on rule + global config.
+    /// </summary>
+    private static bool AreReactionsEnabled(CopilotdConfig config, string ruleName)
+    {
+        if (config.Rules.TryGetValue(ruleName, out var rule) && rule.EnableReactions.HasValue)
+            return rule.EnableReactions.Value;
+        return config.EnableReactions;
+    }
+
+    /// <summary>
+    /// Best-effort reaction transition for use in session commands. Removes the old reaction,
+    /// adds the new one, and updates <see cref="DispatchSession.IssueReactionId"/> in a
+    /// second state lock with identity verification. Failures are logged but do not
+    /// affect the command's return code.
+    /// </summary>
+    private static void TransitionReactionBestEffort(
+        StateStore stateStore, GhCliService ghCli, CopilotdConfig config,
+        string issueKey, string sessionId, string repo, int issueNumber,
+        string ruleName, long? oldReactionId, string? newContent, CancellationToken ct)
+    {
+        if (!AreReactionsEnabled(config, ruleName))
+            return;
+
+        if (oldReactionId.HasValue)
+            ghCli.RemoveIssueReaction(repo, issueNumber, oldReactionId.Value);
+
+        long? newId = null;
+        if (newContent is not null)
+            newId = ghCli.AddIssueReaction(repo, issueNumber, newContent);
+
+        // Persist the new reaction ID with identity check to avoid clobbering a reset session
+        stateStore.WithStateLock(() =>
+        {
+            var state = stateStore.LoadState();
+            if (state.Sessions.TryGetValue(issueKey, out var s) && s.CopilotSessionId == sessionId)
+            {
+                s.IssueReactionId = newId;
+                stateStore.SaveState(state);
+            }
+        }, ct);
     }
 }

--- a/src/copilotd/Models/CopilotdConfig.cs
+++ b/src/copilotd/Models/CopilotdConfig.cs
@@ -70,6 +70,13 @@ public sealed class CopilotdConfig
     public bool EnableControlSession { get; set; } = true;
 
     /// <summary>
+    /// Whether to post emoji reactions on issues to indicate session lifecycle status
+    /// (👀 queued, 🚀 working, 👍 completed, 👎 failed). Default is true.
+    /// Can be overridden per-rule via <see cref="DispatchRule.EnableReactions"/>.
+    /// </summary>
+    public bool EnableReactions { get; set; } = true;
+
+    /// <summary>
     /// Named dispatch rules. Key is the rule name.
     /// </summary>
     public Dictionary<string, DispatchRule> Rules { get; set; } = new(StringComparer.OrdinalIgnoreCase);
@@ -244,6 +251,12 @@ public sealed class DispatchRule
     /// <see cref="PromptMode.Override"/>: rule prompt replaces the global custom prompt entirely.
     /// </summary>
     public PromptMode CustomPromptMode { get; set; } = PromptMode.Append;
+
+    /// <summary>
+    /// Per-rule override for emoji reactions on issues. When null (default), falls back
+    /// to the global <see cref="CopilotdConfig.EnableReactions"/> setting.
+    /// </summary>
+    public bool? EnableReactions { get; set; }
 
     /// <summary>
     /// Returns true if the given issue matches all conditions on this rule.

--- a/src/copilotd/Models/SessionState.cs
+++ b/src/copilotd/Models/SessionState.cs
@@ -172,6 +172,13 @@ public sealed class DispatchSession
     /// </summary>
     public string? BranchName { get; set; }
 
+    /// <summary>
+    /// The GitHub reaction ID currently posted on the issue by copilotd, for lifecycle tracking.
+    /// Used to remove the previous reaction when transitioning to a new state (e.g., 🚀→👍).
+    /// Null when no reaction has been posted or when reactions are disabled.
+    /// </summary>
+    public long? IssueReactionId { get; set; }
+
     /// <summary>Maximum retries before giving up (0 = unlimited).</summary>
     public const int MaxRetries = 3;
 

--- a/src/copilotd/Services/GhCliService.cs
+++ b/src/copilotd/Services/GhCliService.cs
@@ -578,6 +578,56 @@ public sealed class GhCliService
         return new NewCommentInfo(author, createdAt);
     }
 
+    // Reaction content constants for GitHub issue reactions
+    internal const string ReactionEyes = "eyes";
+    internal const string ReactionRocket = "rocket";
+    internal const string ReactionThumbsUp = "+1";
+    internal const string ReactionThumbsDown = "-1";
+
+    /// <summary>
+    /// Adds a reaction emoji to a GitHub issue. Returns the reaction ID for later removal,
+    /// or null on failure. Best-effort: failures are logged but do not block session lifecycle.
+    /// </summary>
+    public long? AddIssueReaction(string repo, int issueNumber, string content)
+    {
+        var args = $"api repos/{repo}/issues/{issueNumber}/reactions -f content={content}";
+        var (exitCode, output) = RunGh(args);
+        if (exitCode != 0)
+        {
+            _logger.LogWarning("Failed to add {Reaction} reaction on {Repo}#{Issue}: {Output}", content, repo, issueNumber, output);
+            return null;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(output);
+            if (doc.RootElement.TryGetProperty("id", out var idEl))
+                return idEl.GetInt64();
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse reaction response for {Repo}#{Issue}", repo, issueNumber);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Removes a reaction from a GitHub issue by reaction ID. Returns true on success.
+    /// Best-effort: failures are logged but do not block session lifecycle.
+    /// </summary>
+    public bool RemoveIssueReaction(string repo, int issueNumber, long reactionId)
+    {
+        var args = $"api repos/{repo}/issues/{issueNumber}/reactions/{reactionId} -X DELETE";
+        var (exitCode, _) = RunGh(args);
+        if (exitCode != 0)
+        {
+            _logger.LogWarning("Failed to remove reaction {Id} from {Repo}#{Issue}", reactionId, repo, issueNumber);
+            return false;
+        }
+        return true;
+    }
+
     private static readonly TimeSpan GhTimeout = TimeSpan.FromSeconds(30);
 
     private (int ExitCode, string Output) RunGh(string arguments)

--- a/src/copilotd/Services/ReconciliationEngine.cs
+++ b/src/copilotd/Services/ReconciliationEngine.cs
@@ -273,6 +273,7 @@ public sealed class ReconciliationEngine
                     session.FailureDetail = null;
                     session.WaitingSince = null;
                     session.UpdatedAt = DateTimeOffset.UtcNow;
+                    TransitionReaction(session, config, null);
                     _processManager.CleanupWorktree(session, config, state);
                     continue;
                 }
@@ -285,6 +286,7 @@ public sealed class ReconciliationEngine
                     session.FailureDetail = null;
                     session.WaitingSince = null;
                     session.UpdatedAt = DateTimeOffset.UtcNow;
+                    TransitionReaction(session, config, null);
                     _processManager.CleanupWorktree(session, config, state);
                     continue;
                 }
@@ -307,6 +309,7 @@ public sealed class ReconciliationEngine
                 session.Status = SessionStatus.Completed;
                 session.FailureDetail = null;
                 session.UpdatedAt = DateTimeOffset.UtcNow;
+                TransitionReaction(session, config, null);
                 _processManager.CleanupWorktree(session, config, state);
             }
         }
@@ -379,6 +382,7 @@ public sealed class ReconciliationEngine
                                 existing.ProcessId = null;
                                 existing.ProcessStartTime = null;
                                 existing.UpdatedAt = DateTimeOffset.UtcNow;
+                                // 👀 stays — it was set when entering WaitingForFeedback
                             }
                             else
                             {
@@ -403,6 +407,7 @@ public sealed class ReconciliationEngine
                                 existing.ProcessId = null;
                                 existing.ProcessStartTime = null;
                                 existing.UpdatedAt = DateTimeOffset.UtcNow;
+                                TransitionReaction(existing, config, GhCliService.ReactionThumbsUp);
                                 _processManager.CleanupWorktree(existing, config, state);
                                 continue;
                             }
@@ -526,6 +531,7 @@ public sealed class ReconciliationEngine
                         existing.ProcessStartTime = null;
                         existing.UpdatedAt = DateTimeOffset.UtcNow;
                         existing.LastFailureAt = DateTimeOffset.UtcNow;
+                        TransitionReaction(existing, config, GhCliService.ReactionEyes);
                         continue;
 
                     case SessionStatus.Orphaned:
@@ -537,6 +543,7 @@ public sealed class ReconciliationEngine
                             existing.FailureDetail ??= $"The session exceeded the maximum retry count ({DispatchSession.MaxRetries}). " +
                                 $"Resolve the underlying issue, then run 'copilotd session reset {issueKey}'.";
                             existing.UpdatedAt = DateTimeOffset.UtcNow;
+                            TransitionReaction(existing, config, GhCliService.ReactionThumbsDown);
                             continue;
                         }
                         continue;
@@ -560,6 +567,7 @@ public sealed class ReconciliationEngine
                         existing.ProcessId = null;
                         existing.ProcessStartTime = null;
                         existing.UpdatedAt = DateTimeOffset.UtcNow;
+                        TransitionReaction(existing, config, GhCliService.ReactionEyes);
                         continue;
                 }
             }
@@ -581,6 +589,7 @@ public sealed class ReconciliationEngine
                 state.Sessions[issueKey] = newSession;
 
                 _logger.LogInformation("New issue {Key} matched by rule '{Rule}', creating pending dispatch", issueKey, ruleName);
+                TransitionReaction(newSession, config, GhCliService.ReactionEyes);
             }
         }
     }
@@ -626,6 +635,7 @@ public sealed class ReconciliationEngine
                         _logger.LogWarning("Copilot folder trust missing for {Key}: {Folders}",
                             session.IssueKey, string.Join(", ", trustCheck.MissingFolders));
                         MarkSessionFailed(session, BuildTrustFailureDetail(session, trustCheck));
+                        TransitionReaction(session, config, GhCliService.ReactionThumbsDown);
                         _stateStore.SaveState(state);
                         continue;
 
@@ -644,6 +654,7 @@ public sealed class ReconciliationEngine
                 _logger.LogWarning("Failed to prepare worktree for {Key}", session.IssueKey);
                 MarkSessionFailed(session,
                     $"Failed to prepare the git worktree for dispatch. Verify the local clone for {session.Repo} is healthy, then run 'copilotd session reset {session.IssueKey}'.");
+                TransitionReaction(session, config, GhCliService.ReactionThumbsDown);
                 _stateStore.SaveState(state);
                 continue;
             }
@@ -661,10 +672,15 @@ public sealed class ReconciliationEngine
                 _logger.LogWarning("Failed to launch copilot for {Key}", session.IssueKey);
                 MarkSessionFailed(session,
                     $"Failed to launch the Copilot CLI process. Review the copilotd logs, then run 'copilotd session reset {session.IssueKey}'.");
+                TransitionReaction(session, config, GhCliService.ReactionThumbsDown);
                 // Clean up the worktree we just created
                 _processManager.CleanupWorktree(session, config, state);
             }
-            // else: session was updated in-place by LaunchCopilot
+            else
+            {
+                // Session launched successfully — indicate active work
+                TransitionReaction(session, config, GhCliService.ReactionRocket);
+            }
 
             // Save state after each launch to prevent ghost processes on crash
             _stateStore.SaveState(state);
@@ -770,5 +786,37 @@ public sealed class ReconciliationEngine
         var backoffMinutes = Math.Min(Math.Pow(2, session.RetryCount), 30);
         var backoff = TimeSpan.FromMinutes(backoffMinutes);
         return DateTimeOffset.UtcNow - session.LastFailureAt.Value < backoff;
+    }
+
+    /// <summary>
+    /// Checks whether reactions are enabled for a session based on rule + global config.
+    /// </summary>
+    private static bool AreReactionsEnabled(CopilotdConfig config, string ruleName)
+    {
+        if (config.Rules.TryGetValue(ruleName, out var rule) && rule.EnableReactions.HasValue)
+            return rule.EnableReactions.Value;
+        return config.EnableReactions;
+    }
+
+    /// <summary>
+    /// Transitions the reaction on a session's issue. Removes the existing reaction (if any),
+    /// then adds a new one (if specified). Updates <see cref="DispatchSession.IssueReactionId"/>.
+    /// Best-effort: failures are logged but do not block session lifecycle.
+    /// </summary>
+    private void TransitionReaction(DispatchSession session, CopilotdConfig config, string? newContent)
+    {
+        if (!AreReactionsEnabled(config, session.RuleName))
+            return;
+
+        if (session.IssueReactionId.HasValue)
+        {
+            _ghCli.RemoveIssueReaction(session.Repo, session.IssueNumber, session.IssueReactionId.Value);
+            session.IssueReactionId = null;
+        }
+
+        if (newContent is not null)
+        {
+            session.IssueReactionId = _ghCli.AddIssueReaction(session.Repo, session.IssueNumber, newContent);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds emoji reactions on GitHub issues to indicate copilotd session lifecycle status, similar to CCA.

### Reaction lifecycle

| State | Reaction | Meaning |
|---|---|---|
| Pending | 👀 | Session queued, waiting for dispatch slot |
| Running | 🚀 | Session actively working |
| WaitingForFeedback / WaitingForReview | 👀 | Session paused, monitoring for new comments |
| Completed | 👍 | Session completed successfully |
| Failed | 👎 | Session failed |
| Issue no longer matches | *(removed)* | Session terminated |

### Configuration

- **Global toggle**: `enableReactions` in config.json (default: `true`)
- **Per-rule override**: `enableReactions` on dispatch rules (nullable, falls back to global)

### Implementation details

- New `AddIssueReaction`/`RemoveIssueReaction` methods on `GhCliService` using `gh api`
- `IssueReactionId` tracked on `DispatchSession` for cleanup on state transitions
- All reaction API calls are best-effort — failures are logged but never block session lifecycle
- Session commands (`complete`, `comment`, `pr`, `reset`) use the two-lock pattern with identity checks to avoid clobbering reactions on concurrently-reset sessions

### Scope

This PR implements **issue-level reactions** only. Comment-level reactions (acknowledging specific issue/PR comments that trigger re-dispatch) require changes to `NewCommentInfo` to include comment IDs and are tracked as a follow-up.

Closes #160
