### PR TITLE
Track copilotd instance identity in comments, control session name, and status

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ When running from a source checkout via `copilotd.sh`, `copilotd.ps1`, or `copil
 - `prompt.md` — optional global custom prompt text appended to the built-in prompt
 - `logs\` — rolling file logs for copilotd commands, with daemon instances isolated under `logs\daemon_<uuid>\`
 - `.lock` — single-instance guard (present while daemon is running)
+- `<local app data>\copilotd\machine.id` — stable machine identifier stored outside `COPILOTD_HOME` so it survives state resets
 
 ### Config options
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Installed copilotd binaries can self-update in the background: the daemon checks
 | `copilotd run` | Start the polling daemon and print the current daemon log folder |
 | `copilotd start` | Start the daemon in the background and print the current daemon log folder |
 | `copilotd stop` | Stop the daemon and print the current daemon log folder |
-| `copilotd status` | Show daemon health, watched repos, the active daemon log folder, and the session list |
+| `copilotd status` | Show daemon health, machine identity, watched repos, the active daemon log folder, and the session list |
 | `copilotd logs` | Print the copilotd logs directory (`copilotd log` also works) |
 | `copilotd logs clear [--days <n>]` | Clear log files, optionally only those older than the supplied age |
 | `copilotd session` | List dispatched sessions with their remote session URLs (`copilotd sessions` also works; default alias for `session list`) |
@@ -191,6 +191,7 @@ The built-in prompt and `session_name_format` support token replacement:
 | `$(repo)` | Repository name only |
 | `$(issue_id)` | Issue number |
 | `$(session_id)` | Copilot session ID used with `--resume` |
+| `$(machine_id)` / `$(machine_identifier)` | Assigned copilotd machine identifier |
 | `$(machine_name)` | Local machine name |
 | `$(gh_user)` | Authenticated GitHub username from copilotd config |
 
@@ -353,6 +354,7 @@ sessions, and more — all via natural language.
 - If the control session process dies, the daemon automatically relaunches it on the next poll cycle
 - It does not count against the `max_instances` limit
 - It is tracked separately from dispatch sessions and shown in the `copilotd status` output, including its GitHub remote session URL
+- Its remote session name includes the copilotd machine identifier so multiple daemon instances are easy to distinguish remotely
 
 **Available commands in the control session:**
 

--- a/src/copilotd/Commands/InitCommand.cs
+++ b/src/copilotd/Commands/InitCommand.cs
@@ -27,6 +27,8 @@ public static class InitCommand
                 var stateStore = services.GetRequiredService<StateStore>();
                 var repoResolver = services.GetRequiredService<RepoPathResolver>();
                 var state = stateStore.LoadState();
+                var hadMachineIdentifier = !string.IsNullOrWhiteSpace(state.MachineIdentifier);
+                state.EnsureMachineIdentifier();
 
                 // ── Phase 1: Dependencies & Auth ──────────────────────────
                 AnsiConsole.Write(new Rule("[bold blue]Dependencies & Authentication[/]").LeftJustified());
@@ -332,6 +334,9 @@ public static class InitCommand
                 AnsiConsole.WriteLine();
 
                 // ── Phase 6: Save & Summary ───────────────────────────────
+                if (!hadMachineIdentifier)
+                    stateStore.SaveState(state);
+
                 stateStore.SaveConfig(config);
 
                 AnsiConsole.Write(new Rule("[bold green]Configuration Saved[/]").LeftJustified());

--- a/src/copilotd/Commands/InitCommand.cs
+++ b/src/copilotd/Commands/InitCommand.cs
@@ -27,7 +27,7 @@ public static class InitCommand
                 var stateStore = services.GetRequiredService<StateStore>();
                 var repoResolver = services.GetRequiredService<RepoPathResolver>();
                 var state = stateStore.LoadState();
-                stateStore.EnsureMachineIdentifier(state, ct);
+                stateStore.EnsureMachineIdentifier(ct);
 
                 // ── Phase 1: Dependencies & Auth ──────────────────────────
                 AnsiConsole.Write(new Rule("[bold blue]Dependencies & Authentication[/]").LeftJustified());

--- a/src/copilotd/Commands/InitCommand.cs
+++ b/src/copilotd/Commands/InitCommand.cs
@@ -27,8 +27,7 @@ public static class InitCommand
                 var stateStore = services.GetRequiredService<StateStore>();
                 var repoResolver = services.GetRequiredService<RepoPathResolver>();
                 var state = stateStore.LoadState();
-                var hadMachineIdentifier = !string.IsNullOrWhiteSpace(state.MachineIdentifier);
-                state.EnsureMachineIdentifier();
+                stateStore.EnsureMachineIdentifier(state, ct);
 
                 // ── Phase 1: Dependencies & Auth ──────────────────────────
                 AnsiConsole.Write(new Rule("[bold blue]Dependencies & Authentication[/]").LeftJustified());
@@ -334,9 +333,6 @@ public static class InitCommand
                 AnsiConsole.WriteLine();
 
                 // ── Phase 6: Save & Summary ───────────────────────────────
-                if (!hadMachineIdentifier)
-                    stateStore.SaveState(state);
-
                 stateStore.SaveConfig(config);
 
                 AnsiConsole.Write(new Rule("[bold green]Configuration Saved[/]").LeftJustified());

--- a/src/copilotd/Commands/RunCommand.cs
+++ b/src/copilotd/Commands/RunCommand.cs
@@ -127,7 +127,7 @@ public static class RunCommand
                         stateStore.WithStateLock(() =>
                         {
                             var state = stateStore.LoadState();
-                            var machineIdentifier = state.EnsureMachineIdentifier();
+                            var machineIdentifier = stateStore.EnsureMachineIdentifier(state, daemonCancellationToken);
 
                             var existingAlive = state.ControlSession is not null
                                 && IsControlSessionHealthy(
@@ -258,7 +258,7 @@ public static class RunCommand
                                             }
 
                                             logger.LogInformation("Relaunching control session...");
-                                            var controlSession = processManager.LaunchControlSession(config, state.EnsureMachineIdentifier());
+                                            var controlSession = processManager.LaunchControlSession(config, stateStore.EnsureMachineIdentifier(state, daemonCancellationToken));
                                             if (controlSession is not null)
                                             {
                                                 state.ControlSession = controlSession;

--- a/src/copilotd/Commands/RunCommand.cs
+++ b/src/copilotd/Commands/RunCommand.cs
@@ -120,15 +120,14 @@ public static class RunCommand
                     // Launch control session if enabled
                     if (config.EnableControlSession)
                     {
-                        var existingControlPid = default(int?);
-                        var existingControlSessionId = default(string);
-                        var launchedControlPid = default(int?);
-                        var launchedControlSessionId = default(string);
+                        ControlSessionInfo? existingControlSession = null;
+                        ControlSessionInfo? launchedControlSession = null;
                         var launchFailed = false;
 
                         stateStore.WithStateLock(() =>
                         {
                             var state = stateStore.LoadState();
+                            var machineIdentifier = state.EnsureMachineIdentifier();
 
                             var existingAlive = state.ControlSession is not null
                                 && IsControlSessionHealthy(
@@ -140,20 +139,18 @@ public static class RunCommand
 
                             if (existingAlive)
                             {
-                                existingControlPid = state.ControlSession!.ProcessId;
-                                existingControlSessionId = state.ControlSession.CopilotSessionId;
+                                existingControlSession = state.ControlSession;
                                 return;
                             }
 
                             if (state.ControlSession?.ProcessId is not null)
                                 processManager.TerminateControlSession(state.ControlSession);
 
-                            var controlSession = processManager.LaunchControlSession(config);
+                            var controlSession = processManager.LaunchControlSession(config, machineIdentifier);
                             if (controlSession is not null)
                             {
                                 state.ControlSession = controlSession;
-                                launchedControlPid = controlSession.ProcessId;
-                                launchedControlSessionId = controlSession.CopilotSessionId;
+                                launchedControlSession = controlSession;
                             }
                             else
                             {
@@ -168,23 +165,21 @@ public static class RunCommand
                             stateStore.SaveState(state);
                         }, daemonCancellationToken);
 
-                        if (existingControlPid is not null)
+                        if (existingControlSession?.ProcessId is not null)
                         {
-                            ConsoleOutput.Success($"Control session already running (PID {existingControlPid}).");
+                            ConsoleOutput.Success($"Control session already running (PID {existingControlSession.ProcessId}).");
                             await WriteControlSessionRemoteUrlAsync(
                                 remoteSessionUrls,
-                                existingControlSessionId,
-                                existingControlPid,
+                                existingControlSession,
                                 config.CurrentUser,
                                 ct);
                         }
-                        else if (launchedControlPid is not null)
+                        else if (launchedControlSession?.ProcessId is not null)
                         {
-                            ConsoleOutput.Success($"Control session launched (PID {launchedControlPid}).");
+                            ConsoleOutput.Success($"Control session launched (PID {launchedControlSession.ProcessId}).");
                             await WriteControlSessionRemoteUrlAsync(
                                 remoteSessionUrls,
-                                launchedControlSessionId,
-                                launchedControlPid,
+                                launchedControlSession,
                                 config.CurrentUser,
                                 ct);
                         }
@@ -263,7 +258,7 @@ public static class RunCommand
                                             }
 
                                             logger.LogInformation("Relaunching control session...");
-                                            var controlSession = processManager.LaunchControlSession(config);
+                                            var controlSession = processManager.LaunchControlSession(config, state.EnsureMachineIdentifier());
                                             if (controlSession is not null)
                                             {
                                                 state.ControlSession = controlSession;
@@ -364,15 +359,14 @@ public static class RunCommand
 
     private static async Task WriteControlSessionRemoteUrlAsync(
         GitHubRemoteSessionUrlResolver remoteSessionUrls,
-        string? sessionId,
-        int? processId,
+        ControlSessionInfo? session,
         string? currentUser,
         CancellationToken ct)
     {
-        if (string.IsNullOrWhiteSpace(sessionId))
+        if (session is null)
             return;
 
-        var url = remoteSessionUrls.TryResolve(sessionId, processId, currentUser);
+        var url = remoteSessionUrls.TryResolve(session, currentUser);
         var deadline = DateTimeOffset.UtcNow + RemoteUrlResolveTimeout;
 
         while (url is null && DateTimeOffset.UtcNow < deadline && !ct.IsCancellationRequested)
@@ -386,7 +380,7 @@ public static class RunCommand
                 break;
             }
 
-            url = remoteSessionUrls.TryResolve(sessionId, processId, currentUser);
+            url = remoteSessionUrls.TryResolve(session, currentUser);
         }
 
         ConsoleOutput.Info("Remote:");

--- a/src/copilotd/Commands/RunCommand.cs
+++ b/src/copilotd/Commands/RunCommand.cs
@@ -127,7 +127,7 @@ public static class RunCommand
                         stateStore.WithStateLock(() =>
                         {
                             var state = stateStore.LoadState();
-                            var machineIdentifier = stateStore.EnsureMachineIdentifier(state, daemonCancellationToken);
+                            var machineIdentifier = stateStore.EnsureMachineIdentifier(daemonCancellationToken);
 
                             var existingAlive = state.ControlSession is not null
                                 && IsControlSessionHealthy(
@@ -258,7 +258,7 @@ public static class RunCommand
                                             }
 
                                             logger.LogInformation("Relaunching control session...");
-                                            var controlSession = processManager.LaunchControlSession(config, stateStore.EnsureMachineIdentifier(state, daemonCancellationToken));
+                                            var controlSession = processManager.LaunchControlSession(config, stateStore.EnsureMachineIdentifier(daemonCancellationToken));
                                             if (controlSession is not null)
                                             {
                                                 state.ControlSession = controlSession;

--- a/src/copilotd/Commands/SessionCommand.cs
+++ b/src/copilotd/Commands/SessionCommand.cs
@@ -388,7 +388,7 @@ public static class SessionCommand
                     oldReactionId = session.IssueReactionId;
                     ruleName = session.RuleName;
 
-                    machineIdentifier = stateStore.EnsureMachineIdentifier(state, ct);
+                    machineIdentifier = stateStore.EnsureMachineIdentifier(ct);
                 }, ct);
 
                 if (errorMessage is not null)

--- a/src/copilotd/Commands/SessionCommand.cs
+++ b/src/copilotd/Commands/SessionCommand.cs
@@ -388,10 +388,7 @@ public static class SessionCommand
                     oldReactionId = session.IssueReactionId;
                     ruleName = session.RuleName;
 
-                    var hadMachineIdentifier = !string.IsNullOrWhiteSpace(state.MachineIdentifier);
-                    machineIdentifier = state.EnsureMachineIdentifier();
-                    if (!hadMachineIdentifier)
-                        stateStore.SaveState(state);
+                    machineIdentifier = stateStore.EnsureMachineIdentifier(state, ct);
                 }, ct);
 
                 if (errorMessage is not null)

--- a/src/copilotd/Commands/SessionCommand.cs
+++ b/src/copilotd/Commands/SessionCommand.cs
@@ -366,6 +366,7 @@ public static class SessionCommand
                 string? errorMessage = null;
                 long? oldReactionId = null;
                 string? ruleName = null;
+                string? machineIdentifier = null;
 
                 stateStore.WithStateLock(() =>
                 {
@@ -386,6 +387,11 @@ public static class SessionCommand
                     expectedSessionId = session.CopilotSessionId;
                     oldReactionId = session.IssueReactionId;
                     ruleName = session.RuleName;
+
+                    var hadMachineIdentifier = !string.IsNullOrWhiteSpace(state.MachineIdentifier);
+                    machineIdentifier = state.EnsureMachineIdentifier();
+                    if (!hadMachineIdentifier)
+                        stateStore.SaveState(state);
                 }, ct);
 
                 if (errorMessage is not null)
@@ -394,7 +400,7 @@ public static class SessionCommand
                     return 1;
                 }
 
-                if (!ghCli.PostIssueComment(repo!, issueNumber, message))
+                if (!ghCli.PostIssueComment(repo!, issueNumber, message, machineIdentifier!))
                 {
                     ConsoleOutput.Error($"Failed to post comment on {issueKey}.");
                     return 1;

--- a/src/copilotd/Commands/StatusCommand.cs
+++ b/src/copilotd/Commands/StatusCommand.cs
@@ -85,7 +85,7 @@ public static class StatusCommand
                 if (daemonInfo is { LogInstanceId: { Length: > 0 } daemonLogInstanceId })
                     ConsoleOutput.Info($"  Logs:      {logFileManager.GetDaemonLogDirectoryForDisplay(daemonLogInstanceId)}");
                 ConsoleOutput.Info($"  Machine:   {Environment.MachineName}");
-                ConsoleOutput.Info($"  Machine ID:{(state.MachineIdentifier is { Length: > 0 } machineIdentifier ? $" {machineIdentifier}" : " (not assigned)")}");
+                ConsoleOutput.Info($"  Machine ID:{(stateStore.GetMachineIdentifier(state) is { Length: > 0 } machineIdentifier ? $" {machineIdentifier}" : " (not assigned)")}");
 
                 // Control session status
                 if (state.ControlSession is not null)

--- a/src/copilotd/Commands/StatusCommand.cs
+++ b/src/copilotd/Commands/StatusCommand.cs
@@ -84,6 +84,8 @@ public static class StatusCommand
                 ConsoleOutput.Info($"  Rules:     {config.Rules.Count}");
                 if (daemonInfo is { LogInstanceId: { Length: > 0 } daemonLogInstanceId })
                     ConsoleOutput.Info($"  Logs:      {logFileManager.GetDaemonLogDirectoryForDisplay(daemonLogInstanceId)}");
+                ConsoleOutput.Info($"  Machine:   {Environment.MachineName}");
+                ConsoleOutput.Info($"  Machine ID:{(state.MachineIdentifier is { Length: > 0 } machineIdentifier ? $" {machineIdentifier}" : " (not assigned)")}");
 
                 // Control session status
                 if (state.ControlSession is not null)

--- a/src/copilotd/Commands/StatusCommand.cs
+++ b/src/copilotd/Commands/StatusCommand.cs
@@ -85,7 +85,7 @@ public static class StatusCommand
                 if (daemonInfo is { LogInstanceId: { Length: > 0 } daemonLogInstanceId })
                     ConsoleOutput.Info($"  Logs:      {logFileManager.GetDaemonLogDirectoryForDisplay(daemonLogInstanceId)}");
                 ConsoleOutput.Info($"  Machine:   {Environment.MachineName}");
-                ConsoleOutput.Info($"  Machine ID:{(stateStore.GetMachineIdentifier(state) is { Length: > 0 } machineIdentifier ? $" {machineIdentifier}" : " (not assigned)")}");
+                ConsoleOutput.Info($"  Machine ID:{(stateStore.GetMachineIdentifier() is { Length: > 0 } machineIdentifier ? $" {machineIdentifier}" : " (not assigned)")}");
 
                 // Control session status
                 if (state.ControlSession is not null)

--- a/src/copilotd/Infrastructure/CopilotdPaths.cs
+++ b/src/copilotd/Infrastructure/CopilotdPaths.cs
@@ -38,6 +38,21 @@ public static class CopilotdPaths
     public static string GetCopilotHomeDirectory()
         => Path.Combine(GetUserProfileDirectory(), ".copilot");
 
+    public static string GetLocalAppDataDirectory()
+    {
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        if (!string.IsNullOrWhiteSpace(localAppData))
+            return localAppData;
+
+        return Path.Combine(GetUserProfileDirectory(), ".local", "share");
+    }
+
+    public static string GetMachineIdentityDirectory()
+        => Path.Combine(GetLocalAppDataDirectory(), "copilotd");
+
+    public static string GetMachineIdentifierPath()
+        => Path.Combine(GetMachineIdentityDirectory(), "machine.id");
+
     public static string GetCopilotConfigPath()
         => Path.Combine(GetCopilotHomeDirectory(), "config.json");
 

--- a/src/copilotd/Infrastructure/GitHubRemoteSessionUrlResolver.cs
+++ b/src/copilotd/Infrastructure/GitHubRemoteSessionUrlResolver.cs
@@ -45,13 +45,24 @@ public sealed class GitHubRemoteSessionUrlResolver
     }
 
     public string? TryResolve(ControlSessionInfo session, string? currentUser)
-        => TryResolve(session.CopilotSessionId, session.ProcessId, currentUser);
+    {
+        if (session.ProcessId is { } pid && session.Status is ControlSessionStatus.Starting or ControlSessionStatus.Running)
+        {
+            var currentProcessUrl = TryResolveFromCurrentProcess(session.CopilotSessionId, pid, currentUser)
+                ?? TryResolveBySessionName(session.CopilotSessionName, pid, currentUser);
+            if (currentProcessUrl is not null)
+                return currentProcessUrl;
+        }
+
+        return TryResolve(session.CopilotSessionId, session.ProcessId, currentUser)
+            ?? TryResolveBySessionName(session.CopilotSessionName, session.ProcessId, currentUser);
+    }
 
     public string? TryResolveTaskId(DispatchSession session, string? currentUser)
         => TryExtractTaskId(TryResolve(session, currentUser), out var taskId) ? taskId : null;
 
     public string? TryResolveTaskId(ControlSessionInfo session, string? currentUser)
-        => TryResolveTaskId(session.CopilotSessionId, session.ProcessId, currentUser);
+        => TryExtractTaskId(TryResolve(session, currentUser), out var taskId) ? taskId : null;
 
     public string? TryResolve(string? sessionId, int? processId, string? currentUser)
     {

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -57,7 +57,7 @@ public sealed partial class ProcessManager
 
         var customPrompt = _stateStore.LoadCustomPrompt(config);
         var copilotdCommand = _runtimeContext.GetCopilotdCallbackCommand();
-        var machineIdentifier = state.EnsureMachineIdentifier();
+        var machineIdentifier = _stateStore.EnsureMachineIdentifier(state);
         var prompt = BuildPrompt(customPrompt, issue, session, config, copilotdCommand, machineIdentifier);
         var hasExistingResumeContext = HasExistingResumeContext(session);
         var sessionName = session.CopilotSessionName;

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -57,12 +57,13 @@ public sealed partial class ProcessManager
 
         var customPrompt = _stateStore.LoadCustomPrompt(config);
         var copilotdCommand = _runtimeContext.GetCopilotdCallbackCommand();
-        var prompt = BuildPrompt(customPrompt, issue, session, config, copilotdCommand);
+        var machineIdentifier = state.EnsureMachineIdentifier();
+        var prompt = BuildPrompt(customPrompt, issue, session, config, copilotdCommand, machineIdentifier);
         var hasExistingResumeContext = HasExistingResumeContext(session);
         var sessionName = session.CopilotSessionName;
         if (!hasExistingResumeContext && string.IsNullOrWhiteSpace(sessionName))
         {
-            sessionName = TryBuildSessionName(issue, session, config, copilotdCommand);
+            sessionName = TryBuildSessionName(issue, session, config, copilotdCommand, machineIdentifier);
             session.CopilotSessionName = sessionName;
         }
 
@@ -502,7 +503,7 @@ public sealed partial class ProcessManager
     /// allows remote management of copilotd via the GitHub remote sessions UI.
     /// Returns a populated <see cref="ControlSessionInfo"/> on success, or null on failure.
     /// </summary>
-    public ControlSessionInfo? LaunchControlSession(CopilotdConfig config)
+    public ControlSessionInfo? LaunchControlSession(CopilotdConfig config, string machineIdentifier)
     {
         // Clone the copilotd repo to <RepoHome>/DamianEdwards/copilotd if needed, then
         // launch from a dedicated subdirectory so repo-root wrapper scripts don't shadow
@@ -517,6 +518,7 @@ public sealed partial class ProcessManager
         var session = new ControlSessionInfo
         {
             CopilotSessionId = Guid.NewGuid().ToString("D"),
+            CopilotSessionName = BuildControlSessionName(machineIdentifier),
             Status = ControlSessionStatus.Starting,
             StartedAt = DateTimeOffset.UtcNow,
             UpdatedAt = DateTimeOffset.UtcNow,
@@ -524,8 +526,8 @@ public sealed partial class ProcessManager
 
         var prompt = CopilotdConfig.ControlSessionPrompt
             .Replace("$(copilotd.command)", _runtimeContext.GetCopilotdCallbackCommand(), StringComparison.Ordinal);
-        var args = BuildControlSessionArguments(session.CopilotSessionId, prompt, config.DefaultModel, _runtimeContext);
-        _logger.LogInformation("Launching control session {SessionId}", session.CopilotSessionId);
+        var args = BuildControlSessionArguments(session, prompt, config.DefaultModel, _runtimeContext);
+        _logger.LogInformation("Launching control session {SessionName}", session.CopilotSessionName);
         _logger.LogDebug("copilot {Args}", args);
 
         try
@@ -600,14 +602,25 @@ public sealed partial class ProcessManager
     public bool TerminateControlSession(ControlSessionInfo session)
         => TerminateProcess("control session", session.ProcessId, session.ProcessStartTime);
 
-    private static string BuildControlSessionArguments(string sessionId, string prompt, string? defaultModel, RuntimeContext runtimeContext)
+    private static string BuildControlSessionArguments(ControlSessionInfo session, string prompt, string? defaultModel, RuntimeContext runtimeContext)
     {
         var args = new List<string>
         {
             "--remote",
-            $"--resume={sessionId}",
-            "-i", $"\"{EscapeArg(prompt)}\"",
         };
+
+        if (!string.IsNullOrWhiteSpace(session.CopilotSessionName))
+        {
+            args.Add("--name");
+            args.Add($"\"{EscapeArg(session.CopilotSessionName)}\"");
+        }
+        else if (!string.IsNullOrWhiteSpace(session.CopilotSessionId))
+        {
+            args.Add($"--resume=\"{EscapeArg(session.CopilotSessionId)}\"");
+        }
+
+        args.Add("-i");
+        args.Add($"\"{EscapeArg(prompt)}\"");
 
         // Only allow the commands needed to manage the daemon remotely — no general shell access.
         foreach (var command in runtimeContext.GetControlSessionAllowedShellCommands().Distinct(StringComparer.OrdinalIgnoreCase))
@@ -627,6 +640,9 @@ public sealed partial class ProcessManager
 
         return string.Join(' ', args);
     }
+
+    private static string BuildControlSessionName(string machineIdentifier)
+        => $"(copilotd control) {machineIdentifier}";
 
     /// <summary>
     /// The copilotd repo to clone for the control session's working directory.
@@ -732,7 +748,7 @@ public sealed partial class ProcessManager
         }
     }
 
-    private static string BuildPrompt(string globalCustomPrompt, GitHubIssue issue, DispatchSession session, CopilotdConfig config, string copilotdCommand)
+    private static string BuildPrompt(string globalCustomPrompt, GitHubIssue issue, DispatchSession session, CopilotdConfig config, string copilotdCommand, string machineIdentifier)
     {
         var prompt = session.RedispatchCount > 0
             ? session.PullRequestNumber is not null && !session.LastRedispatchWasIssueComment
@@ -762,7 +778,7 @@ public sealed partial class ProcessManager
         }
 
         // Replace tokens in the entire prompt (default + custom + extra)
-        return ExpandTemplate(prompt, issue, session, copilotdCommand, config.CurrentUser);
+        return ExpandTemplate(prompt, issue, session, copilotdCommand, config.CurrentUser, machineIdentifier);
     }
 
     /// <summary>
@@ -816,7 +832,7 @@ public sealed partial class ProcessManager
         };
     }
 
-    private string? TryBuildSessionName(GitHubIssue issue, DispatchSession session, CopilotdConfig config, string copilotdCommand)
+    private string? TryBuildSessionName(GitHubIssue issue, DispatchSession session, CopilotdConfig config, string copilotdCommand, string machineIdentifier)
     {
         if (string.IsNullOrWhiteSpace(config.SessionNameFormat))
             return null;
@@ -852,7 +868,7 @@ public sealed partial class ProcessManager
 
         try
         {
-            var sessionName = ExpandTemplate(config.SessionNameFormat, issue, session, copilotdCommand, config.CurrentUser).Trim();
+            var sessionName = ExpandTemplate(config.SessionNameFormat, issue, session, copilotdCommand, config.CurrentUser, machineIdentifier).Trim();
             if (string.IsNullOrWhiteSpace(sessionName))
             {
                 _logger.LogWarning(
@@ -870,7 +886,7 @@ public sealed partial class ProcessManager
         }
     }
 
-    private static string ExpandTemplate(string template, GitHubIssue issue, DispatchSession session, string copilotdCommand, string? ghUser)
+    private static string ExpandTemplate(string template, GitHubIssue issue, DispatchSession session, string copilotdCommand, string? ghUser, string machineIdentifier)
     {
         var (org, repo) = SplitRepoSlug(issue.Repo);
 
@@ -885,6 +901,8 @@ public sealed partial class ProcessManager
             .Replace("$(repo)", repo, StringComparison.Ordinal)
             .Replace("$(issue_id)", issue.Number.ToString(), StringComparison.Ordinal)
             .Replace("$(session_id)", session.CopilotSessionId, StringComparison.Ordinal)
+            .Replace("$(machine_id)", machineIdentifier, StringComparison.Ordinal)
+            .Replace("$(machine_identifier)", machineIdentifier, StringComparison.Ordinal)
             .Replace("$(machine_name)", Environment.MachineName, StringComparison.Ordinal)
             .Replace("$(gh_user)", ghUser ?? "", StringComparison.Ordinal);
     }

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -57,7 +57,7 @@ public sealed partial class ProcessManager
 
         var customPrompt = _stateStore.LoadCustomPrompt(config);
         var copilotdCommand = _runtimeContext.GetCopilotdCallbackCommand();
-        var machineIdentifier = _stateStore.EnsureMachineIdentifier(state);
+        var machineIdentifier = _stateStore.EnsureMachineIdentifier();
         var prompt = BuildPrompt(customPrompt, issue, session, config, copilotdCommand, machineIdentifier);
         var hasExistingResumeContext = HasExistingResumeContext(session);
         var sessionName = session.CopilotSessionName;

--- a/src/copilotd/Infrastructure/StateStore.cs
+++ b/src/copilotd/Infrastructure/StateStore.cs
@@ -16,6 +16,9 @@ public sealed class StateStore
     private readonly string _configPath;
     private readonly string _statePath;
     private readonly string _updateStatePath;
+    private readonly string _machineIdentityDir;
+    private readonly string _machineIdentifierPath;
+    private readonly string _machineIdentifierLockPath;
     private readonly string _lockPath;
     private readonly string _stateLockPath;
     private readonly string _updateLockPath;
@@ -35,6 +38,9 @@ public sealed class StateStore
         _configPath = Path.Combine(_configDir, "config.json");
         _statePath = Path.Combine(_configDir, "state.json");
         _updateStatePath = Path.Combine(_configDir, "update-state.json");
+        _machineIdentityDir = CopilotdPaths.GetMachineIdentityDirectory();
+        _machineIdentifierPath = CopilotdPaths.GetMachineIdentifierPath();
+        _machineIdentifierLockPath = Path.Combine(_machineIdentityDir, ".machine-id.lock");
         _lockPath = Path.Combine(_configDir, ".lock");
         _stateLockPath = Path.Combine(_configDir, ".state-lock");
         _updateLockPath = Path.Combine(_configDir, ".update-lock");
@@ -102,6 +108,33 @@ public sealed class StateStore
         var json = JsonSerializer.Serialize(state, CopilotdJsonContext.Default.DaemonState);
         AtomicWrite(_statePath, json);
         _logger.LogDebug("State saved to {Path}", _statePath);
+    }
+
+    public string? GetMachineIdentifier(DaemonState? state = null)
+    {
+        var persistedIdentifier = ReadMachineIdentifierFromFile();
+        if (persistedIdentifier is not null)
+            return persistedIdentifier;
+
+        return NormalizeMachineIdentifier(state?.MachineIdentifier);
+    }
+
+    public string EnsureMachineIdentifier(DaemonState? state = null, CancellationToken ct = default)
+    {
+        Directory.CreateDirectory(_machineIdentityDir);
+
+        using var lockStream = AcquireExclusiveLock(_machineIdentifierLockPath, ct);
+
+        var persistedIdentifier = ReadMachineIdentifierFromFile();
+        if (persistedIdentifier is not null)
+            return persistedIdentifier;
+
+        var machineIdentifier = NormalizeMachineIdentifier(state?.MachineIdentifier)
+                                ?? Guid.NewGuid().ToString("D");
+
+        AtomicWrite(_machineIdentifierPath, machineIdentifier);
+        _logger.LogDebug("Machine identifier saved to {Path}", _machineIdentifierPath);
+        return machineIdentifier;
     }
 
     /// <summary>
@@ -338,6 +371,32 @@ public sealed class StateStore
     }
 
     // --- Helpers ---
+
+    private string? ReadMachineIdentifierFromFile()
+    {
+        if (!File.Exists(_machineIdentifierPath))
+            return null;
+
+        try
+        {
+            return NormalizeMachineIdentifier(File.ReadAllText(_machineIdentifierPath));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to read machine identifier from {Path}", _machineIdentifierPath);
+            return null;
+        }
+    }
+
+    private static string? NormalizeMachineIdentifier(string? machineIdentifier)
+    {
+        if (string.IsNullOrWhiteSpace(machineIdentifier))
+            return null;
+
+        return Guid.TryParse(machineIdentifier.Trim(), out var parsedIdentifier)
+            ? parsedIdentifier.ToString("D")
+            : null;
+    }
 
     private static void AtomicWrite(string path, string content)
     {

--- a/src/copilotd/Infrastructure/StateStore.cs
+++ b/src/copilotd/Infrastructure/StateStore.cs
@@ -110,16 +110,12 @@ public sealed class StateStore
         _logger.LogDebug("State saved to {Path}", _statePath);
     }
 
-    public string? GetMachineIdentifier(DaemonState? state = null)
+    public string? GetMachineIdentifier()
     {
-        var persistedIdentifier = ReadMachineIdentifierFromFile();
-        if (persistedIdentifier is not null)
-            return persistedIdentifier;
-
-        return NormalizeMachineIdentifier(state?.MachineIdentifier);
+        return ReadMachineIdentifierFromFile();
     }
 
-    public string EnsureMachineIdentifier(DaemonState? state = null, CancellationToken ct = default)
+    public string EnsureMachineIdentifier(CancellationToken ct = default)
     {
         Directory.CreateDirectory(_machineIdentityDir);
 
@@ -129,8 +125,7 @@ public sealed class StateStore
         if (persistedIdentifier is not null)
             return persistedIdentifier;
 
-        var machineIdentifier = NormalizeMachineIdentifier(state?.MachineIdentifier)
-                                ?? Guid.NewGuid().ToString("D");
+        var machineIdentifier = Guid.NewGuid().ToString("D");
 
         AtomicWrite(_machineIdentifierPath, machineIdentifier);
         _logger.LogDebug("Machine identifier saved to {Path}", _machineIdentifierPath);
@@ -379,23 +374,16 @@ public sealed class StateStore
 
         try
         {
-            return NormalizeMachineIdentifier(File.ReadAllText(_machineIdentifierPath));
+            var persistedIdentifier = File.ReadAllText(_machineIdentifierPath).Trim();
+            return Guid.TryParse(persistedIdentifier, out var parsedIdentifier)
+                ? parsedIdentifier.ToString("D")
+                : null;
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to read machine identifier from {Path}", _machineIdentifierPath);
             return null;
         }
-    }
-
-    private static string? NormalizeMachineIdentifier(string? machineIdentifier)
-    {
-        if (string.IsNullOrWhiteSpace(machineIdentifier))
-            return null;
-
-        return Guid.TryParse(machineIdentifier.Trim(), out var parsedIdentifier)
-            ? parsedIdentifier.ToString("D")
-            : null;
     }
 
     private static void AtomicWrite(string path, string content)

--- a/src/copilotd/Models/SessionState.cs
+++ b/src/copilotd/Models/SessionState.cs
@@ -12,9 +12,9 @@ public sealed class DaemonState
     public int SchemaVersion { get; set; } = 1;
 
     /// <summary>
-    /// Stable UUID assigned to this copilotd installation for cross-machine attribution.
-    /// Persisted in state so public metadata can identify which instance acted without
-    /// exposing the local machine name.
+    /// Legacy migration fallback for machine identity. Newer versions persist the
+    /// machine identifier separately in the local app data machine.id file so it
+    /// survives copilotd home/state resets.
     /// </summary>
     public string? MachineIdentifier { get; set; }
 
@@ -39,16 +39,6 @@ public sealed class DaemonState
     /// </summary>
     public ControlSessionInfo? ControlSession { get; set; }
 
-    /// <summary>
-    /// Returns the persisted machine identifier, assigning a new stable UUID when missing.
-    /// </summary>
-    public string EnsureMachineIdentifier()
-    {
-        if (string.IsNullOrWhiteSpace(MachineIdentifier))
-            MachineIdentifier = Guid.NewGuid().ToString("D");
-
-        return MachineIdentifier;
-    }
 }
 
 /// <summary>

--- a/src/copilotd/Models/SessionState.cs
+++ b/src/copilotd/Models/SessionState.cs
@@ -12,13 +12,6 @@ public sealed class DaemonState
     public int SchemaVersion { get; set; } = 1;
 
     /// <summary>
-    /// Legacy migration fallback for machine identity. Newer versions persist the
-    /// machine identifier separately in the local app data machine.id file so it
-    /// survives copilotd home/state resets.
-    /// </summary>
-    public string? MachineIdentifier { get; set; }
-
-    /// <summary>
     /// All tracked dispatch sessions keyed by issue key ("org/repo#number").
     /// </summary>
     public Dictionary<string, DispatchSession> Sessions { get; set; } = new(StringComparer.OrdinalIgnoreCase);
@@ -38,7 +31,6 @@ public sealed class DaemonState
     /// dispatch sessions to avoid interference with reconciliation and pruning.
     /// </summary>
     public ControlSessionInfo? ControlSession { get; set; }
-
 }
 
 /// <summary>

--- a/src/copilotd/Models/SessionState.cs
+++ b/src/copilotd/Models/SessionState.cs
@@ -12,6 +12,13 @@ public sealed class DaemonState
     public int SchemaVersion { get; set; } = 1;
 
     /// <summary>
+    /// Stable UUID assigned to this copilotd installation for cross-machine attribution.
+    /// Persisted in state so public metadata can identify which instance acted without
+    /// exposing the local machine name.
+    /// </summary>
+    public string? MachineIdentifier { get; set; }
+
+    /// <summary>
     /// All tracked dispatch sessions keyed by issue key ("org/repo#number").
     /// </summary>
     public Dictionary<string, DispatchSession> Sessions { get; set; } = new(StringComparer.OrdinalIgnoreCase);
@@ -31,6 +38,17 @@ public sealed class DaemonState
     /// dispatch sessions to avoid interference with reconciliation and pruning.
     /// </summary>
     public ControlSessionInfo? ControlSession { get; set; }
+
+    /// <summary>
+    /// Returns the persisted machine identifier, assigning a new stable UUID when missing.
+    /// </summary>
+    public string EnsureMachineIdentifier()
+    {
+        if (string.IsNullOrWhiteSpace(MachineIdentifier))
+            MachineIdentifier = Guid.NewGuid().ToString("D");
+
+        return MachineIdentifier;
+    }
 }
 
 /// <summary>
@@ -232,8 +250,17 @@ public enum ControlSessionStatus
 /// </summary>
 public sealed class ControlSessionInfo
 {
-    /// <summary>Generated UUID for the copilot remote session.</summary>
+    /// <summary>
+    /// Copilot session ID when known. For named control sessions, copilotd may initially
+    /// resolve the live remote session via <see cref="CopilotSessionName"/> instead.
+    /// </summary>
     public string CopilotSessionId { get; set; } = "";
+
+    /// <summary>
+    /// Human-readable control session name shown in the remote sessions UI.
+    /// Includes the copilotd machine identifier, but never the real machine name.
+    /// </summary>
+    public string? CopilotSessionName { get; set; }
 
     /// <summary>OS process ID of the copilot process.</summary>
     public int? ProcessId { get; set; }

--- a/src/copilotd/Services/GhCliService.cs
+++ b/src/copilotd/Services/GhCliService.cs
@@ -411,19 +411,25 @@ public sealed class GhCliService
     }
 
     /// <summary>
-    /// Marker appended to comments posted by copilotd, used to distinguish
+    /// Prefix for hidden HTML metadata appended to comments posted by copilotd, used to distinguish
     /// bot-posted comments from human replies when checking for new feedback.
     /// Invisible on GitHub (HTML comment).
     /// </summary>
-    internal const string CommentMarker = "<!-- posted by copilotd -->";
+    internal const string CommentMarkerPrefix = "<!-- posted by copilotd";
+
+    /// <summary>
+    /// Legacy hidden marker used before machine identifiers were added to comment metadata.
+    /// Preserved so older copilotd comments remain attributable and ignored during feedback checks.
+    /// </summary>
+    internal const string LegacyCommentMarker = "<!-- posted by copilotd -->";
 
     /// <summary>
     /// Posts a comment on a GitHub issue. Appends a hidden marker so copilotd
     /// can distinguish its own comments from human replies.
     /// </summary>
-    public bool PostIssueComment(string repo, int issueNumber, string message)
+    public bool PostIssueComment(string repo, int issueNumber, string message, string machineIdentifier)
     {
-        var body = message + "\n\n" + CommentMarker;
+        var body = message + "\n\n" + BuildCommentMarker(machineIdentifier);
 
         // Use --body-file - to pipe via stdin, avoiding all shell escaping issues
         var args = $"issue comment {issueNumber} --repo {repo} --body-file -";
@@ -474,7 +480,7 @@ public sealed class GhCliService
 
     /// <summary>
     /// Checks whether there are new comments on an issue since the given timestamp,
-    /// excluding comments posted by copilotd itself (identified by <see cref="CommentMarker"/>).
+    /// excluding comments posted by copilotd itself (identified by the hidden copilotd marker).
     /// </summary>
     public bool HasNewCommentsSince(string repo, int issueNumber, DateTimeOffset since)
         => GetNewCommentSince(repo, issueNumber, since) is not null;
@@ -515,7 +521,7 @@ public sealed class GhCliService
                 if (comment.TryGetProperty("body", out var bodyEl))
                 {
                     var body = bodyEl.GetString();
-                    if (body is not null && body.Contains(CommentMarker, StringComparison.Ordinal))
+                    if (IsCopilotdComment(body))
                         continue;
                 }
 
@@ -615,7 +621,7 @@ public sealed class GhCliService
 
     /// <summary>
     /// Checks whether there are new review comments on a pull request since the given timestamp,
-    /// excluding comments posted by copilotd itself (identified by <see cref="CommentMarker"/>).
+    /// excluding comments posted by copilotd itself (identified by the hidden copilotd marker).
     /// Checks both PR review comments (from formal reviews) and regular PR comments.
     /// </summary>
     public bool HasNewPrReviewCommentsSince(string repo, int prNumber, DateTimeOffset since)
@@ -674,7 +680,7 @@ public sealed class GhCliService
                     if (review.TryGetProperty("body", out var bodyEl))
                     {
                         var body = bodyEl.GetString();
-                        if (body is not null && body.Contains(CommentMarker, StringComparison.Ordinal))
+                        if (IsCopilotdComment(body))
                             continue;
                     }
 
@@ -751,7 +757,7 @@ public sealed class GhCliService
         if (comment.TryGetProperty("body", out var bodyEl))
         {
             var body = bodyEl.GetString();
-            if (body is not null && body.Contains(CommentMarker, StringComparison.Ordinal))
+            if (IsCopilotdComment(body))
                 return null;
         }
 
@@ -761,6 +767,14 @@ public sealed class GhCliService
 
         return new NewCommentInfo(author, createdAt);
     }
+
+    private static string BuildCommentMarker(string machineIdentifier)
+        => $"<!-- posted by copilotd; machine-id: {machineIdentifier} -->";
+
+    private static bool IsCopilotdComment(string? body)
+        => body is not null
+           && (body.Contains(CommentMarkerPrefix, StringComparison.Ordinal)
+               || body.Contains(LegacyCommentMarker, StringComparison.Ordinal));
 
     // Reaction content constants for GitHub issue reactions
     internal const string ReactionEyes = "eyes";

--- a/src/copilotd/Services/ReconciliationEngine.cs
+++ b/src/copilotd/Services/ReconciliationEngine.cs
@@ -46,6 +46,11 @@ public sealed class ReconciliationEngine
     {
         _logger.LogInformation("Starting reconciliation cycle");
 
+        var hadMachineIdentifier = !string.IsNullOrWhiteSpace(state.MachineIdentifier);
+        var machineIdentifier = state.EnsureMachineIdentifier();
+        if (!hadMachineIdentifier)
+            _logger.LogInformation("Assigned machine identifier {MachineIdentifier}", machineIdentifier);
+
         // Step 0: Prune terminal sessions older than 7 days
         PruneTerminalSessions(state);
 

--- a/src/copilotd/Services/ReconciliationEngine.cs
+++ b/src/copilotd/Services/ReconciliationEngine.cs
@@ -46,8 +46,8 @@ public sealed class ReconciliationEngine
     {
         _logger.LogInformation("Starting reconciliation cycle");
 
-        var hadMachineIdentifier = _stateStore.GetMachineIdentifier(state) is not null;
-        var machineIdentifier = _stateStore.EnsureMachineIdentifier(state);
+        var hadMachineIdentifier = _stateStore.GetMachineIdentifier() is not null;
+        var machineIdentifier = _stateStore.EnsureMachineIdentifier();
         if (!hadMachineIdentifier)
             _logger.LogInformation("Assigned machine identifier {MachineIdentifier}", machineIdentifier);
 

--- a/src/copilotd/Services/ReconciliationEngine.cs
+++ b/src/copilotd/Services/ReconciliationEngine.cs
@@ -46,8 +46,8 @@ public sealed class ReconciliationEngine
     {
         _logger.LogInformation("Starting reconciliation cycle");
 
-        var hadMachineIdentifier = !string.IsNullOrWhiteSpace(state.MachineIdentifier);
-        var machineIdentifier = state.EnsureMachineIdentifier();
+        var hadMachineIdentifier = _stateStore.GetMachineIdentifier(state) is not null;
+        var machineIdentifier = _stateStore.EnsureMachineIdentifier(state);
         if (!hadMachineIdentifier)
             _logger.LogInformation("Assigned machine identifier {MachineIdentifier}", machineIdentifier);
 


### PR DESCRIPTION
## Summary
- persist a stable copilotd machine identifier in a dedicated local-app-data `copilotd\machine.id` file so it survives `COPILOTD_HOME` and state resets
- include the machine identifier in hidden issue comment metadata and named control sessions
- show machine name plus machine identifier in status output while keeping the real machine name out of public comment metadata

## Verification
- dotnet build .\src\copilotd\copilotd.csproj -nologo
- isolated `copilotd run --interval 15 --log-level debug` with `COPILOTD_HOME` pointing at a temporary config/state home
- confirmed the isolated `state.json` no longer contains `machineIdentifier`
- confirmed the machine identifier is written to the local app data `copilotd\machine.id` file

Closes #176