### PR TITLE
Improve init repository picker

### DIFF
--- a/src/copilotd/Commands/InitCommand.cs
+++ b/src/copilotd/Commands/InitCommand.cs
@@ -698,16 +698,6 @@ public static class InitCommand
     {
         const string prompt = "Search term or owner/repo (empty to go back): ";
         var input = new StringBuilder();
-        bool? originalCursorVisible = null;
-
-        try
-        {
-            originalCursorVisible = Console.CursorVisible;
-            Console.CursorVisible = true;
-        }
-        catch
-        {
-        }
 
         RenderInlinePrompt(prompt, input.ToString());
 
@@ -718,17 +708,7 @@ public static class InitCommand
             {
                 case ConsoleKey.Enter:
                     ClearInlinePrompt();
-                    if (originalCursorVisible.HasValue)
-                    {
-                        try
-                        {
-                            Console.CursorVisible = originalCursorVisible.Value;
-                        }
-                        catch
-                        {
-                        }
-                    }
-                     return input.ToString();
+                    return input.ToString();
 
                 case ConsoleKey.Backspace:
                     if (input.Length > 0)
@@ -738,16 +718,6 @@ public static class InitCommand
                 case ConsoleKey.Escape:
                     input.Clear();
                     ClearInlinePrompt();
-                    if (originalCursorVisible.HasValue)
-                    {
-                        try
-                        {
-                            Console.CursorVisible = originalCursorVisible.Value;
-                        }
-                        catch
-                        {
-                        }
-                    }
                     return "";
 
                 default:

--- a/src/copilotd/Commands/InitCommand.cs
+++ b/src/copilotd/Commands/InitCommand.cs
@@ -252,7 +252,7 @@ public static class InitCommand
                 AnsiConsole.WriteLine();
 
                 ConsoleOutput.Info("Fetching repositories you can watch...");
-                var repos = ghCli.ListAccessibleRepos();
+                var repos = ghCli.ListAccessibleRepos(username);
 
                 if (repos.Count == 0)
                 {
@@ -479,6 +479,7 @@ public static class InitCommand
         var groupPrompt = new MultiSelectionPrompt<AccessibleGitHubRepo>()
             .Title($"Select repositories in {Markup.Escape(menuOption.Label)}:")
             .PageSize(15)
+            .NotRequired()
             .MoreChoicesText("[grey](Move up/down to see more repos)[/]")
             .InstructionsText("[grey](Press space to toggle, enter to save this group and return)[/]")
             .UseConverter(repo => FormatRepoChoice(repo, cloneStatus))
@@ -515,6 +516,7 @@ public static class InitCommand
         var reviewPrompt = new MultiSelectionPrompt<AccessibleGitHubRepo>()
             .Title("Review selected repositories:")
             .PageSize(15)
+            .NotRequired()
             .MoreChoicesText("[grey](Move up/down to see more repos)[/]")
             .InstructionsText("[grey](Press space to remove or restore, enter to return)[/]")
             .UseConverter(repo => FormatRepoChoice(repo, cloneStatus))

--- a/src/copilotd/Commands/InitCommand.cs
+++ b/src/copilotd/Commands/InitCommand.cs
@@ -251,8 +251,37 @@ public static class InitCommand
                 AnsiConsole.Write(new Rule("[bold blue]Repository Selection[/]").LeftJustified());
                 AnsiConsole.WriteLine();
 
-                ConsoleOutput.Info("Fetching repositories you can watch...");
-                var repos = ghCli.ListAccessibleRepos(username);
+                ConsoleOutput.Info("Fetching owned repositories and checking local clones...");
+                var ownedRepos = ghCli.ListOwnedRepos();
+                var clonedRepoSlugs = repoResolver.ListClonedRepoSlugs(config);
+                var ownedRepoSlugs = new HashSet<string>(
+                    ownedRepos.Select(repo => repo.NameWithOwner),
+                    StringComparer.OrdinalIgnoreCase);
+
+                var repos = new List<AccessibleGitHubRepo>(ownedRepos);
+                if (!string.IsNullOrWhiteSpace(username))
+                {
+                    foreach (var repoSlug in clonedRepoSlugs.OrderBy(slug => slug, StringComparer.OrdinalIgnoreCase))
+                    {
+                        if (ownedRepoSlugs.Contains(repoSlug))
+                            continue;
+
+                        if (!ghCli.HasWriteAccess(repoSlug, username))
+                            continue;
+
+                        repos.Add(new AccessibleGitHubRepo
+                        {
+                            NameWithOwner = repoSlug,
+                            AccessKind = GitHubRepoAccessKind.WriteAccess,
+                        });
+                    }
+                }
+
+                MergeExistingRepos(repos, existingRule?.Repos ?? [], username);
+                repos = repos
+                    .DistinctBy(repo => repo.NameWithOwner, StringComparer.OrdinalIgnoreCase)
+                    .OrderBy(repo => repo.NameWithOwner, StringComparer.OrdinalIgnoreCase)
+                    .ToList();
 
                 if (repos.Count == 0)
                 {
@@ -260,22 +289,20 @@ public static class InitCommand
                 }
                 else
                 {
-                    var repoSlugs = repos.Select(repo => repo.NameWithOwner).ToList();
-
-                    // Check which repos are cloned locally under RepoHome (single scan, not per-repo)
-                    var cloneStatus = repoResolver.BuildCloneStatusMap(repoSlugs, config);
+                    var cloneStatus = BuildCloneStatusMap(repos, clonedRepoSlugs);
 
                     var clonedCount = cloneStatus.Values.Count(v => v);
                     var ownedCount = repos.Count(repo => repo.AccessKind == GitHubRepoAccessKind.Owned);
                     var writeAccessCount = repos.Count - ownedCount;
                     AnsiConsole.MarkupLine(
-                        $"[grey]Found {repos.Count} repos you can watch: {ownedCount} owned and {writeAccessCount} with write access.[/]");
+                        $"[grey]Loaded {repos.Count} repos to start with: {ownedCount} owned and {writeAccessCount} write-access clones or saved selections.[/]");
                     AnsiConsole.MarkupLine(
                         $"[grey]{clonedCount} are cloned under {Markup.Escape(config.RepoHome)} and can dispatch immediately.[/]");
+                    AnsiConsole.MarkupLine("[grey]Additional write-access repos that are not cloned can be loaded on demand from the group picker.[/]");
                     AnsiConsole.MarkupLine("[grey]Use the group picker to edit one slice at a time. Only cloned repos can dispatch — repos are not auto-cloned.[/]");
                     AnsiConsole.WriteLine();
 
-                    var selected = PromptForRepoSelection(repos, cloneStatus, existingRule?.Repos ?? []);
+                    var selected = PromptForRepoSelection(repos, clonedRepoSlugs, existingRule?.Repos ?? [], ghCli, username);
 
                     var notClonedSelected = selected.Where(r => !cloneStatus.GetValueOrDefault(r)).ToList();
                     if (notClonedSelected.Count > 0)
@@ -372,19 +399,54 @@ public static class InitCommand
         return parts.Count > 0 ? string.Join(", ", parts) : "(defaults)";
     }
 
-    private static List<string> PromptForRepoSelection(
-        IReadOnlyList<AccessibleGitHubRepo> repos,
-        IReadOnlyDictionary<string, bool> cloneStatus,
-        IReadOnlyList<string> existingRepos)
+    private static void MergeExistingRepos(
+        List<AccessibleGitHubRepo> repos,
+        IReadOnlyList<string> existingRepos,
+        string? username)
     {
-        var reposBySlug = repos.ToDictionary(repo => repo.NameWithOwner, StringComparer.OrdinalIgnoreCase);
-        var selectedRepos = new HashSet<string>(
-            existingRepos.Where(reposBySlug.ContainsKey),
+        var knownRepos = new HashSet<string>(
+            repos.Select(repo => repo.NameWithOwner),
             StringComparer.OrdinalIgnoreCase);
+
+        foreach (var repoSlug in existingRepos)
+        {
+            if (!knownRepos.Add(repoSlug))
+                continue;
+
+            var owner = repoSlug.Split('/', 2)[0];
+            repos.Add(new AccessibleGitHubRepo
+            {
+                NameWithOwner = repoSlug,
+                AccessKind = !string.IsNullOrWhiteSpace(username)
+                    && string.Equals(owner, username, StringComparison.OrdinalIgnoreCase)
+                    ? GitHubRepoAccessKind.Owned
+                    : GitHubRepoAccessKind.WriteAccess,
+            });
+        }
+    }
+
+    private static Dictionary<string, bool> BuildCloneStatusMap(
+        IReadOnlyList<AccessibleGitHubRepo> repos,
+        IReadOnlySet<string> clonedRepoSlugs)
+        => repos.ToDictionary(
+            repo => repo.NameWithOwner,
+            repo => clonedRepoSlugs.Contains(repo.NameWithOwner),
+            StringComparer.OrdinalIgnoreCase);
+
+    private static List<string> PromptForRepoSelection(
+        List<AccessibleGitHubRepo> repos,
+        HashSet<string> clonedRepoSlugs,
+        IReadOnlyList<string> existingRepos,
+        GhCliService ghCli,
+        string? username)
+    {
+        var selectedRepos = new HashSet<string>(existingRepos, StringComparer.OrdinalIgnoreCase);
+        var additionalWriteAccessReposLoaded = false;
 
         while (true)
         {
-            var menuOptions = BuildRepoSelectionMenuOptions(repos, cloneStatus, selectedRepos);
+            var cloneStatus = BuildCloneStatusMap(repos, clonedRepoSlugs);
+            var menuOptions = BuildRepoSelectionMenuOptions(repos, cloneStatus, selectedRepos, additionalWriteAccessReposLoaded);
 
             var selectedMenuOption = AnsiConsole.Prompt(
                 new SelectionPrompt<RepoSelectionMenuOption>()
@@ -400,6 +462,25 @@ public static class InitCommand
             {
                 case RepoSelectionMenuAction.EditGroup:
                     EditRepoSelectionGroup(selectedMenuOption, repos, cloneStatus, selectedRepos);
+                    AnsiConsole.MarkupLine($"[grey]{selectedRepos.Count} repo(s) selected so far.[/]");
+                    AnsiConsole.WriteLine();
+                    break;
+
+                case RepoSelectionMenuAction.LoadAdditionalWriteAccess:
+                    additionalWriteAccessReposLoaded = true;
+                    LoadAdditionalWriteAccessRepos(repos, ghCli, username);
+                    cloneStatus = BuildCloneStatusMap(repos, clonedRepoSlugs);
+                    EditRepoSelectionGroup(
+                        new RepoSelectionMenuOption
+                        {
+                            Action = RepoSelectionMenuAction.EditGroup,
+                            AccessKind = GitHubRepoAccessKind.WriteAccess,
+                            IsCloned = false,
+                            Label = "Write access (not cloned)",
+                        },
+                        repos,
+                        cloneStatus,
+                        selectedRepos);
                     AnsiConsole.MarkupLine($"[grey]{selectedRepos.Count} repo(s) selected so far.[/]");
                     AnsiConsole.WriteLine();
                     break;
@@ -420,12 +501,31 @@ public static class InitCommand
     private static List<RepoSelectionMenuOption> BuildRepoSelectionMenuOptions(
         IReadOnlyList<AccessibleGitHubRepo> repos,
         IReadOnlyDictionary<string, bool> cloneStatus,
-        IReadOnlySet<string> selectedRepos)
+        IReadOnlySet<string> selectedRepos,
+        bool additionalWriteAccessReposLoaded)
     {
         List<RepoSelectionMenuOption> options = [];
 
         foreach (var (accessKind, isCloned, label) in RepoSelectionGroups)
         {
+            if (accessKind == GitHubRepoAccessKind.WriteAccess && !isCloned && !additionalWriteAccessReposLoaded)
+            {
+                var knownReposInGroup = repos
+                    .Where(repo => repo.AccessKind == accessKind && cloneStatus.GetValueOrDefault(repo.NameWithOwner) == isCloned)
+                    .ToList();
+                options.Add(new RepoSelectionMenuOption
+                {
+                    Action = RepoSelectionMenuAction.LoadAdditionalWriteAccess,
+                    AccessKind = accessKind,
+                    IsCloned = isCloned,
+                    Label = label,
+                    DisplayText = knownReposInGroup.Count > 0
+                        ? $"{label} — {knownReposInGroup.Count} saved repo(s), load more from GitHub"
+                        : $"{label} — load from GitHub on demand",
+                });
+                continue;
+            }
+
             var reposInGroup = repos
                 .Where(repo => repo.AccessKind == accessKind && cloneStatus.GetValueOrDefault(repo.NameWithOwner) == isCloned)
                 .ToList();
@@ -453,6 +553,37 @@ public static class InitCommand
         });
 
         return options;
+    }
+
+    private static void LoadAdditionalWriteAccessRepos(
+        List<AccessibleGitHubRepo> repos,
+        GhCliService ghCli,
+        string? username)
+    {
+        ConsoleOutput.Info("Fetching additional write-access repositories from GitHub. This can take a while for large org memberships...");
+
+        List<AccessibleGitHubRepo> accessibleRepos = [];
+        AnsiConsole.Status()
+            .Spinner(Spinner.Known.Dots)
+            .Start("Loading write-access repositories...", _ =>
+            {
+                accessibleRepos = ghCli.ListAccessibleRepos(username);
+            });
+
+        var existingRepoSlugs = new HashSet<string>(
+            repos.Select(repo => repo.NameWithOwner),
+            StringComparer.OrdinalIgnoreCase);
+
+        foreach (var repo in accessibleRepos)
+        {
+            if (repo.AccessKind != GitHubRepoAccessKind.WriteAccess)
+                continue;
+
+            if (existingRepoSlugs.Add(repo.NameWithOwner))
+                repos.Add(repo);
+        }
+
+        repos.Sort((left, right) => StringComparer.OrdinalIgnoreCase.Compare(left.NameWithOwner, right.NameWithOwner));
     }
 
     private static void EditRepoSelectionGroup(
@@ -554,6 +685,7 @@ public static class InitCommand
     private enum RepoSelectionMenuAction
     {
         EditGroup,
+        LoadAdditionalWriteAccess,
         ReviewSelected,
         Done,
     }

--- a/src/copilotd/Commands/InitCommand.cs
+++ b/src/copilotd/Commands/InitCommand.cs
@@ -251,8 +251,8 @@ public static class InitCommand
                 AnsiConsole.Write(new Rule("[bold blue]Repository Selection[/]").LeftJustified());
                 AnsiConsole.WriteLine();
 
-                ConsoleOutput.Info("Fetching your repositories...");
-                var repos = ghCli.ListRepos();
+                ConsoleOutput.Info("Fetching repositories you can watch...");
+                var repos = ghCli.ListAccessibleRepos();
 
                 if (repos.Count == 0)
                 {
@@ -260,32 +260,22 @@ public static class InitCommand
                 }
                 else
                 {
+                    var repoSlugs = repos.Select(repo => repo.NameWithOwner).ToList();
+
                     // Check which repos are cloned locally under RepoHome (single scan, not per-repo)
-                    var cloneStatus = repoResolver.BuildCloneStatusMap(repos, config);
+                    var cloneStatus = repoResolver.BuildCloneStatusMap(repoSlugs, config);
 
                     var clonedCount = cloneStatus.Values.Count(v => v);
-                    AnsiConsole.MarkupLine($"[grey]Found {clonedCount} of {repos.Count} repos cloned under {Markup.Escape(config.RepoHome)}[/]");
-                    AnsiConsole.MarkupLine("[grey]Only cloned repos can be dispatched — repos are not auto-cloned.[/]");
+                    var ownedCount = repos.Count(repo => repo.AccessKind == GitHubRepoAccessKind.Owned);
+                    var writeAccessCount = repos.Count - ownedCount;
+                    AnsiConsole.MarkupLine(
+                        $"[grey]Found {repos.Count} repos you can watch: {ownedCount} owned and {writeAccessCount} with write access.[/]");
+                    AnsiConsole.MarkupLine(
+                        $"[grey]{clonedCount} are cloned under {Markup.Escape(config.RepoHome)} and can dispatch immediately.[/]");
+                    AnsiConsole.MarkupLine("[grey]Use the group picker to edit one slice at a time. Only cloned repos can dispatch — repos are not auto-cloned.[/]");
                     AnsiConsole.WriteLine();
 
-                    var repoPrompt = new MultiSelectionPrompt<string>()
-                            .Title("Select repositories to watch ([green]cloned[/] repos will dispatch, [red]not cloned[/] repos will be skipped until cloned):")
-                            .PageSize(15)
-                            .MoreChoicesText("[grey](Move up/down, space to select, enter to confirm)[/]")
-                            .InstructionsText("[grey](Press space to toggle, enter to accept)[/]")
-                            .UseConverter(r => cloneStatus.GetValueOrDefault(r)
-                                ? $"{Markup.Escape(r)} [green](cloned)[/]"
-                                : $"{Markup.Escape(r)} [red](not cloned)[/]")
-                            .AddChoices(repos);
-
-                    // Pre-select previously chosen repos on re-run
-                    if (existingRule?.Repos is { Count: > 0 } existingRepos)
-                    {
-                        foreach (var repo in existingRepos.Where(r => repos.Contains(r, StringComparer.OrdinalIgnoreCase)))
-                            repoPrompt.Select(repo);
-                    }
-
-                    var selected = AnsiConsole.Prompt(repoPrompt);
+                    var selected = PromptForRepoSelection(repos, cloneStatus, existingRule?.Repos ?? []);
 
                     var notClonedSelected = selected.Where(r => !cloneStatus.GetValueOrDefault(r)).ToList();
                     if (notClonedSelected.Count > 0)
@@ -380,5 +370,200 @@ public static class InitCommand
         if (rule.AllowAllTools) parts.Add("--allow-all-tools");
         if (rule.AllowAllUrls) parts.Add("--allow-all-urls");
         return parts.Count > 0 ? string.Join(", ", parts) : "(defaults)";
+    }
+
+    private static List<string> PromptForRepoSelection(
+        IReadOnlyList<AccessibleGitHubRepo> repos,
+        IReadOnlyDictionary<string, bool> cloneStatus,
+        IReadOnlyList<string> existingRepos)
+    {
+        var reposBySlug = repos.ToDictionary(repo => repo.NameWithOwner, StringComparer.OrdinalIgnoreCase);
+        var selectedRepos = new HashSet<string>(
+            existingRepos.Where(reposBySlug.ContainsKey),
+            StringComparer.OrdinalIgnoreCase);
+
+        while (true)
+        {
+            var menuOptions = BuildRepoSelectionMenuOptions(repos, cloneStatus, selectedRepos);
+
+            var selectedMenuOption = AnsiConsole.Prompt(
+                new SelectionPrompt<RepoSelectionMenuOption>()
+                    .Title($"Choose a repository group to edit ({selectedRepos.Count} selected):")
+                    .PageSize(8)
+                    .EnableSearch()
+                    .SearchPlaceholderText("Type to search groups...")
+                    .MoreChoicesText("[grey](Use up/down to navigate, type to search, enter to open)[/]")
+                    .UseConverter(option => option.DisplayText)
+                    .AddChoices(menuOptions));
+
+            switch (selectedMenuOption.Action)
+            {
+                case RepoSelectionMenuAction.EditGroup:
+                    EditRepoSelectionGroup(selectedMenuOption, repos, cloneStatus, selectedRepos);
+                    AnsiConsole.MarkupLine($"[grey]{selectedRepos.Count} repo(s) selected so far.[/]");
+                    AnsiConsole.WriteLine();
+                    break;
+
+                case RepoSelectionMenuAction.ReviewSelected:
+                    ReviewSelectedRepos(repos, cloneStatus, selectedRepos);
+                    AnsiConsole.WriteLine();
+                    break;
+
+                case RepoSelectionMenuAction.Done:
+                    return selectedRepos
+                        .OrderBy(repo => repo, StringComparer.OrdinalIgnoreCase)
+                        .ToList();
+            }
+        }
+    }
+
+    private static List<RepoSelectionMenuOption> BuildRepoSelectionMenuOptions(
+        IReadOnlyList<AccessibleGitHubRepo> repos,
+        IReadOnlyDictionary<string, bool> cloneStatus,
+        IReadOnlySet<string> selectedRepos)
+    {
+        List<RepoSelectionMenuOption> options = [];
+
+        foreach (var (accessKind, isCloned, label) in RepoSelectionGroups)
+        {
+            var reposInGroup = repos
+                .Where(repo => repo.AccessKind == accessKind && cloneStatus.GetValueOrDefault(repo.NameWithOwner) == isCloned)
+                .ToList();
+            var selectedCount = reposInGroup.Count(repo => selectedRepos.Contains(repo.NameWithOwner));
+            options.Add(new RepoSelectionMenuOption
+            {
+                Action = RepoSelectionMenuAction.EditGroup,
+                AccessKind = accessKind,
+                IsCloned = isCloned,
+                Label = label,
+                DisplayText = $"{label} — {reposInGroup.Count} repo(s), {selectedCount} selected",
+            });
+        }
+
+        options.Add(new RepoSelectionMenuOption
+        {
+            Action = RepoSelectionMenuAction.ReviewSelected,
+            DisplayText = $"Review selected repos — {selectedRepos.Count} selected",
+        });
+
+        options.Add(new RepoSelectionMenuOption
+        {
+            Action = RepoSelectionMenuAction.Done,
+            DisplayText = "Done",
+        });
+
+        return options;
+    }
+
+    private static void EditRepoSelectionGroup(
+        RepoSelectionMenuOption menuOption,
+        IReadOnlyList<AccessibleGitHubRepo> repos,
+        IReadOnlyDictionary<string, bool> cloneStatus,
+        HashSet<string> selectedRepos)
+    {
+        if (menuOption.AccessKind is null || menuOption.IsCloned is null || string.IsNullOrWhiteSpace(menuOption.Label))
+            return;
+
+        var groupRepos = repos
+            .Where(repo => repo.AccessKind == menuOption.AccessKind
+                && cloneStatus.GetValueOrDefault(repo.NameWithOwner) == menuOption.IsCloned.Value)
+            .OrderBy(repo => repo.NameWithOwner, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (groupRepos.Count == 0)
+        {
+            ConsoleOutput.Info($"No repositories found in {menuOption.Label}.");
+            return;
+        }
+
+        var groupPrompt = new MultiSelectionPrompt<AccessibleGitHubRepo>()
+            .Title($"Select repositories in {Markup.Escape(menuOption.Label)}:")
+            .PageSize(15)
+            .MoreChoicesText("[grey](Move up/down to see more repos)[/]")
+            .InstructionsText("[grey](Press space to toggle, enter to save this group and return)[/]")
+            .UseConverter(repo => FormatRepoChoice(repo, cloneStatus))
+            .AddChoices(groupRepos);
+
+        foreach (var repo in groupRepos.Where(repo => selectedRepos.Contains(repo.NameWithOwner)))
+            groupPrompt.Select(repo);
+
+        var selectedInGroup = AnsiConsole.Prompt(groupPrompt);
+
+        foreach (var repo in groupRepos)
+            selectedRepos.Remove(repo.NameWithOwner);
+
+        foreach (var repo in selectedInGroup)
+            selectedRepos.Add(repo.NameWithOwner);
+    }
+
+    private static void ReviewSelectedRepos(
+        IReadOnlyList<AccessibleGitHubRepo> repos,
+        IReadOnlyDictionary<string, bool> cloneStatus,
+        HashSet<string> selectedRepos)
+    {
+        var currentSelection = repos
+            .Where(repo => selectedRepos.Contains(repo.NameWithOwner))
+            .OrderBy(repo => repo.NameWithOwner, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (currentSelection.Count == 0)
+        {
+            ConsoleOutput.Warning("No repositories selected yet.");
+            return;
+        }
+
+        var reviewPrompt = new MultiSelectionPrompt<AccessibleGitHubRepo>()
+            .Title("Review selected repositories:")
+            .PageSize(15)
+            .MoreChoicesText("[grey](Move up/down to see more repos)[/]")
+            .InstructionsText("[grey](Press space to remove or restore, enter to return)[/]")
+            .UseConverter(repo => FormatRepoChoice(repo, cloneStatus))
+            .AddChoices(currentSelection);
+
+        foreach (var repo in currentSelection)
+            reviewPrompt.Select(repo);
+
+        var reviewedSelection = AnsiConsole.Prompt(reviewPrompt);
+
+        selectedRepos.Clear();
+        foreach (var repo in reviewedSelection)
+            selectedRepos.Add(repo.NameWithOwner);
+    }
+
+    private static string FormatRepoChoice(AccessibleGitHubRepo repo, IReadOnlyDictionary<string, bool> cloneStatus)
+    {
+        var cloneLabel = cloneStatus.GetValueOrDefault(repo.NameWithOwner)
+            ? "[green](cloned)[/]"
+            : "[red](not cloned)[/]";
+        var accessLabel = repo.AccessKind == GitHubRepoAccessKind.Owned
+            ? "[blue](owned)[/]"
+            : "[yellow](write access)[/]";
+        return $"{Markup.Escape(repo.NameWithOwner)} {cloneLabel} {accessLabel}";
+    }
+
+    private static readonly (GitHubRepoAccessKind AccessKind, bool IsCloned, string Label)[] RepoSelectionGroups =
+    [
+        (GitHubRepoAccessKind.Owned, true, "Owned (cloned)"),
+        (GitHubRepoAccessKind.WriteAccess, true, "Write access (cloned)"),
+        (GitHubRepoAccessKind.Owned, false, "Owned (not cloned)"),
+        (GitHubRepoAccessKind.WriteAccess, false, "Write access (not cloned)"),
+    ];
+
+    private enum RepoSelectionMenuAction
+    {
+        EditGroup,
+        ReviewSelected,
+        Done,
+    }
+
+    private sealed class RepoSelectionMenuOption
+    {
+        public RepoSelectionMenuAction Action { get; init; }
+        public GitHubRepoAccessKind? AccessKind { get; init; }
+        public bool? IsCloned { get; init; }
+        public string? Label { get; init; }
+        public string DisplayText { get; init; } = "";
+
+        public override string ToString() => DisplayText;
     }
 }

--- a/src/copilotd/Commands/InitCommand.cs
+++ b/src/copilotd/Commands/InitCommand.cs
@@ -466,21 +466,14 @@ public static class InitCommand
                     AnsiConsole.WriteLine();
                     break;
 
-                case RepoSelectionMenuAction.LoadAdditionalWriteAccess:
-                    additionalWriteAccessReposLoaded = true;
-                    LoadAdditionalWriteAccessRepos(repos, ghCli, username);
-                    cloneStatus = BuildCloneStatusMap(repos, clonedRepoSlugs);
-                    EditRepoSelectionGroup(
-                        new RepoSelectionMenuOption
-                        {
-                            Action = RepoSelectionMenuAction.EditGroup,
-                            AccessKind = GitHubRepoAccessKind.WriteAccess,
-                            IsCloned = false,
-                            Label = "Write access (not cloned)",
-                        },
+                case RepoSelectionMenuAction.OpenWriteAccessNotCloned:
+                    HandleWriteAccessNotClonedFlow(
                         repos,
-                        cloneStatus,
-                        selectedRepos);
+                        clonedRepoSlugs,
+                        selectedRepos,
+                        ghCli,
+                        username,
+                        ref additionalWriteAccessReposLoaded);
                     AnsiConsole.MarkupLine($"[grey]{selectedRepos.Count} repo(s) selected so far.[/]");
                     AnsiConsole.WriteLine();
                     break;
@@ -508,20 +501,23 @@ public static class InitCommand
 
         foreach (var (accessKind, isCloned, label) in RepoSelectionGroups)
         {
-            if (accessKind == GitHubRepoAccessKind.WriteAccess && !isCloned && !additionalWriteAccessReposLoaded)
+            if (accessKind == GitHubRepoAccessKind.WriteAccess && !isCloned)
             {
-                var knownReposInGroup = repos
+                var loadedReposInGroup = repos
                     .Where(repo => repo.AccessKind == accessKind && cloneStatus.GetValueOrDefault(repo.NameWithOwner) == isCloned)
                     .ToList();
+                var loadedSelectedCount = loadedReposInGroup.Count(repo => selectedRepos.Contains(repo.NameWithOwner));
                 options.Add(new RepoSelectionMenuOption
                 {
-                    Action = RepoSelectionMenuAction.LoadAdditionalWriteAccess,
+                    Action = RepoSelectionMenuAction.OpenWriteAccessNotCloned,
                     AccessKind = accessKind,
                     IsCloned = isCloned,
                     Label = label,
-                    DisplayText = knownReposInGroup.Count > 0
-                        ? $"{label} — {knownReposInGroup.Count} saved repo(s), load more from GitHub"
-                        : $"{label} — load from GitHub on demand",
+                    DisplayText = additionalWriteAccessReposLoaded
+                        ? $"{label} — {loadedReposInGroup.Count} repo(s), {loadedSelectedCount} selected"
+                        : loadedReposInGroup.Count > 0
+                            ? $"{label} — {loadedReposInGroup.Count} loaded, {loadedSelectedCount} selected (search or load all)"
+                            : $"{label} — search GitHub or load all",
                 });
                 continue;
             }
@@ -555,6 +551,165 @@ public static class InitCommand
         return options;
     }
 
+    private static void HandleWriteAccessNotClonedFlow(
+        List<AccessibleGitHubRepo> repos,
+        HashSet<string> clonedRepoSlugs,
+        HashSet<string> selectedRepos,
+        GhCliService ghCli,
+        string? username,
+        ref bool additionalWriteAccessReposLoaded)
+    {
+        while (true)
+        {
+            var cloneStatus = BuildCloneStatusMap(repos, clonedRepoSlugs);
+            var loadedRepos = repos
+                .Where(repo => repo.AccessKind == GitHubRepoAccessKind.WriteAccess && !cloneStatus.GetValueOrDefault(repo.NameWithOwner))
+                .OrderBy(repo => repo.NameWithOwner, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            var selectedCount = loadedRepos.Count(repo => selectedRepos.Contains(repo.NameWithOwner));
+
+            var menuOptions = new List<WriteAccessNotClonedMenuOption>
+            {
+                new()
+                {
+                    Action = WriteAccessNotClonedMenuAction.SearchByTerm,
+                    DisplayText = "Search GitHub by term (recommended)",
+                },
+            };
+
+            if (loadedRepos.Count > 0)
+            {
+                menuOptions.Add(new WriteAccessNotClonedMenuOption
+                {
+                    Action = WriteAccessNotClonedMenuAction.EditLoadedResults,
+                    DisplayText = $"Edit loaded results — {loadedRepos.Count} repo(s), {selectedCount} selected",
+                });
+            }
+
+            if (!additionalWriteAccessReposLoaded)
+            {
+                menuOptions.Add(new WriteAccessNotClonedMenuOption
+                {
+                    Action = WriteAccessNotClonedMenuAction.LoadAll,
+                    DisplayText = "Load all from GitHub (slow)",
+                });
+            }
+
+            menuOptions.Add(new WriteAccessNotClonedMenuOption
+            {
+                Action = WriteAccessNotClonedMenuAction.Back,
+                DisplayText = "Back",
+            });
+
+            var selectedOption = AnsiConsole.Prompt(
+                new SelectionPrompt<WriteAccessNotClonedMenuOption>()
+                    .Title("Choose how to find write-access repos that are not cloned:")
+                    .PageSize(6)
+                    .UseConverter(option => option.DisplayText)
+                    .AddChoices(menuOptions));
+
+            switch (selectedOption.Action)
+            {
+                case WriteAccessNotClonedMenuAction.SearchByTerm:
+                    SearchWriteAccessNotClonedRepos(repos, clonedRepoSlugs, selectedRepos, ghCli, username);
+                    break;
+
+                case WriteAccessNotClonedMenuAction.EditLoadedResults:
+                    EditRepoSelectionGroup(
+                        new RepoSelectionMenuOption
+                        {
+                            Action = RepoSelectionMenuAction.EditGroup,
+                            AccessKind = GitHubRepoAccessKind.WriteAccess,
+                            IsCloned = false,
+                            Label = "Write access (not cloned)",
+                        },
+                        repos,
+                        cloneStatus,
+                        selectedRepos);
+                    break;
+
+                case WriteAccessNotClonedMenuAction.LoadAll:
+                    additionalWriteAccessReposLoaded = true;
+                    LoadAdditionalWriteAccessRepos(repos, ghCli, username);
+                    break;
+
+                case WriteAccessNotClonedMenuAction.Back:
+                    return;
+            }
+        }
+    }
+
+    private static void SearchWriteAccessNotClonedRepos(
+        List<AccessibleGitHubRepo> repos,
+        HashSet<string> clonedRepoSlugs,
+        HashSet<string> selectedRepos,
+        GhCliService ghCli,
+        string? username)
+    {
+        var searchTerm = AnsiConsole.Prompt(
+            new TextPrompt<string>("Search term or owner/repo (empty to go back):")
+                .AllowEmpty());
+        if (string.IsNullOrWhiteSpace(searchTerm))
+            return;
+
+        List<AccessibleGitHubRepo> searchResults = [];
+        AnsiConsole.Status()
+            .Spinner(Spinner.Known.Dots)
+            .Start("Searching GitHub...", _ =>
+            {
+                searchResults = ghCli.SearchAccessibleRepos(searchTerm, username);
+            });
+
+        var matches = searchResults
+            .Where(repo => repo.AccessKind == GitHubRepoAccessKind.WriteAccess && !clonedRepoSlugs.Contains(repo.NameWithOwner))
+            .OrderBy(repo => repo.NameWithOwner, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (matches.Count == 0)
+        {
+            ConsoleOutput.Warning($"No write-access repos found for '{searchTerm}' that are not already cloned.");
+            return;
+        }
+
+        MergeDiscoveredRepos(repos, matches);
+        var matchCloneStatus = BuildCloneStatusMap(matches, clonedRepoSlugs);
+
+        var resultPrompt = new MultiSelectionPrompt<AccessibleGitHubRepo>()
+            .Title($"Search results for {Markup.Escape(searchTerm)}:")
+            .PageSize(15)
+            .NotRequired()
+            .MoreChoicesText("[grey](Move up/down to see more repos)[/]")
+            .InstructionsText("[grey](Press space to toggle, enter to save these results)[/]")
+            .UseConverter(repo => FormatRepoChoice(repo, matchCloneStatus))
+            .AddChoices(matches);
+
+        foreach (var repo in matches.Where(repo => selectedRepos.Contains(repo.NameWithOwner)))
+            resultPrompt.Select(repo);
+
+        var selectedMatches = AnsiConsole.Prompt(resultPrompt);
+
+        foreach (var repo in matches)
+            selectedRepos.Remove(repo.NameWithOwner);
+
+        foreach (var repo in selectedMatches)
+            selectedRepos.Add(repo.NameWithOwner);
+    }
+
+    private static void MergeDiscoveredRepos(List<AccessibleGitHubRepo> repos, IReadOnlyList<AccessibleGitHubRepo> discoveredRepos)
+    {
+        var existingRepoSlugs = new HashSet<string>(
+            repos.Select(repo => repo.NameWithOwner),
+            StringComparer.OrdinalIgnoreCase);
+
+        foreach (var repo in discoveredRepos)
+        {
+            if (existingRepoSlugs.Add(repo.NameWithOwner))
+                repos.Add(repo);
+        }
+
+        repos.Sort((left, right) => StringComparer.OrdinalIgnoreCase.Compare(left.NameWithOwner, right.NameWithOwner));
+    }
+
     private static void LoadAdditionalWriteAccessRepos(
         List<AccessibleGitHubRepo> repos,
         GhCliService ghCli,
@@ -570,20 +725,9 @@ public static class InitCommand
                 accessibleRepos = ghCli.ListAccessibleRepos(username);
             });
 
-        var existingRepoSlugs = new HashSet<string>(
-            repos.Select(repo => repo.NameWithOwner),
-            StringComparer.OrdinalIgnoreCase);
-
-        foreach (var repo in accessibleRepos)
-        {
-            if (repo.AccessKind != GitHubRepoAccessKind.WriteAccess)
-                continue;
-
-            if (existingRepoSlugs.Add(repo.NameWithOwner))
-                repos.Add(repo);
-        }
-
-        repos.Sort((left, right) => StringComparer.OrdinalIgnoreCase.Compare(left.NameWithOwner, right.NameWithOwner));
+        MergeDiscoveredRepos(
+            repos,
+            accessibleRepos.Where(repo => repo.AccessKind == GitHubRepoAccessKind.WriteAccess).ToList());
     }
 
     private static void EditRepoSelectionGroup(
@@ -685,9 +829,17 @@ public static class InitCommand
     private enum RepoSelectionMenuAction
     {
         EditGroup,
-        LoadAdditionalWriteAccess,
+        OpenWriteAccessNotCloned,
         ReviewSelected,
         Done,
+    }
+
+    private enum WriteAccessNotClonedMenuAction
+    {
+        SearchByTerm,
+        EditLoadedResults,
+        LoadAll,
+        Back,
     }
 
     private sealed class RepoSelectionMenuOption
@@ -696,6 +848,14 @@ public static class InitCommand
         public GitHubRepoAccessKind? AccessKind { get; init; }
         public bool? IsCloned { get; init; }
         public string? Label { get; init; }
+        public string DisplayText { get; init; } = "";
+
+        public override string ToString() => DisplayText;
+    }
+
+    private sealed class WriteAccessNotClonedMenuOption
+    {
+        public WriteAccessNotClonedMenuAction Action { get; init; }
         public string DisplayText { get; init; } = "";
 
         public override string ToString() => DisplayText;

--- a/src/copilotd/Commands/InitCommand.cs
+++ b/src/copilotd/Commands/InitCommand.cs
@@ -1,5 +1,6 @@
 using System.CommandLine;
 using System.Reflection;
+using System.Text;
 using Copilotd.Infrastructure;
 using Copilotd.Models;
 using Copilotd.Services;
@@ -646,9 +647,7 @@ public static class InitCommand
         GhCliService ghCli,
         string? username)
     {
-        var searchTerm = AnsiConsole.Prompt(
-            new TextPrompt<string>("Search term or owner/repo (empty to go back):")
-                .AllowEmpty());
+        var searchTerm = PromptInlineSearchTerm();
         if (string.IsNullOrWhiteSpace(searchTerm))
             return;
 
@@ -693,6 +692,104 @@ public static class InitCommand
 
         foreach (var repo in selectedMatches)
             selectedRepos.Add(repo.NameWithOwner);
+    }
+
+    private static string PromptInlineSearchTerm()
+    {
+        const string prompt = "Search term or owner/repo (empty to go back): ";
+        var input = new StringBuilder();
+        bool? originalCursorVisible = null;
+
+        try
+        {
+            originalCursorVisible = Console.CursorVisible;
+            Console.CursorVisible = true;
+        }
+        catch
+        {
+        }
+
+        RenderInlinePrompt(prompt, input.ToString());
+
+        while (true)
+        {
+            var key = Console.ReadKey(intercept: true);
+            switch (key.Key)
+            {
+                case ConsoleKey.Enter:
+                    ClearInlinePrompt();
+                    if (originalCursorVisible.HasValue)
+                    {
+                        try
+                        {
+                            Console.CursorVisible = originalCursorVisible.Value;
+                        }
+                        catch
+                        {
+                        }
+                    }
+                     return input.ToString();
+
+                case ConsoleKey.Backspace:
+                    if (input.Length > 0)
+                        input.Length--;
+                    break;
+
+                case ConsoleKey.Escape:
+                    input.Clear();
+                    ClearInlinePrompt();
+                    if (originalCursorVisible.HasValue)
+                    {
+                        try
+                        {
+                            Console.CursorVisible = originalCursorVisible.Value;
+                        }
+                        catch
+                        {
+                        }
+                    }
+                    return "";
+
+                default:
+                    if (!char.IsControl(key.KeyChar))
+                        input.Append(key.KeyChar);
+                    break;
+            }
+
+            RenderInlinePrompt(prompt, input.ToString());
+        }
+    }
+
+    private static void RenderInlinePrompt(string prompt, string value)
+    {
+        var text = prompt + value;
+        var width = Math.Max(GetConsoleWidth() - 1, text.Length);
+        Console.Write('\r');
+        Console.Write(text);
+        if (width > text.Length)
+            Console.Write(new string(' ', width - text.Length));
+        Console.Write('\r');
+        Console.Write(text);
+    }
+
+    private static void ClearInlinePrompt()
+    {
+        var width = Math.Max(GetConsoleWidth() - 1, 1);
+        Console.Write('\r');
+        Console.Write(new string(' ', width));
+        Console.Write('\r');
+    }
+
+    private static int GetConsoleWidth()
+    {
+        try
+        {
+            return Console.BufferWidth;
+        }
+        catch
+        {
+            return 120;
+        }
     }
 
     private static void MergeDiscoveredRepos(List<AccessibleGitHubRepo> repos, IReadOnlyList<AccessibleGitHubRepo> discoveredRepos)

--- a/src/copilotd/Infrastructure/RepoPathResolver.cs
+++ b/src/copilotd/Infrastructure/RepoPathResolver.cs
@@ -133,6 +133,18 @@ public sealed class RepoPathResolver
     }
 
     /// <summary>
+    /// Scans RepoHome once and returns the normalized slugs for all local git repositories found.
+    /// </summary>
+    public HashSet<string> ListClonedRepoSlugs(CopilotdConfig config)
+    {
+        var repoHome = config.RepoHome;
+        if (string.IsNullOrEmpty(repoHome))
+            return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        return new HashSet<string>(ScanAllRepos(repoHome).Keys, StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
     /// Scans RepoHome up to 2 levels deep and resolves the origin remote for every git repo found.
     /// Returns a dictionary mapping normalized repo slugs to their local paths.
     /// </summary>

--- a/src/copilotd/Services/GhCliService.cs
+++ b/src/copilotd/Services/GhCliService.cs
@@ -6,6 +6,18 @@ using Microsoft.Extensions.Logging;
 
 namespace Copilotd.Services;
 
+public enum GitHubRepoAccessKind
+{
+    Owned,
+    WriteAccess,
+}
+
+public sealed class AccessibleGitHubRepo
+{
+    public string NameWithOwner { get; init; } = "";
+    public GitHubRepoAccessKind AccessKind { get; init; }
+}
+
 /// <summary>
 /// Adapter for the GitHub CLI (gh). Handles dependency checks, auth, repo listing, and issue queries.
 /// </summary>
@@ -98,19 +110,131 @@ public sealed class GhCliService
     }
 
     /// <summary>
-    /// Lists repositories the user has access to.
+    /// Lists repositories the user can watch during init:
+    /// repos they own plus repos where they have write-or-better access.
     /// </summary>
-    public List<string> ListRepos(int limit = 200)
+    public List<AccessibleGitHubRepo> ListAccessibleRepos()
+    {
+        const string query = """
+            query($cursor: String) {
+                viewer {
+                    login
+                    repositories(
+                        first: 100
+                        after: $cursor
+                        affiliations: [OWNER, COLLABORATOR, ORGANIZATION_MEMBER]
+                    ) {
+                        nodes {
+                            nameWithOwner
+                            viewerPermission
+                            owner {
+                                login
+                            }
+                        }
+                        pageInfo {
+                            hasNextPage
+                            endCursor
+                        }
+                    }
+                }
+            }
+            """;
+
+        var repos = new Dictionary<string, AccessibleGitHubRepo>(StringComparer.OrdinalIgnoreCase);
+        string? cursor = null;
+
+        while (true)
+        {
+            var request = new JsonObject
+            {
+                ["query"] = query,
+                ["variables"] = new JsonObject
+                {
+                    ["cursor"] = cursor,
+                },
+            };
+
+            var (exitCode, output) = RunGhWithStdin("api graphql --input -", request.ToJsonString());
+            if (exitCode != 0)
+            {
+                _logger.LogWarning("Failed to list accessible repos via GraphQL: {Output}", output);
+                return ListOwnedReposFallback();
+            }
+
+            try
+            {
+                using var doc = JsonDocument.Parse(output);
+
+                if (doc.RootElement.TryGetProperty("errors", out var errors))
+                {
+                    _logger.LogWarning("GraphQL errors listing accessible repos: {Errors}", errors.ToString());
+                    return ListOwnedReposFallback();
+                }
+
+                var viewer = doc.RootElement.GetProperty("data").GetProperty("viewer");
+                var viewerLogin = viewer.GetProperty("login").GetString();
+                var repositories = viewer.GetProperty("repositories");
+
+                foreach (var node in repositories.GetProperty("nodes").EnumerateArray())
+                {
+                    var nameWithOwner = node.GetProperty("nameWithOwner").GetString();
+                    var ownerLogin = node.GetProperty("owner").GetProperty("login").GetString();
+                    var viewerPermission = node.TryGetProperty("viewerPermission", out var permissionEl)
+                        ? permissionEl.GetString()
+                        : null;
+
+                    if (string.IsNullOrWhiteSpace(nameWithOwner) || string.IsNullOrWhiteSpace(ownerLogin))
+                        continue;
+
+                    var isOwnedByViewer = !string.IsNullOrWhiteSpace(viewerLogin)
+                        && string.Equals(ownerLogin, viewerLogin, StringComparison.OrdinalIgnoreCase);
+
+                    if (!isOwnedByViewer && !HasWriteOrBetter(viewerPermission))
+                        continue;
+
+                    repos[nameWithOwner] = new AccessibleGitHubRepo
+                    {
+                        NameWithOwner = nameWithOwner,
+                        AccessKind = isOwnedByViewer ? GitHubRepoAccessKind.Owned : GitHubRepoAccessKind.WriteAccess,
+                    };
+                }
+
+                var pageInfo = repositories.GetProperty("pageInfo");
+                if (!pageInfo.GetProperty("hasNextPage").GetBoolean())
+                    break;
+
+                cursor = pageInfo.GetProperty("endCursor").GetString();
+                if (string.IsNullOrWhiteSpace(cursor))
+                    break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to parse accessible repo GraphQL response");
+                return ListOwnedReposFallback();
+            }
+        }
+
+        return repos.Values
+            .OrderBy(repo => repo.NameWithOwner, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private List<AccessibleGitHubRepo> ListOwnedReposFallback(int limit = 200)
     {
         var (exitCode, output) = RunGh($"repo list --limit {limit} --json nameWithOwner --jq \".[].nameWithOwner\"");
         if (exitCode != 0)
         {
-            _logger.LogWarning("Failed to list repos: {Output}", output);
+            _logger.LogWarning("Failed to list fallback owned repos: {Output}", output);
             return [];
         }
 
         return output
             .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(nameWithOwner => new AccessibleGitHubRepo
+            {
+                NameWithOwner = nameWithOwner,
+                AccessKind = GitHubRepoAccessKind.Owned,
+            })
             .ToList();
     }
 
@@ -630,6 +754,9 @@ public sealed class GhCliService
     }
 
     private static readonly TimeSpan GhTimeout = TimeSpan.FromSeconds(30);
+
+    private static bool HasWriteOrBetter(string? permission)
+        => permission is "ADMIN" or "MAINTAIN" or "WRITE";
 
     private (int ExitCode, string Output) RunGh(string arguments)
     {

--- a/src/copilotd/Services/GhCliService.cs
+++ b/src/copilotd/Services/GhCliService.cs
@@ -110,8 +110,16 @@ public sealed class GhCliService
     }
 
     /// <summary>
+    /// Lists repositories the user owns.
+    /// </summary>
+    public List<AccessibleGitHubRepo> ListOwnedRepos(int limit = 200)
+        => ListOwnedReposFallback(limit);
+
+    /// <summary>
     /// Lists repositories the user can watch during init:
     /// repos they own plus repos where they have write-or-better access.
+    /// This can be expensive for users who belong to large organizations because
+    /// GitHub's API does not support server-side filtering by write permission.
     /// </summary>
     public List<AccessibleGitHubRepo> ListAccessibleRepos(string? currentUsername = null)
     {

--- a/src/copilotd/Services/GhCliService.cs
+++ b/src/copilotd/Services/GhCliService.cs
@@ -113,105 +113,59 @@ public sealed class GhCliService
     /// Lists repositories the user can watch during init:
     /// repos they own plus repos where they have write-or-better access.
     /// </summary>
-    public List<AccessibleGitHubRepo> ListAccessibleRepos()
+    public List<AccessibleGitHubRepo> ListAccessibleRepos(string? currentUsername = null)
     {
-        const string query = """
-            query($cursor: String) {
-                viewer {
-                    login
-                    repositories(
-                        first: 100
-                        after: $cursor
-                        affiliations: [OWNER, COLLABORATOR, ORGANIZATION_MEMBER]
-                    ) {
-                        nodes {
-                            nameWithOwner
-                            viewerPermission
-                            owner {
-                                login
-                            }
-                        }
-                        pageInfo {
-                            hasNextPage
-                            endCursor
-                        }
-                    }
-                }
-            }
-            """;
-
         var repos = new Dictionary<string, AccessibleGitHubRepo>(StringComparer.OrdinalIgnoreCase);
-        string? cursor = null;
+        currentUsername ??= CheckAuth().Username;
 
-        while (true)
+        var (exitCode, output) = RunGh(
+            "api --paginate --slurp \"user/repos?per_page=100&affiliation=owner,collaborator,organization_member\"");
+        if (exitCode != 0)
         {
-            var request = new JsonObject
+            _logger.LogWarning("Failed to list accessible repos via REST API: {Output}", output);
+            return ListOwnedReposFallback();
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(output);
+            foreach (var page in doc.RootElement.EnumerateArray())
             {
-                ["query"] = query,
-                ["variables"] = new JsonObject
+                foreach (var repo in page.EnumerateArray())
                 {
-                    ["cursor"] = cursor,
-                },
-            };
-
-            var (exitCode, output) = RunGhWithStdin("api graphql --input -", request.ToJsonString());
-            if (exitCode != 0)
-            {
-                _logger.LogWarning("Failed to list accessible repos via GraphQL: {Output}", output);
-                return ListOwnedReposFallback();
-            }
-
-            try
-            {
-                using var doc = JsonDocument.Parse(output);
-
-                if (doc.RootElement.TryGetProperty("errors", out var errors))
-                {
-                    _logger.LogWarning("GraphQL errors listing accessible repos: {Errors}", errors.ToString());
-                    return ListOwnedReposFallback();
-                }
-
-                var viewer = doc.RootElement.GetProperty("data").GetProperty("viewer");
-                var viewerLogin = viewer.GetProperty("login").GetString();
-                var repositories = viewer.GetProperty("repositories");
-
-                foreach (var node in repositories.GetProperty("nodes").EnumerateArray())
-                {
-                    var nameWithOwner = node.GetProperty("nameWithOwner").GetString();
-                    var ownerLogin = node.GetProperty("owner").GetProperty("login").GetString();
-                    var viewerPermission = node.TryGetProperty("viewerPermission", out var permissionEl)
-                        ? permissionEl.GetString()
+                    var fullName = repo.TryGetProperty("full_name", out var fullNameEl)
+                        ? fullNameEl.GetString()
                         : null;
 
-                    if (string.IsNullOrWhiteSpace(nameWithOwner) || string.IsNullOrWhiteSpace(ownerLogin))
+                    if (string.IsNullOrWhiteSpace(fullName))
                         continue;
 
-                    var isOwnedByViewer = !string.IsNullOrWhiteSpace(viewerLogin)
-                        && string.Equals(ownerLogin, viewerLogin, StringComparison.OrdinalIgnoreCase);
+                    var ownerLogin = repo.TryGetProperty("owner", out var ownerEl)
+                        && ownerEl.TryGetProperty("login", out var ownerLoginEl)
+                        ? ownerLoginEl.GetString()
+                        : null;
 
-                    if (!isOwnedByViewer && !HasWriteOrBetter(viewerPermission))
+                    if (string.IsNullOrWhiteSpace(ownerLogin))
                         continue;
 
-                    repos[nameWithOwner] = new AccessibleGitHubRepo
+                    var isOwnedByViewer = !string.IsNullOrWhiteSpace(currentUsername)
+                        && string.Equals(ownerLogin, currentUsername, StringComparison.OrdinalIgnoreCase);
+
+                    if (!isOwnedByViewer && !HasWriteOrBetter(repo))
+                        continue;
+
+                    repos[fullName] = new AccessibleGitHubRepo
                     {
-                        NameWithOwner = nameWithOwner,
+                        NameWithOwner = fullName,
                         AccessKind = isOwnedByViewer ? GitHubRepoAccessKind.Owned : GitHubRepoAccessKind.WriteAccess,
                     };
                 }
-
-                var pageInfo = repositories.GetProperty("pageInfo");
-                if (!pageInfo.GetProperty("hasNextPage").GetBoolean())
-                    break;
-
-                cursor = pageInfo.GetProperty("endCursor").GetString();
-                if (string.IsNullOrWhiteSpace(cursor))
-                    break;
             }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to parse accessible repo GraphQL response");
-                return ListOwnedReposFallback();
-            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse accessible repo REST response");
+            return ListOwnedReposFallback();
         }
 
         return repos.Values
@@ -755,8 +709,20 @@ public sealed class GhCliService
 
     private static readonly TimeSpan GhTimeout = TimeSpan.FromSeconds(30);
 
-    private static bool HasWriteOrBetter(string? permission)
-        => permission is "ADMIN" or "MAINTAIN" or "WRITE";
+    private static bool HasWriteOrBetter(JsonElement repo)
+    {
+        if (!repo.TryGetProperty("permissions", out var permissions) || permissions.ValueKind != JsonValueKind.Object)
+            return false;
+
+        return GetBooleanProperty(permissions, "admin")
+            || GetBooleanProperty(permissions, "maintain")
+            || GetBooleanProperty(permissions, "push");
+    }
+
+    private static bool GetBooleanProperty(JsonElement obj, string propertyName)
+        => obj.TryGetProperty(propertyName, out var property)
+            && property.ValueKind is JsonValueKind.True or JsonValueKind.False
+            && property.GetBoolean();
 
     private (int ExitCode, string Output) RunGh(string arguments)
     {

--- a/src/copilotd/Services/GhCliService.cs
+++ b/src/copilotd/Services/GhCliService.cs
@@ -181,6 +181,103 @@ public sealed class GhCliService
             .ToList();
     }
 
+    /// <summary>
+    /// Searches for repositories the current user can access and returns only owned
+    /// or write-access matches. Intended for narrowing the expensive write-access
+    /// not-cloned picker during init.
+    /// </summary>
+    public List<AccessibleGitHubRepo> SearchAccessibleRepos(string searchTerm, string? currentUsername = null, int limit = 50)
+    {
+        currentUsername ??= CheckAuth().Username;
+        var query = BuildRepositorySearchQuery(searchTerm);
+        var request = new JsonObject
+        {
+            ["query"] = """
+                query($query: String!, $limit: Int!) {
+                    search(type: REPOSITORY, query: $query, first: $limit) {
+                        nodes {
+                            ... on Repository {
+                                nameWithOwner
+                                viewerPermission
+                                owner {
+                                    login
+                                }
+                            }
+                        }
+                    }
+                }
+                """,
+            ["variables"] = new JsonObject
+            {
+                ["query"] = query,
+                ["limit"] = limit,
+            },
+        };
+
+        var (exitCode, output) = RunGhWithStdin("api graphql --input -", request.ToJsonString());
+        if (exitCode != 0)
+        {
+            _logger.LogWarning("Failed to search accessible repos for '{SearchTerm}': {Output}", searchTerm, output);
+            return [];
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(output);
+            if (doc.RootElement.TryGetProperty("errors", out var errors))
+            {
+                _logger.LogWarning("GraphQL errors searching repos for '{SearchTerm}': {Errors}", searchTerm, errors.ToString());
+                return [];
+            }
+
+            if (!doc.RootElement.TryGetProperty("data", out var data)
+                || !data.TryGetProperty("search", out var search)
+                || !search.TryGetProperty("nodes", out var nodes))
+            {
+                return [];
+            }
+
+            var repos = new Dictionary<string, AccessibleGitHubRepo>(StringComparer.OrdinalIgnoreCase);
+            foreach (var node in nodes.EnumerateArray())
+            {
+                var nameWithOwner = node.TryGetProperty("nameWithOwner", out var nameEl)
+                    ? nameEl.GetString()
+                    : null;
+                var ownerLogin = node.TryGetProperty("owner", out var ownerEl)
+                    && ownerEl.TryGetProperty("login", out var ownerLoginEl)
+                    ? ownerLoginEl.GetString()
+                    : null;
+                var viewerPermission = node.TryGetProperty("viewerPermission", out var permissionEl)
+                    ? permissionEl.GetString()
+                    : null;
+
+                if (string.IsNullOrWhiteSpace(nameWithOwner) || string.IsNullOrWhiteSpace(ownerLogin))
+                    continue;
+
+                var isOwnedByViewer = !string.IsNullOrWhiteSpace(currentUsername)
+                    && string.Equals(ownerLogin, currentUsername, StringComparison.OrdinalIgnoreCase);
+
+                if (!isOwnedByViewer && !HasWriteOrBetter(viewerPermission))
+                    continue;
+
+                repos[nameWithOwner] = new AccessibleGitHubRepo
+                {
+                    NameWithOwner = nameWithOwner,
+                    AccessKind = isOwnedByViewer ? GitHubRepoAccessKind.Owned : GitHubRepoAccessKind.WriteAccess,
+                };
+            }
+
+            return repos.Values
+                .OrderBy(repo => repo.NameWithOwner, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse accessible repo search response for '{SearchTerm}'", searchTerm);
+            return [];
+        }
+    }
+
     private List<AccessibleGitHubRepo> ListOwnedReposFallback(int limit = 200)
     {
         var (exitCode, output) = RunGh($"repo list --limit {limit} --json nameWithOwner --jq \".[].nameWithOwner\"");
@@ -731,6 +828,24 @@ public sealed class GhCliService
         => obj.TryGetProperty(propertyName, out var property)
             && property.ValueKind is JsonValueKind.True or JsonValueKind.False
             && property.GetBoolean();
+
+    private static bool HasWriteOrBetter(string? viewerPermission)
+        => viewerPermission is "ADMIN" or "MAINTAIN" or "WRITE";
+
+    private static string BuildRepositorySearchQuery(string searchTerm)
+    {
+        var trimmed = searchTerm.Trim();
+        if (string.IsNullOrWhiteSpace(trimmed))
+            return "";
+
+        if (trimmed.Contains(':', StringComparison.Ordinal))
+            return trimmed;
+
+        if (trimmed.Contains('/', StringComparison.Ordinal) && !trimmed.Contains(' ', StringComparison.Ordinal))
+            return $"repo:{trimmed}";
+
+        return $"{trimmed} in:name";
+    }
 
     private (int ExitCode, string Output) RunGh(string arguments)
     {

--- a/src/copilotd/copilotd.csproj
+++ b/src/copilotd/copilotd.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DefaultItemExcludes>$(DefaultItemExcludes);artifacts\**</DefaultItemExcludes>
     <PublishAot>true</PublishAot>
     <InvariantGlobalization>false</InvariantGlobalization>


### PR DESCRIPTION
## Summary
- include owned and write-access repositories in init by querying GitHub via GraphQL with a safe fallback
- replace the flat repo picker with a grouped selection flow for owned/write-access and cloned/uncloned repos
- add a review step and clearer repo badges/status copy during init

## Validation
- dotnet build .\\src\\copilotd\\copilotd.csproj -nologo
- smoke-ran init with a temp COPILOTD_HOME to verify the grouped repository selection flow renders and loads repo groups

Closes #139