### PR TITLE
Push session branch and link to issue on dispatch

### DIFF
--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -939,19 +939,22 @@ public sealed partial class ProcessManager
     /// Creates a git worktree for the session on a new branch from the latest default branch.
     /// Layout: &lt;repo_home&gt;/org/repo_sessions/issue-N/
     /// If the session already has a worktree (e.g., re-dispatching for PR review), refreshes it instead.
+    /// Returns <see cref="WorktreeResult.CreatedNew"/> for new worktrees,
+    /// <see cref="WorktreeResult.Refreshed"/> for existing ones, or
+    /// <see cref="WorktreeResult.Failed"/> on error.
     /// </summary>
-    public bool PrepareWorktree(DispatchSession session, CopilotdConfig config, DaemonState state)
+    public WorktreeResult PrepareWorktree(DispatchSession session, CopilotdConfig config, DaemonState state)
     {
         // If the session already has a worktree (PR review re-dispatch), refresh it
         if (!string.IsNullOrEmpty(session.WorktreePath) && Directory.Exists(session.WorktreePath))
         {
-            return RefreshWorktree(session);
+            return RefreshWorktree(session) ? WorktreeResult.Refreshed : WorktreeResult.Failed;
         }
         var mainRepoPath = _repoResolver.ResolveRepoPath(session.Repo, config, state);
         if (mainRepoPath is null || !Directory.Exists(mainRepoPath))
         {
             _logger.LogWarning("Main repo directory not found for {Repo}", session.Repo);
-            return false;
+            return WorktreeResult.Failed;
         }
 
         // Session dir: <repo_home>/org/repo_sessions/issue-N/
@@ -988,7 +991,7 @@ public sealed partial class ProcessManager
         if (!RunGit(mainRepoPath, "fetch origin"))
         {
             _logger.LogWarning("Failed to fetch origin for {Repo}", session.Repo);
-            return false;
+            return WorktreeResult.Failed;
         }
 
         // Determine default branch (origin/HEAD → origin/main or origin/master)
@@ -996,7 +999,7 @@ public sealed partial class ProcessManager
         if (defaultBranch is null)
         {
             _logger.LogWarning("Could not determine default branch for {Repo}", session.Repo);
-            return false;
+            return WorktreeResult.Failed;
         }
 
         // Generate a unique branch name with random suffix to avoid conflicts
@@ -1015,12 +1018,12 @@ public sealed partial class ProcessManager
         if (!RunGit(mainRepoPath, $"worktree add \"{worktreePath}\" -b {branchName} {defaultBranch}"))
         {
             _logger.LogWarning("Failed to create worktree for {Key}", session.IssueKey);
-            return false;
+            return WorktreeResult.Failed;
         }
 
         session.WorktreePath = worktreePath;
         _logger.LogInformation("Worktree ready for {Key} at {Path}", session.IssueKey, worktreePath);
-        return true;
+        return WorktreeResult.CreatedNew;
     }
 
     /// <summary>
@@ -1176,10 +1179,113 @@ public sealed partial class ProcessManager
         }
     }
 
+    private (bool Success, string Output) RunGitWithOutput(string workingDir, string arguments)
+    {
+        try
+        {
+            _logger.LogDebug("Running: git {Arguments} (in {Dir})", arguments, workingDir);
+
+            var psi = new ProcessStartInfo
+            {
+                FileName = "git",
+                Arguments = arguments,
+                WorkingDirectory = workingDir,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+            };
+
+            using var process = Process.Start(psi);
+            if (process is null)
+            {
+                _logger.LogWarning("Failed to start git process for: git {Arguments}", arguments);
+                return (false, "");
+            }
+
+            // Read both streams asynchronously to avoid deadlock when pipe buffers fill
+            var stderrTask = process.StandardError.ReadToEndAsync();
+            var stdoutTask = process.StandardOutput.ReadToEndAsync();
+
+            if (!process.WaitForExit(TimeSpan.FromSeconds(30)))
+            {
+                _logger.LogWarning("git {Arguments} timed out after 30 seconds", arguments);
+                process.Kill();
+                return (false, "git command timed out");
+            }
+
+            var stdout = stdoutTask.GetAwaiter().GetResult();
+            var stderr = stderrTask.GetAwaiter().GetResult();
+
+            if (process.ExitCode != 0)
+            {
+                _logger.LogWarning("git {Arguments} failed (exit {ExitCode}): {StdErr}",
+                    arguments, process.ExitCode, stderr.Trim());
+                return (false, stderr);
+            }
+
+            return (true, stdout);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Exception running: git {Arguments}", arguments);
+            return (false, "");
+        }
+    }
+
     private bool RunGitCheck(string workingDir, string arguments)
     {
         return RunGit(workingDir, arguments);
     }
+
+    /// <summary>
+    /// Pushes the session branch to the remote and sets up upstream tracking.
+    /// Best-effort: failures are logged but do not block session lifecycle.
+    /// </summary>
+    public bool PushBranch(DispatchSession session, CopilotdConfig config, DaemonState state)
+    {
+        if (string.IsNullOrEmpty(session.BranchName))
+        {
+            _logger.LogWarning("Cannot push branch for {Key}: no branch name set", session.IssueKey);
+            return false;
+        }
+
+        // Push from the worktree directory (shares the same git repo as the main checkout)
+        var workDir = session.WorktreePath;
+        if (string.IsNullOrEmpty(workDir) || !Directory.Exists(workDir))
+        {
+            // Fall back to the main repo path
+            workDir = _repoResolver.ResolveRepoPath(session.Repo, config, state);
+            if (workDir is null || !Directory.Exists(workDir))
+            {
+                _logger.LogWarning("Cannot push branch for {Key}: no working directory found", session.IssueKey);
+                return false;
+            }
+        }
+
+        _logger.LogInformation("Pushing branch {Branch} to origin for {Key}", session.BranchName, session.IssueKey);
+        return RunGit(workDir, $"push -u origin {session.BranchName}");
+    }
+
+    /// <summary>
+    /// Gets the HEAD commit SHA from the session's worktree directory.
+    /// Returns null if the worktree is unavailable or the command fails.
+    /// </summary>
+    public string? GetHeadSha(DispatchSession session)
+    {
+        if (string.IsNullOrEmpty(session.WorktreePath) || !Directory.Exists(session.WorktreePath))
+            return null;
+
+        var (success, output) = RunGitWithOutput(session.WorktreePath, "rev-parse HEAD");
+        return success ? output.Trim() : null;
+    }
+}
+
+public enum WorktreeResult
+{
+    Failed,
+    CreatedNew,
+    Refreshed,
 }
 
 public enum ProcessLivenessResult

--- a/src/copilotd/Services/GhCliService.cs
+++ b/src/copilotd/Services/GhCliService.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Copilotd.Models;
 using Microsoft.Extensions.Logging;
 
@@ -610,5 +611,150 @@ public sealed class GhCliService
         var stderr = stderrTask.Result;
         var output = string.IsNullOrEmpty(stdout) ? stderr : stdout;
         return (process.ExitCode, output);
+    }
+
+    private (int ExitCode, string Output) RunGhWithStdin(string arguments, string stdinContent)
+    {
+        _logger.LogDebug("Running: gh {Args} (with stdin)", arguments);
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "gh",
+            Arguments = arguments,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        using var process = Process.Start(psi);
+        if (process is null)
+        {
+            _logger.LogWarning("Failed to start gh process for: gh {Args}", arguments);
+            return (-1, "failed to start process");
+        }
+
+        var stderrTask = process.StandardError.ReadToEndAsync();
+        process.StandardInput.Write(stdinContent);
+        process.StandardInput.Close();
+
+        var stdout = process.StandardOutput.ReadToEnd();
+
+        if (!process.WaitForExit(GhTimeout))
+        {
+            _logger.LogWarning("gh command timed out after {Timeout}s: gh {Args}", GhTimeout.TotalSeconds, arguments);
+            process.Kill();
+            return (-1, "gh command timed out");
+        }
+
+        var stderr = stderrTask.Result;
+        var output = string.IsNullOrEmpty(stdout) ? stderr : stdout;
+        return (process.ExitCode, output);
+    }
+
+    /// <summary>
+    /// Links a branch to a GitHub issue via the Development sidebar using the
+    /// <c>createLinkedBranch</c> GraphQL mutation. Call after pushing the branch
+    /// to the remote so the ref exists on GitHub.
+    /// Best-effort: failures are logged but do not block session lifecycle.
+    /// </summary>
+    public bool LinkBranchToIssue(string repo, int issueNumber, string branchName, string commitSha)
+    {
+        var parts = repo.Split('/');
+        if (parts.Length != 2)
+        {
+            _logger.LogWarning("Cannot link branch: invalid repo format {Repo}", repo);
+            return false;
+        }
+        var owner = parts[0];
+        var repoName = parts[1];
+
+        // Step 1: Get the GitHub node IDs for the issue and repository
+        var idsRequest = new JsonObject
+        {
+            ["query"] = """
+                query($owner: String!, $repo: String!, $number: Int!) {
+                    repository(owner: $owner, name: $repo) {
+                        id
+                        issue(number: $number) { id }
+                    }
+                }
+                """,
+            ["variables"] = new JsonObject
+            {
+                ["owner"] = owner,
+                ["repo"] = repoName,
+                ["number"] = issueNumber,
+            },
+        };
+
+        var (idsExitCode, idsOutput) = RunGhWithStdin("api graphql --input -", idsRequest.ToJsonString());
+        if (idsExitCode != 0)
+        {
+            _logger.LogWarning("Failed to get GitHub node IDs for {Repo}#{Issue}: {Output}", repo, issueNumber, idsOutput);
+            return false;
+        }
+
+        string issueId, repoId;
+        try
+        {
+            using var doc = JsonDocument.Parse(idsOutput);
+            var data = doc.RootElement.GetProperty("data");
+            var repository = data.GetProperty("repository");
+            repoId = repository.GetProperty("id").GetString()!;
+            issueId = repository.GetProperty("issue").GetProperty("id").GetString()!;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse GitHub node IDs for {Repo}#{Issue}", repo, issueNumber);
+            return false;
+        }
+
+        // Step 2: Create the linked branch via GraphQL mutation
+        var mutationRequest = new JsonObject
+        {
+            ["query"] = """
+                mutation($issueId: ID!, $oid: GitObjectID!, $name: String!, $repositoryId: ID!) {
+                    createLinkedBranch(input: {issueId: $issueId, oid: $oid, name: $name, repositoryId: $repositoryId}) {
+                        linkedBranch { id }
+                    }
+                }
+                """,
+            ["variables"] = new JsonObject
+            {
+                ["issueId"] = issueId,
+                ["oid"] = commitSha,
+                ["name"] = $"refs/heads/{branchName}",
+                ["repositoryId"] = repoId,
+            },
+        };
+
+        var (mutExitCode, mutOutput) = RunGhWithStdin("api graphql --input -", mutationRequest.ToJsonString());
+        if (mutExitCode != 0)
+        {
+            _logger.LogWarning("Failed to link branch {Branch} to {Repo}#{Issue}: {Output}",
+                branchName, repo, issueNumber, mutOutput);
+            return false;
+        }
+
+        // Check for GraphQL-level errors in the response
+        try
+        {
+            using var doc = JsonDocument.Parse(mutOutput);
+            if (doc.RootElement.TryGetProperty("errors", out var errors))
+            {
+                _logger.LogWarning("GraphQL errors linking branch {Branch} to {Repo}#{Issue}: {Errors}",
+                    branchName, repo, issueNumber, errors.ToString());
+                return false;
+            }
+        }
+        catch
+        {
+            // Best-effort error check — if parsing fails, assume success
+        }
+
+        _logger.LogInformation("Linked branch {Branch} to {Repo}#{Issue}", branchName, repo, issueNumber);
+        return true;
     }
 }

--- a/src/copilotd/Services/ReconciliationEngine.cs
+++ b/src/copilotd/Services/ReconciliationEngine.cs
@@ -639,13 +639,29 @@ public sealed class ReconciliationEngine
             session.UpdatedAt = DateTimeOffset.UtcNow;
 
             // Create worktree for isolated working directory
-            if (!_processManager.PrepareWorktree(session, config, state))
+            var worktreeResult = _processManager.PrepareWorktree(session, config, state);
+            if (worktreeResult == WorktreeResult.Failed)
             {
                 _logger.LogWarning("Failed to prepare worktree for {Key}", session.IssueKey);
                 MarkSessionFailed(session,
                     $"Failed to prepare the git worktree for dispatch. Verify the local clone for {session.Repo} is healthy, then run 'copilotd session reset {session.IssueKey}'.");
                 _stateStore.SaveState(state);
                 continue;
+            }
+
+            // For newly created worktrees, push the branch and link it to the issue
+            // so it's visible on the GitHub issue UI immediately (best-effort)
+            if (worktreeResult == WorktreeResult.CreatedNew && !string.IsNullOrEmpty(session.BranchName))
+            {
+                // Push the branch to the remote and set up tracking
+                _processManager.PushBranch(session, config, state);
+
+                // Try to link the branch to the issue via GitHub's Development sidebar
+                var sha = _processManager.GetHeadSha(session);
+                if (sha is not null)
+                {
+                    _ghCli.LinkBranchToIssue(session.Repo, session.IssueNumber, session.BranchName, sha);
+                }
             }
 
             // We need the issue data for prompt building


### PR DESCRIPTION
## Summary

Implements Phase 1 of #157: push the session branch to the remote and associate it with the GitHub issue immediately when a session is dispatched.

## Changes

### ProcessManager.cs
- **`PrepareWorktree` return type** changed from `bool` to `WorktreeResult` `enum` (`Failed`/`CreatedNew`/`Refreshed`), enabling callers to reliably distinguish new worktree creation from refresh
- **`PushBranch`**: pushes the session branch to origin and sets upstream tracking
- **`GetHeadSha`**: reads the HEAD commit SHA from the worktree directory
- **`RunGitWithOutput`**: helper that captures stdout (unlike `RunGit` which returns bool)

### GhCliService.cs
- **`LinkBranchToIssue`**: uses `createLinkedBranch` GraphQL mutation to associate the branch with the issue in GitHub's Development sidebar. Two API calls: one to fetch issue + repo node IDs, one to create the linked branch.
- **`RunGhWithStdin`**: reusable helper for running `gh` commands with stdin input (avoids shell quoting issues with GraphQL queries)

### ReconciliationEngine.cs
- After `PrepareWorktree` creates a new worktree, pushes the branch and links it to the issue
- Both operations are best-effort — failures are logged but do not block session launch

## Design decisions
- **Push + link only on new worktrees**: Skipped for re-dispatches (PR review feedback) where the branch is already pushed
- **Best-effort**: These operations enhance visibility but aren't required for the session to function
- **No remote branch cleanup**: Not added to `CleanupWorktree` in this PR since it's called from many paths (reset, failed launch, PR closed, etc.) and could accidentally delete branches with open PRs