### PR TITLE
Fix copilot CLI --resume/--name conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ the built-in prompt with a trailer. Rules can also specify a `custom_prompt` tha
 to or overrides the global custom prompt (controlled by `custom_prompt_mode`). Tokens are replaced
 in both the built-in and custom prompt text. Per-rule extra prompts are appended last. By default,
 `session_name_format` is `(copilotd) $(org)/$(repo)#$(issue_id)`. Session naming is skipped when the
-installed Copilot CLI is older than `1.0.35` or if name generation fails.
+launch uses `--resume`, when the installed Copilot CLI is older than `1.0.35`, or if name generation fails.
 
 ## Session lifecycle
 
@@ -393,7 +393,7 @@ When running from a source checkout via `copilotd.sh`, `copilotd.ps1`, or `copil
 | `repo_home` | — | Root directory where repos are cloned (`<org>/<repo>` sub-folders expected) |
 | `default_model` | *(none)* | Default model passed to copilot via `--model` for all sessions (rule-specific `model` overrides) |
 | `prompt` | *(empty)* | Custom prompt text appended to the built-in prompt |
-| `session_name_format` | `(copilotd) $(org)/$(repo)#$(issue_id)` | Session name template passed to `copilot --name` when the installed Copilot CLI supports it (`1.0.35+`) |
+| `session_name_format` | `(copilotd) $(org)/$(repo)#$(issue_id)` | Session name template passed to `copilot --name` when the installed Copilot CLI supports it (`1.0.35+`) and the launch does not use `--resume` |
 | `max_instances` | `3` | Maximum concurrent copilot processes; excess sessions queue as Pending |
 | `session_shutdown_delay_seconds` | `15` | Delay before shutting down an orchestrated session after `session comment`, `session pr`, or `session complete` |
 | `max_redispatches` | `10` | Maximum re-dispatches per session via comment/review feedback loops before requiring manual reset |

--- a/README.md
+++ b/README.md
@@ -199,7 +199,9 @@ the built-in prompt with a trailer. Rules can also specify a `custom_prompt` tha
 to or overrides the global custom prompt (controlled by `custom_prompt_mode`). Tokens are replaced
 in both the built-in and custom prompt text. Per-rule extra prompts are appended last. By default,
 `session_name_format` is `(copilotd) $(org)/$(repo)#$(issue_id)`. Session naming is skipped when the
-launch uses `--resume`, when the installed Copilot CLI is older than `1.0.35`, or if name generation fails.
+installed Copilot CLI is older than `1.0.35`, or if name generation fails. New sessions start with
+`copilot --name`, later re-dispatches resume by that exact name via `copilot --resume=<name>`, and
+older persisted sessions that already have a resume ID continue to resume by ID.
 
 ## Session lifecycle
 
@@ -393,7 +395,7 @@ When running from a source checkout via `copilotd.sh`, `copilotd.ps1`, or `copil
 | `repo_home` | — | Root directory where repos are cloned (`<org>/<repo>` sub-folders expected) |
 | `default_model` | *(none)* | Default model passed to copilot via `--model` for all sessions (rule-specific `model` overrides) |
 | `prompt` | *(empty)* | Custom prompt text appended to the built-in prompt |
-| `session_name_format` | `(copilotd) $(org)/$(repo)#$(issue_id)` | Session name template passed to `copilot --name` when the installed Copilot CLI supports it (`1.0.35+`) and the launch does not use `--resume` |
+| `session_name_format` | `(copilotd) $(org)/$(repo)#$(issue_id)` | Session name template for new sessions when the installed Copilot CLI supports naming (`1.0.35+`); later re-dispatches resume by that name, while older ID-based sessions keep resuming by ID |
 | `max_instances` | `3` | Maximum concurrent copilot processes; excess sessions queue as Pending |
 | `session_shutdown_delay_seconds` | `15` | Delay before shutting down an orchestrated session after `session comment`, `session pr`, or `session complete` |
 | `max_redispatches` | `10` | Maximum re-dispatches per session via comment/review feedback loops before requiring manual reset |

--- a/src/copilotd/Commands/SessionCommand.cs
+++ b/src/copilotd/Commands/SessionCommand.cs
@@ -208,9 +208,9 @@ public static class SessionCommand
                         return;
                     }
 
-                    if (string.IsNullOrEmpty(session.CopilotSessionId))
+                    if (string.IsNullOrEmpty(session.CopilotSessionId) && string.IsNullOrEmpty(session.CopilotSessionName))
                     {
-                        errorMessage = $"Session for '{issueKey}' has no copilot session ID.";
+                        errorMessage = $"Session for '{issueKey}' has no copilot resume target.";
                         return;
                     }
 
@@ -221,6 +221,8 @@ public static class SessionCommand
                     {
                         IssueKey = session.IssueKey,
                         CopilotSessionId = session.CopilotSessionId,
+                        CopilotSessionName = session.CopilotSessionName,
+                        HasStarted = session.HasStarted,
                         ProcessId = session.ProcessId,
                         ProcessStartTime = session.ProcessStartTime,
                         Status = session.Status,
@@ -691,7 +693,10 @@ public static class SessionCommand
                     session.CompletedBySession = false;
                     session.PullRequestNumber = null;
                     session.CopilotSessionId = Guid.NewGuid().ToString();
+                    session.CopilotSessionName = null;
+                    session.HasStarted = false;
                     ClearTrackedProcess(session);
+                    session.LastVerifiedAt = null;
                     session.RetryCount = 0;
                     session.RedispatchCount = 0;
                     session.LastRedispatchWasIssueComment = false;
@@ -834,7 +839,7 @@ public static class SessionCommand
         table.AddColumn("Rule");
         table.AddColumn("Status");
         table.AddColumn("PID");
-        table.AddColumn("Session ID");
+        table.AddColumn("Resume");
         table.AddColumn("Worktree");
         table.AddColumn("Created");
         table.AddColumn("Updated");
@@ -854,9 +859,7 @@ public static class SessionCommand
             };
 
             var pid = s.ProcessId?.ToString() ?? "-";
-            var sessionId = string.IsNullOrEmpty(s.CopilotSessionId)
-                ? "-"
-                : s.CopilotSessionId;
+            var resumeTarget = GetResumeTargetDisplay(s);
             var worktree = string.IsNullOrEmpty(s.WorktreePath)
                 ? "-"
                 : s.WorktreePath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
@@ -866,7 +869,7 @@ public static class SessionCommand
                 Markup.Escape(s.RuleName),
                 statusMarkup,
                 Markup.Escape(pid),
-                Markup.Escape(sessionId),
+                Markup.Escape(resumeTarget),
                 Markup.Escape(worktree),
                 FormatTime(s.CreatedAt),
                 FormatTime(s.UpdatedAt)
@@ -945,7 +948,8 @@ public static class SessionCommand
         table.AddRow("Process ID", Markup.Escape(session.ProcessId?.ToString() ?? "-"));
         table.AddRow("Process start", Markup.Escape(FormatOptionalTime(session.ProcessStartTime)));
         table.AddRow("Process liveness", Markup.Escape(FormatOptionalLiveness(liveness)));
-        table.AddRow("Session ID", Markup.Escape(string.IsNullOrEmpty(session.CopilotSessionId) ? "-" : session.CopilotSessionId));
+        table.AddRow("Resume target", Markup.Escape(GetResumeTargetDisplay(session)));
+        table.AddRow("Session name", Markup.Escape(session.CopilotSessionName ?? "-"));
         table.AddRow("Remote task ID", Markup.Escape(remoteTaskId ?? "-"));
         table.AddRow("Remote URL", Markup.Escape(remoteUrl ?? GetUnavailableRemoteSessionUrlMessage(session)));
         table.AddRow("Repo path", Markup.Escape(NormalizeDisplayPath(repoPath) ?? "-"));
@@ -1021,6 +1025,8 @@ public static class SessionCommand
             RuleName = session.RuleName,
             IssueAuthor = session.IssueAuthor,
             CopilotSessionId = session.CopilotSessionId,
+            CopilotSessionName = session.CopilotSessionName,
+            HasStarted = session.HasStarted,
             ProcessId = session.ProcessId,
             ProcessStartTime = session.ProcessStartTime,
             Status = session.Status,
@@ -1038,6 +1044,13 @@ public static class SessionCommand
             WorktreePath = session.WorktreePath,
             BranchName = session.BranchName,
         };
+
+    private static string GetResumeTargetDisplay(DispatchSession session)
+        => !string.IsNullOrWhiteSpace(session.CopilotSessionName)
+            ? session.CopilotSessionName
+            : string.IsNullOrEmpty(session.CopilotSessionId)
+                ? "-"
+                : session.CopilotSessionId;
 
     private static void ClearTrackedProcess(DispatchSession session)
     {

--- a/src/copilotd/Infrastructure/GitHubRemoteSessionUrlResolver.cs
+++ b/src/copilotd/Infrastructure/GitHubRemoteSessionUrlResolver.cs
@@ -31,9 +31,18 @@ public sealed class GitHubRemoteSessionUrlResolver
     }
 
     public string? TryResolve(DispatchSession session, string? currentUser)
-        => session.ProcessId is { } pid && session.Status is SessionStatus.Dispatching or SessionStatus.Running
-            ? TryResolveFromCurrentProcess(session.CopilotSessionId, pid, currentUser)
-            : TryResolve(session.CopilotSessionId, session.ProcessId, currentUser);
+    {
+        if (session.ProcessId is { } pid && session.Status is SessionStatus.Dispatching or SessionStatus.Running)
+        {
+            var currentProcessUrl = TryResolveFromCurrentProcess(session.CopilotSessionId, pid, currentUser)
+                ?? TryResolveBySessionName(session.CopilotSessionName, pid, currentUser);
+            if (currentProcessUrl is not null)
+                return currentProcessUrl;
+        }
+
+        return TryResolve(session.CopilotSessionId, session.ProcessId, currentUser)
+            ?? TryResolveBySessionName(session.CopilotSessionName, session.ProcessId, currentUser);
+    }
 
     public string? TryResolve(ControlSessionInfo session, string? currentUser)
         => TryResolve(session.CopilotSessionId, session.ProcessId, currentUser);
@@ -79,6 +88,15 @@ public sealed class GitHubRemoteSessionUrlResolver
         }
 
         return null;
+    }
+
+    private string? TryResolveBySessionName(string? sessionName, int? processId, string? currentUser)
+    {
+        if (string.IsNullOrWhiteSpace(sessionName))
+            return null;
+
+        var sessionId = TryResolveSessionIdFromSessionName(sessionName, processId);
+        return sessionId is null ? null : TryResolve(sessionId, processId, currentUser);
     }
 
     private string? TryResolveFromCurrentProcess(string? sessionId, int processId, string? currentUser)
@@ -127,6 +145,62 @@ public sealed class GitHubRemoteSessionUrlResolver
         }
 
         return resolvedUrl;
+    }
+
+    private string? TryResolveSessionIdFromSessionName(string sessionName, int? processId)
+    {
+        var sessionId = TryResolveSessionIdFromSessionStateName(sessionName);
+        if (sessionId is not null)
+            return sessionId;
+
+        if (processId is not { } pid)
+            return null;
+
+        foreach (var logPath in EnumerateProcessLogFiles(pid))
+        {
+            try
+            {
+                var resolved = TryResolveSessionIdFromLog(logPath);
+                if (resolved is not null)
+                    return resolved;
+            }
+            catch (IOException ex)
+            {
+                _logger.LogDebug(ex, "Failed reading Copilot log {Path}", logPath);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                _logger.LogDebug(ex, "Access denied reading Copilot log {Path}", logPath);
+            }
+        }
+
+        return null;
+    }
+
+    private string? TryResolveSessionIdFromSessionStateName(string sessionName)
+    {
+        if (!Directory.Exists(_sessionStateDir))
+            return null;
+
+        foreach (var sessionDirectory in new DirectoryInfo(_sessionStateDir)
+                     .EnumerateDirectories()
+                     .OrderByDescending(directory => directory.LastWriteTimeUtc))
+        {
+            var workspacePath = Path.Combine(sessionDirectory.FullName, "workspace.yaml");
+            if (!File.Exists(workspacePath))
+                continue;
+
+            foreach (var line in ReadLinesShared(workspacePath))
+            {
+                if (TryExtractWorkspaceName(line, out var workspaceName)
+                    && string.Equals(workspaceName, sessionName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return sessionDirectory.Name;
+                }
+            }
+        }
+
+        return null;
     }
 
     private IEnumerable<string> EnumerateCandidateLogFiles(int? processId)
@@ -191,6 +265,17 @@ public sealed class GitHubRemoteSessionUrlResolver
             yield return line;
     }
 
+    private static string? TryResolveSessionIdFromLog(string logPath)
+    {
+        foreach (var line in ReadLinesShared(logPath))
+        {
+            if (TryExtractSessionId(line, out var sessionId))
+                return sessionId;
+        }
+
+        return null;
+    }
+
     private static bool LineReferencesSession(string line, string sessionId)
     {
         if (line.Equals($@"  ""session_id"": ""{sessionId}"",", StringComparison.Ordinal)
@@ -205,9 +290,49 @@ public sealed class GitHubRemoteSessionUrlResolver
             || Regex.IsMatch(line,
                 $@"^\d{{4}}-\d{{2}}-\d{{2}}T\S+\s\[INFO\]\sCreating new session with provided ID: {Regex.Escape(sessionId)}$",
                 RegexOptions.CultureInvariant)
-            || Regex.IsMatch(line,
-                $@"^\d{{4}}-\d{{2}}-\d{{2}}T\S+\s\[INFO\]\sWorkspace initialized: {Regex.Escape(sessionId)} \(checkpoints: \d+\)$",
-                RegexOptions.CultureInvariant);
+             || Regex.IsMatch(line,
+                 $@"^\d{{4}}-\d{{2}}-\d{{2}}T\S+\s\[INFO\]\sWorkspace initialized: {Regex.Escape(sessionId)} \(checkpoints: \d+\)$",
+                 RegexOptions.CultureInvariant);
+    }
+
+    private static bool TryExtractSessionId(string line, out string? sessionId)
+    {
+        var workspaceMatch = Regex.Match(
+            line,
+            @"^\d{4}-\d{2}-\d{2}T\S+\s\[INFO\]\sWorkspace initialized:\s+([0-9a-fA-F-]{36})\s+\(checkpoints:\s+\d+\)$",
+            RegexOptions.CultureInvariant);
+        if (workspaceMatch.Success)
+        {
+            sessionId = workspaceMatch.Groups[1].Value;
+            return true;
+        }
+
+        var jsonMatch = Regex.Match(
+            line,
+            @"^\s*""session_id"":\s+""([0-9a-fA-F-]{36})"",\s*$",
+            RegexOptions.CultureInvariant);
+        if (jsonMatch.Success)
+        {
+            sessionId = jsonMatch.Groups[1].Value;
+            return true;
+        }
+
+        sessionId = null;
+        return false;
+    }
+
+    private static bool TryExtractWorkspaceName(string line, out string? workspaceName)
+    {
+        const string NamePrefix = "name:";
+
+        if (line.StartsWith(NamePrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            workspaceName = line[NamePrefix.Length..].Trim();
+            return !string.IsNullOrEmpty(workspaceName);
+        }
+
+        workspaceName = null;
+        return false;
     }
 
     private static bool TryExtractRemoteTaskUrl(string line, out string? url)

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -58,7 +58,8 @@ public sealed partial class ProcessManager
         var customPrompt = _stateStore.LoadCustomPrompt(config);
         var copilotdCommand = _runtimeContext.GetCopilotdCallbackCommand();
         var prompt = BuildPrompt(customPrompt, issue, session, config, copilotdCommand);
-        var sessionName = TryBuildSessionName(issue, session, config, copilotdCommand);
+        var usesResume = !string.IsNullOrWhiteSpace(session.CopilotSessionId);
+        var sessionName = usesResume ? null : TryBuildSessionName(issue, session, config, copilotdCommand);
         var args = BuildArguments(
             session,
             prompt,
@@ -895,10 +896,15 @@ public sealed partial class ProcessManager
         var args = new List<string>
         {
             "--remote",
-            $"--resume={session.CopilotSessionId}",
         };
 
-        if (!string.IsNullOrWhiteSpace(sessionName))
+        var usesResume = !string.IsNullOrWhiteSpace(session.CopilotSessionId);
+        if (usesResume)
+        {
+            args.Add($"--resume={session.CopilotSessionId}");
+        }
+
+        if (usesResume is false && !string.IsNullOrWhiteSpace(sessionName))
         {
             args.Add("--name");
             args.Add($"\"{EscapeArg(sessionName)}\"");

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -58,8 +58,14 @@ public sealed partial class ProcessManager
         var customPrompt = _stateStore.LoadCustomPrompt(config);
         var copilotdCommand = _runtimeContext.GetCopilotdCallbackCommand();
         var prompt = BuildPrompt(customPrompt, issue, session, config, copilotdCommand);
-        var usesResume = !string.IsNullOrWhiteSpace(session.CopilotSessionId);
-        var sessionName = usesResume ? null : TryBuildSessionName(issue, session, config, copilotdCommand);
+        var hasExistingResumeContext = HasExistingResumeContext(session);
+        var sessionName = session.CopilotSessionName;
+        if (!hasExistingResumeContext && string.IsNullOrWhiteSpace(sessionName))
+        {
+            sessionName = TryBuildSessionName(issue, session, config, copilotdCommand);
+            session.CopilotSessionName = sessionName;
+        }
+
         var args = BuildArguments(
             session,
             prompt,
@@ -69,7 +75,10 @@ public sealed partial class ProcessManager
             config.DefaultModel,
             _runtimeContext.GetExtraAllowedDirectories());
 
-        _logger.LogInformation("Launching copilot for {IssueKey} with session {SessionId}", session.IssueKey, session.CopilotSessionId);
+        _logger.LogInformation(
+            "Launching copilot for {IssueKey} with session {SessionId}",
+            session.IssueKey,
+            session.CopilotSessionName ?? session.CopilotSessionId);
         _logger.LogDebug("copilot {Args}", args);
 
         try
@@ -136,6 +145,7 @@ public sealed partial class ProcessManager
 
             session.Status = SessionStatus.Running;
             session.FailureDetail = null;
+            session.HasStarted = true;
             session.UpdatedAt = DateTimeOffset.UtcNow;
             session.LastVerifiedAt = DateTimeOffset.UtcNow;
 
@@ -898,13 +908,23 @@ public sealed partial class ProcessManager
             "--remote",
         };
 
-        var usesResume = !string.IsNullOrWhiteSpace(session.CopilotSessionId);
-        if (usesResume)
+        string? resumeTarget = null;
+        if (HasExistingResumeContext(session))
         {
-            args.Add($"--resume={session.CopilotSessionId}");
+            resumeTarget = !string.IsNullOrWhiteSpace(session.CopilotSessionName)
+                ? session.CopilotSessionName
+                : session.CopilotSessionId;
+        }
+        else if (string.IsNullOrWhiteSpace(sessionName))
+        {
+            resumeTarget = session.CopilotSessionId;
         }
 
-        if (usesResume is false && !string.IsNullOrWhiteSpace(sessionName))
+        if (!string.IsNullOrWhiteSpace(resumeTarget))
+        {
+            args.Add($"--resume=\"{EscapeArg(resumeTarget)}\"");
+        }
+        else if (!string.IsNullOrWhiteSpace(sessionName))
         {
             args.Add("--name");
             args.Add($"\"{EscapeArg(sessionName)}\"");
@@ -952,6 +972,16 @@ public sealed partial class ProcessManager
 
         return string.Join(' ', args);
     }
+
+    private static bool HasExistingResumeContext(DispatchSession session)
+        => session.HasStarted
+            || session.ProcessId is not null
+            || session.ProcessStartTime is not null
+            || session.LastVerifiedAt is not null
+            || session.WaitingSince is not null
+            || session.PullRequestNumber is not null
+            || session.RedispatchCount > 0
+            || session.CompletedBySession;
 
     private static string EscapeArg(string value)
     {

--- a/src/copilotd/Models/CopilotdConfig.cs
+++ b/src/copilotd/Models/CopilotdConfig.cs
@@ -37,9 +37,10 @@ public sealed class CopilotdConfig
     public string? CurrentUser { get; set; }
 
     /// <summary>
-    /// Format string used for naming dispatched copilot sessions via <c>copilot --name</c>.
-    /// Uses the same <c>$(token)</c> replacement style as prompt templating. Set to an empty
-    /// string to disable naming entirely. Default is <c>(copilotd) $(org)/$(repo)#$(issue_id)</c>.
+    /// Format string used for naming dispatched copilot sessions via <c>copilot --name</c>
+    /// when the launch does not use <c>--resume</c>. Uses the same <c>$(token)</c> replacement
+    /// style as prompt templating. Set to an empty string to disable naming entirely. Default is
+    /// <c>(copilotd) $(org)/$(repo)#$(issue_id)</c>.
     /// </summary>
     public string SessionNameFormat { get; set; } = DefaultSessionNameFormat;
 

--- a/src/copilotd/Models/CopilotdConfig.cs
+++ b/src/copilotd/Models/CopilotdConfig.cs
@@ -37,9 +37,10 @@ public sealed class CopilotdConfig
     public string? CurrentUser { get; set; }
 
     /// <summary>
-    /// Format string used for naming dispatched copilot sessions via <c>copilot --name</c>
-    /// when the launch does not use <c>--resume</c>. Uses the same <c>$(token)</c> replacement
-    /// style as prompt templating. Set to an empty string to disable naming entirely. Default is
+    /// Format string used for naming dispatched copilot sessions via <c>copilot --name</c>.
+    /// When available, new sessions start with this name and later re-dispatches resume by name
+    /// via <c>copilot --resume=&lt;name&gt;</c>. Uses the same <c>$(token)</c> replacement style
+    /// as prompt templating. Set to an empty string to disable naming entirely. Default is
     /// <c>(copilotd) $(org)/$(repo)#$(issue_id)</c>.
     /// </summary>
     public string SessionNameFormat { get; set; } = DefaultSessionNameFormat;

--- a/src/copilotd/Models/SessionState.cs
+++ b/src/copilotd/Models/SessionState.cs
@@ -96,8 +96,24 @@ public sealed class DispatchSession
     /// </summary>
     public string? IssueAuthor { get; set; }
 
-    /// <summary>Generated UUID used with copilot --resume=&lt;id&gt;.</summary>
+    /// <summary>
+    /// Stable local identifier for this tracked session. Existing persisted sessions also use this
+    /// as their copilot <c>--resume</c> value. New named sessions keep this identifier for
+    /// copilotd's own state tracking while resuming via <see cref="CopilotSessionName"/>.
+    /// </summary>
     public string CopilotSessionId { get; set; } = "";
+
+    /// <summary>
+    /// Optional name used to start a new Copilot session via <c>copilot --name</c> and later
+    /// resume it via <c>copilot --resume=&lt;name&gt;</c>.
+    /// </summary>
+    public string? CopilotSessionName { get; set; }
+
+    /// <summary>
+    /// True once copilotd has successfully launched this session at least once. Used to decide
+    /// whether a named session should start with <c>--name</c> or resume with <c>--resume</c>.
+    /// </summary>
+    public bool HasStarted { get; set; }
 
     /// <summary>OS process ID of the launched copilot process.</summary>
     public int? ProcessId { get; set; }

--- a/src/copilotd/Services/ReconciliationEngine.cs
+++ b/src/copilotd/Services/ReconciliationEngine.cs
@@ -373,7 +373,7 @@ public sealed class ReconciliationEngine
 
                                 _logger.LogInformation("New comment from {Author} detected on {Key}, re-dispatching waiting session (redispatch {N}/{Max})",
                                     commentInfo.Author, issueKey, existing.RedispatchCount + 1, config.MaxRedispatches);
-                                // Keep same CopilotSessionId so --resume preserves context
+                                // Keep the same resume target so --resume preserves context
                                 existing.Status = SessionStatus.Pending;
                                 existing.FailureDetail = null;
                                 existing.RedispatchCount++;
@@ -449,7 +449,7 @@ public sealed class ReconciliationEngine
 
                                     _logger.LogInformation("New PR review from {Author} detected on PR #{Pr} for {Key}, re-dispatching session (redispatch {N}/{Max})",
                                         reviewInfo.Author, existing.PullRequestNumber, issueKey, existing.RedispatchCount + 1, config.MaxRedispatches);
-                                    // Keep same CopilotSessionId so --resume preserves context
+                                    // Keep the same resume target so --resume preserves context
                                     existing.Status = SessionStatus.Pending;
                                     existing.FailureDetail = null;
                                     existing.RedispatchCount++;
@@ -527,8 +527,11 @@ public sealed class ReconciliationEngine
                         existing.RedispatchCount = 0;
                         existing.LastRedispatchWasIssueComment = false;
                         existing.CopilotSessionId = Guid.NewGuid().ToString();
+                        existing.CopilotSessionName = null;
+                        existing.HasStarted = false;
                         existing.ProcessId = null;
                         existing.ProcessStartTime = null;
+                        existing.LastVerifiedAt = null;
                         existing.UpdatedAt = DateTimeOffset.UtcNow;
                         existing.LastFailureAt = DateTimeOffset.UtcNow;
                         TransitionReaction(existing, config, GhCliService.ReactionEyes);
@@ -564,8 +567,11 @@ public sealed class ReconciliationEngine
                         existing.RedispatchCount = 0;
                         existing.LastRedispatchWasIssueComment = false;
                         existing.CopilotSessionId = Guid.NewGuid().ToString();
+                        existing.CopilotSessionName = null;
+                        existing.HasStarted = false;
                         existing.ProcessId = null;
                         existing.ProcessStartTime = null;
+                        existing.LastVerifiedAt = null;
                         existing.UpdatedAt = DateTimeOffset.UtcNow;
                         TransitionReaction(existing, config, GhCliService.ReactionEyes);
                         continue;
@@ -582,6 +588,7 @@ public sealed class ReconciliationEngine
                     RuleName = ruleName,
                     IssueAuthor = issue.Author,
                     CopilotSessionId = Guid.NewGuid().ToString(),
+                    HasStarted = false,
                     Status = SessionStatus.Pending,
                     CreatedAt = DateTimeOffset.UtcNow,
                     UpdatedAt = DateTimeOffset.UtcNow,


### PR DESCRIPTION
## Summary
- skip session naming for launches that use --resume
- enforce the CLI constraint in the dispatch argument builder
- document when session_name_format is applied

Closes #170