### PR TITLE
Fix issue branch linking on dispatch

### DIFF
--- a/src/copilotd/Services/GhCliService.cs
+++ b/src/copilotd/Services/GhCliService.cs
@@ -934,12 +934,13 @@ public sealed class GhCliService
     }
 
     /// <summary>
-    /// Links a branch to a GitHub issue via the Development sidebar using the
-    /// <c>createLinkedBranch</c> GraphQL mutation. Call after pushing the branch
-    /// to the remote so the ref exists on GitHub.
+    /// Creates a linked branch for a GitHub issue via the Development sidebar
+    /// using the <c>createLinkedBranch</c> GraphQL mutation. This mutation
+    /// creates the remote branch as part of linking it, so call it before
+    /// pushing the local branch and use the same branch name locally.
     /// Best-effort: failures are logged but do not block session lifecycle.
     /// </summary>
-    public bool LinkBranchToIssue(string repo, int issueNumber, string branchName, string commitSha)
+    public bool CreateLinkedBranchForIssue(string repo, int issueNumber, string branchName, string commitSha)
     {
         var parts = repo.Split('/');
         if (parts.Length != 2)
@@ -1005,7 +1006,7 @@ public sealed class GhCliService
             {
                 ["issueId"] = issueId,
                 ["oid"] = commitSha,
-                ["name"] = $"refs/heads/{branchName}",
+                ["name"] = branchName,
                 ["repositoryId"] = repoId,
             },
         };
@@ -1013,7 +1014,7 @@ public sealed class GhCliService
         var (mutExitCode, mutOutput) = RunGhWithStdin("api graphql --input -", mutationRequest.ToJsonString());
         if (mutExitCode != 0)
         {
-            _logger.LogWarning("Failed to link branch {Branch} to {Repo}#{Issue}: {Output}",
+            _logger.LogWarning("Failed to create linked branch {Branch} for {Repo}#{Issue}: {Output}",
                 branchName, repo, issueNumber, mutOutput);
             return false;
         }
@@ -1024,7 +1025,7 @@ public sealed class GhCliService
             using var doc = JsonDocument.Parse(mutOutput);
             if (doc.RootElement.TryGetProperty("errors", out var errors))
             {
-                _logger.LogWarning("GraphQL errors linking branch {Branch} to {Repo}#{Issue}: {Errors}",
+                _logger.LogWarning("GraphQL errors creating linked branch {Branch} for {Repo}#{Issue}: {Errors}",
                     branchName, repo, issueNumber, errors.ToString());
                 return false;
             }
@@ -1034,7 +1035,7 @@ public sealed class GhCliService
             // Best-effort error check — if parsing fails, assume success
         }
 
-        _logger.LogInformation("Linked branch {Branch} to {Repo}#{Issue}", branchName, repo, issueNumber);
+        _logger.LogInformation("Created linked branch {Branch} for {Repo}#{Issue}", branchName, repo, issueNumber);
         return true;
     }
 }

--- a/src/copilotd/Services/ReconciliationEngine.cs
+++ b/src/copilotd/Services/ReconciliationEngine.cs
@@ -672,19 +672,20 @@ public sealed class ReconciliationEngine
                 continue;
             }
 
-            // For newly created worktrees, push the branch and link it to the issue
-            // so it's visible on the GitHub issue UI immediately (best-effort)
+            // For newly created worktrees, create the linked branch on GitHub first
+            // (that mutation creates the remote branch), then push locally to set
+            // upstream tracking. Both operations are best-effort.
             if (worktreeResult == WorktreeResult.CreatedNew && !string.IsNullOrEmpty(session.BranchName))
             {
-                // Push the branch to the remote and set up tracking
-                _processManager.PushBranch(session, config, state);
-
-                // Try to link the branch to the issue via GitHub's Development sidebar
                 var sha = _processManager.GetHeadSha(session);
                 if (sha is not null)
                 {
-                    _ghCli.LinkBranchToIssue(session.Repo, session.IssueNumber, session.BranchName, sha);
+                    _ghCli.CreateLinkedBranchForIssue(session.Repo, session.IssueNumber, session.BranchName, sha);
                 }
+
+                // Push the branch to the remote and set up tracking. If the linked branch
+                // was created successfully above, this becomes a no-op push plus upstream setup.
+                _processManager.PushBranch(session, config, state);
             }
 
             // We need the issue data for prompt building


### PR DESCRIPTION
## Summary
- create the linked issue branch on GitHub before pushing the local session branch
- send the plain branch name to createLinkedBranch instead of refs/heads/...
- keep the follow-up push to establish upstream tracking for the local worktree branch

## Root cause
createLinkedBranch creates the linked branch as part of the mutation. It does not associate an already-pushed branch with the issue, so the previous push-then-link order could not produce the GitHub issue UI association.

Fixes #173