### PR TITLE
Add configurable session naming for dispatched Copilot sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Installed copilotd binaries can self-update in the background: the daemon checks
 | `copilotd session pr <pr-number> <issue>` | Associate a PR with a session and wait for review feedback (callable from within a copilot session) |
 | `copilotd session reset <issue>` | Reset a completed/failed session to pending for re-dispatch |
 | `copilotd config` | Display current configuration |
-| `copilotd config --set key=value` | Set a config value (`repo_home`, `default_model`, `custom_prompt`, `max_instances`, `session_shutdown_delay_seconds`) |
+| `copilotd config --set key=value` | Set a config value (`repo_home`, `default_model`, `custom_prompt`, `session_name_format`, `max_instances`, `session_shutdown_delay_seconds`) |
 | `copilotd rules list` | List all dispatch rules (`copilotd rule list` also works) |
 | `copilotd rules add <name>` | Add a new dispatch rule (`copilotd rule create <name>` and `copilotd rule new <name>` also work) |
 | `copilotd rules update <name>` | Update an existing rule (`copilotd rule edit <name>` also works) |
@@ -178,7 +178,7 @@ copilotd rules update "Trusted" --add-author NewUser --delete-author OldUser
 
 ### Prompt templating
 
-The built-in prompt supports token replacement:
+The built-in prompt and `session_name_format` support token replacement:
 
 | Token | Value |
 |-------|-------|
@@ -187,11 +187,19 @@ The built-in prompt supports token replacement:
 | `$(issue.type)` | Issue type (e.g., `bug`) |
 | `$(issue.milestone)` | Milestone title |
 | `$(pr.id)` | Pull request number (available in PR review re-dispatch prompts) |
+| `$(org)` | Repository owner / organization |
+| `$(repo)` | Repository name only |
+| `$(issue_id)` | Issue number |
+| `$(session_id)` | Copilot session ID used with `--resume` |
+| `$(machine_name)` | Local machine name |
+| `$(gh_user)` | Authenticated GitHub username from copilotd config |
 
 Custom prompt text (configured via `custom_prompt` or `~/.copilotd/prompt.md` by default) is appended after
 the built-in prompt with a trailer. Rules can also specify a `custom_prompt` that either appends
 to or overrides the global custom prompt (controlled by `custom_prompt_mode`). Tokens are replaced
-in both the built-in and custom prompt text. Per-rule extra prompts are appended last.
+in both the built-in and custom prompt text. Per-rule extra prompts are appended last. By default,
+`session_name_format` is `(copilotd) $(org)/$(repo)#$(issue_id)`. Session naming is skipped when the
+installed Copilot CLI is older than `1.0.35` or if name generation fails.
 
 ## Session lifecycle
 
@@ -385,6 +393,7 @@ When running from a source checkout via `copilotd.sh`, `copilotd.ps1`, or `copil
 | `repo_home` | — | Root directory where repos are cloned (`<org>/<repo>` sub-folders expected) |
 | `default_model` | *(none)* | Default model passed to copilot via `--model` for all sessions (rule-specific `model` overrides) |
 | `prompt` | *(empty)* | Custom prompt text appended to the built-in prompt |
+| `session_name_format` | `(copilotd) $(org)/$(repo)#$(issue_id)` | Session name template passed to `copilot --name` when the installed Copilot CLI supports it (`1.0.35+`) |
 | `max_instances` | `3` | Maximum concurrent copilot processes; excess sessions queue as Pending |
 | `session_shutdown_delay_seconds` | `15` | Delay before shutting down an orchestrated session after `session comment`, `session pr`, or `session complete` |
 | `max_redispatches` | `10` | Maximum re-dispatches per session via comment/review feedback loops before requiring manual reset |

--- a/src/copilotd/Commands/ConfigCommand.cs
+++ b/src/copilotd/Commands/ConfigCommand.cs
@@ -40,6 +40,7 @@ public static class ConfigCommand
                     table.AddRow("repo_home", Markup.Escape(config.RepoHome ?? "(not set)"));
                     table.AddRow("default_model", Markup.Escape(config.DefaultModel ?? "(not set)"));
                     table.AddRow("custom_prompt", Markup.Escape(string.IsNullOrEmpty(config.Prompt) ? "(not set)" : config.Prompt));
+                    table.AddRow("session_name_format", Markup.Escape(string.IsNullOrWhiteSpace(config.SessionNameFormat) ? "(disabled)" : config.SessionNameFormat));
                     table.AddRow("current_user", Markup.Escape(config.CurrentUser ?? "(not set)"));
                     table.AddRow("max_instances", Markup.Escape(config.MaxInstances.ToString()));
                     table.AddRow("session_shutdown_delay_seconds", Markup.Escape(config.SessionShutdownDelaySeconds.ToString()));
@@ -122,6 +123,13 @@ public static class ConfigCommand
                             : "default_model cleared.");
                         break;
 
+                    case "session_name_format":
+                        cfg.SessionNameFormat = value;
+                        ConsoleOutput.Success(string.IsNullOrWhiteSpace(cfg.SessionNameFormat)
+                            ? "session_name_format cleared; session naming disabled."
+                            : $"session_name_format set to: {cfg.SessionNameFormat}");
+                        break;
+
                     case "max_instances":
                         if (int.TryParse(value, out var maxInst) && maxInst > 0)
                         {
@@ -151,7 +159,7 @@ public static class ConfigCommand
 
                     default:
                         ConsoleOutput.Error($"Unknown config key: {key}");
-                        ConsoleOutput.Info("Valid keys: repo_home, default_model, custom_prompt, max_instances, session_shutdown_delay_seconds");
+                        ConsoleOutput.Info("Valid keys: repo_home, default_model, custom_prompt, session_name_format, max_instances, session_shutdown_delay_seconds");
                         return 1;
                 }
 

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -2,7 +2,9 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Copilotd.Commands;
 using Copilotd.Models;
+using Copilotd.Services;
 using Microsoft.Extensions.Logging;
+using NuGet.Versioning;
 using static Copilotd.Infrastructure.NativeInterop;
 
 namespace Copilotd.Infrastructure;
@@ -17,17 +19,25 @@ public sealed partial class ProcessManager
     private static readonly TimeSpan GracefulTimeout = TimeSpan.FromSeconds(10);
     private static readonly TimeSpan WindowsCopilotChildDiscoveryTimeout = TimeSpan.FromSeconds(3);
     private static readonly TimeSpan WindowsCopilotChildDiscoveryPollInterval = TimeSpan.FromMilliseconds(100);
+    private static readonly NuGetVersion MinimumNamedSessionVersion = new(1, 0, 35);
 
     private readonly StateStore _stateStore;
     private readonly RepoPathResolver _repoResolver;
     private readonly RuntimeContext _runtimeContext;
+    private readonly CopilotCliService _copilotCli;
     private readonly ILogger<ProcessManager> _logger;
 
-    public ProcessManager(StateStore stateStore, RepoPathResolver repoResolver, RuntimeContext runtimeContext, ILogger<ProcessManager> logger)
+    public ProcessManager(
+        StateStore stateStore,
+        RepoPathResolver repoResolver,
+        RuntimeContext runtimeContext,
+        CopilotCliService copilotCli,
+        ILogger<ProcessManager> logger)
     {
         _stateStore = stateStore;
         _repoResolver = repoResolver;
         _runtimeContext = runtimeContext;
+        _copilotCli = copilotCli;
         _logger = logger;
     }
 
@@ -46,10 +56,13 @@ public sealed partial class ProcessManager
         }
 
         var customPrompt = _stateStore.LoadCustomPrompt(config);
-        var prompt = BuildPrompt(customPrompt, issue, session, config, _runtimeContext.GetCopilotdCallbackCommand());
+        var copilotdCommand = _runtimeContext.GetCopilotdCallbackCommand();
+        var prompt = BuildPrompt(customPrompt, issue, session, config, copilotdCommand);
+        var sessionName = TryBuildSessionName(issue, session, config, copilotdCommand);
         var args = BuildArguments(
             session,
             prompt,
+            sessionName,
             config.Rules.GetValueOrDefault(session.RuleName),
             repoPath,
             config.DefaultModel,
@@ -738,15 +751,7 @@ public sealed partial class ProcessManager
         }
 
         // Replace tokens in the entire prompt (default + custom + extra)
-        prompt = prompt
-            .Replace("$(copilotd.command)", copilotdCommand, StringComparison.Ordinal)
-            .Replace("$(issue.repo)", issue.Repo)
-            .Replace("$(issue.id)", issue.Number.ToString())
-            .Replace("$(issue.type)", issue.Type ?? "issue")
-            .Replace("$(issue.milestone)", issue.Milestone ?? "none")
-            .Replace("$(pr.id)", session.PullRequestNumber?.ToString() ?? "");
-
-        return prompt;
+        return ExpandTemplate(prompt, issue, session, copilotdCommand, config.CurrentUser);
     }
 
     /// <summary>
@@ -800,14 +805,107 @@ public sealed partial class ProcessManager
         };
     }
 
-    private static string BuildArguments(DispatchSession session, string prompt, DispatchRule? rule, string repoPath, string? defaultModel, IEnumerable<string> extraAllowedDirectories)
+    private string? TryBuildSessionName(GitHubIssue issue, DispatchSession session, CopilotdConfig config, string copilotdCommand)
+    {
+        if (string.IsNullOrWhiteSpace(config.SessionNameFormat))
+            return null;
+
+        if (!_copilotCli.TryGetSemanticVersion(out var installedVersion, out var versionDisplay))
+        {
+            if (string.IsNullOrWhiteSpace(versionDisplay))
+            {
+                _logger.LogWarning(
+                    "Could not determine the installed copilot CLI version; skipping session name for {IssueKey}",
+                    session.IssueKey);
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "Could not parse copilot CLI version '{VersionDisplay}'; skipping session name for {IssueKey}",
+                    versionDisplay,
+                    session.IssueKey);
+            }
+
+            return null;
+        }
+
+        if (installedVersion < MinimumNamedSessionVersion)
+        {
+            _logger.LogWarning(
+                "copilot CLI {VersionDisplay} is older than {MinimumVersion}; skipping session name for {IssueKey}",
+                versionDisplay,
+                MinimumNamedSessionVersion,
+                session.IssueKey);
+            return null;
+        }
+
+        try
+        {
+            var sessionName = ExpandTemplate(config.SessionNameFormat, issue, session, copilotdCommand, config.CurrentUser).Trim();
+            if (string.IsNullOrWhiteSpace(sessionName))
+            {
+                _logger.LogWarning(
+                    "session_name_format resolved to an empty session name for {IssueKey}; skipping --name",
+                    session.IssueKey);
+                return null;
+            }
+
+            return sessionName;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to build session name for {IssueKey}; continuing without --name", session.IssueKey);
+            return null;
+        }
+    }
+
+    private static string ExpandTemplate(string template, GitHubIssue issue, DispatchSession session, string copilotdCommand, string? ghUser)
+    {
+        var (org, repo) = SplitRepoSlug(issue.Repo);
+
+        return template
+            .Replace("$(copilotd.command)", copilotdCommand, StringComparison.Ordinal)
+            .Replace("$(issue.repo)", issue.Repo, StringComparison.Ordinal)
+            .Replace("$(issue.id)", issue.Number.ToString(), StringComparison.Ordinal)
+            .Replace("$(issue.type)", issue.Type ?? "issue", StringComparison.Ordinal)
+            .Replace("$(issue.milestone)", issue.Milestone ?? "none", StringComparison.Ordinal)
+            .Replace("$(pr.id)", session.PullRequestNumber?.ToString() ?? "", StringComparison.Ordinal)
+            .Replace("$(org)", org, StringComparison.Ordinal)
+            .Replace("$(repo)", repo, StringComparison.Ordinal)
+            .Replace("$(issue_id)", issue.Number.ToString(), StringComparison.Ordinal)
+            .Replace("$(session_id)", session.CopilotSessionId, StringComparison.Ordinal)
+            .Replace("$(machine_name)", Environment.MachineName, StringComparison.Ordinal)
+            .Replace("$(gh_user)", ghUser ?? "", StringComparison.Ordinal);
+    }
+
+    private static (string Org, string Repo) SplitRepoSlug(string repoSlug)
+    {
+        if (string.IsNullOrWhiteSpace(repoSlug))
+            return ("", "");
+
+        var separatorIndex = repoSlug.IndexOf('/');
+        if (separatorIndex < 0)
+            return ("", repoSlug);
+
+        return (repoSlug[..separatorIndex], repoSlug[(separatorIndex + 1)..]);
+    }
+
+    private static string BuildArguments(DispatchSession session, string prompt, string? sessionName, DispatchRule? rule, string repoPath, string? defaultModel, IEnumerable<string> extraAllowedDirectories)
     {
         var args = new List<string>
         {
             "--remote",
             $"--resume={session.CopilotSessionId}",
-            "-i", $"\"{EscapeArg(prompt)}\"",
         };
+
+        if (!string.IsNullOrWhiteSpace(sessionName))
+        {
+            args.Add("--name");
+            args.Add($"\"{EscapeArg(sessionName)}\"");
+        }
+
+        args.Add("-i");
+        args.Add($"\"{EscapeArg(prompt)}\"");
 
         // Model: rule-specific overrides global default
         var model = rule?.Model ?? defaultModel;

--- a/src/copilotd/Models/CopilotdConfig.cs
+++ b/src/copilotd/Models/CopilotdConfig.cs
@@ -37,6 +37,13 @@ public sealed class CopilotdConfig
     public string? CurrentUser { get; set; }
 
     /// <summary>
+    /// Format string used for naming dispatched copilot sessions via <c>copilot --name</c>.
+    /// Uses the same <c>$(token)</c> replacement style as prompt templating. Set to an empty
+    /// string to disable naming entirely. Default is <c>(copilotd) $(org)/$(repo)#$(issue_id)</c>.
+    /// </summary>
+    public string SessionNameFormat { get; set; } = DefaultSessionNameFormat;
+
+    /// <summary>
     /// Maximum number of concurrent copilot instances. Sessions beyond this limit
     /// are queued as Pending until a slot opens. Default is 3.
     /// </summary>
@@ -118,6 +125,8 @@ public sealed class CopilotdConfig
         - Run `$(copilotd.command) session comment $(issue.repo)#$(issue.id) --message "Your question or findings here"` to post a comment on the issue.
         - This will pause your session until a response is posted on the issue, at which point your session will automatically resume.
         """;
+
+    public const string DefaultSessionNameFormat = "(copilotd) $(org)/$(repo)#$(issue_id)";
 
     public const string IssueFeedbackPrompt =
         """


### PR DESCRIPTION
## Summary
- add global `session_name_format` config with a default of `(copilotd) $(org)/$(repo)#$(issue_id)`
- reuse shared prompt-style token expansion for prompts and session names
- gate `--name` on Copilot CLI 1.0.35+ and warn instead of failing when naming can't be applied

Closes #161