### PR TITLE
Anchor lifecycle reactions to redispatch comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,9 +251,9 @@ stateDiagram-v2
 | **Orphaned** | **Pending** | Retry eligible (retry count < 3) — exponential backoff: 2^n minutes, capped at 30m |
 | **Orphaned** | **Failed** | Max retries (3) exceeded |
 | **Failed** | **Pending** | Issue still matches and retry count < 3 |
-| **WaitingForFeedback** | **Pending** | New comment detected from a trusted author (not posted by copilotd) — re-dispatched with same session ID for `--resume` context continuity. Author trust is controlled by `trust_level` rule setting |
+| **WaitingForFeedback** | **Pending** | New comment detected from a trusted author (not posted by copilotd) — re-dispatched with same session ID for `--resume` context continuity, and the lifecycle reaction moves to that triggering issue comment. Author trust is controlled by `trust_level` rule setting |
 | **WaitingForFeedback** | **Completed** | Issue no longer matches rules while waiting |
-| **WaitingForReview** | **Pending** | New review comment or changes-requested review detected on the PR — re-dispatched with PR review prompt |
+| **WaitingForReview** | **Pending** | New review comment or changes-requested review detected on the PR, or a new trusted issue comment is added while review is pending — re-dispatched with the appropriate resume prompt. Issue-comment redispatches move the lifecycle reaction to the triggering issue comment |
 | **WaitingForReview** | **Completed** | PR is merged or closed, or issue no longer matches rules |
 | **Completed** | **Pending** | Issue re-matches rules (e.g., reopened) — only if not explicitly completed by copilot |
 | Any non-terminal | **Completed** | Copilot calls `copilotd session complete` — sets `CompletedBySession` flag, prevents re-dispatch |
@@ -276,7 +276,7 @@ When a copilot session encounters an issue that needs more information before wo
 2. The comment is posted to the GitHub issue (with a hidden `<!-- posted by copilotd -->` marker)
 3. The session transitions to **WaitingForFeedback** — the copilot process exits, no instance slot is consumed
 4. On each poll cycle, the reconciler checks for new comments on the issue (ignoring copilotd-posted comments)
-5. When a new comment is detected, the session is re-dispatched with `--resume` to preserve the full conversation context
+5. When a new trusted comment is detected, the session is re-dispatched with `--resume` to preserve the full conversation context, and the lifecycle reaction moves from the issue body to that specific comment
 6. The model can then decide to start coding or ask further questions (multiple rounds supported)
 
 The default prompt instructs copilot sessions to use this flow when they need clarification.
@@ -288,12 +288,12 @@ When a copilot session creates a pull request, it can enter a review monitoring 
 1. The session calls `copilotd session pr <pr-number> <issue>` after pushing a PR
 2. The session transitions to **WaitingForReview** — the copilot process exits, no instance slot is consumed
 3. On each poll cycle, the reconciler checks for new PR review comments, formal reviews (`CHANGES_REQUESTED` or `COMMENTED`), and falls back to checking issue comments
-4. When review feedback is detected, the session is re-dispatched with a PR-specific prompt that instructs copilot to address the feedback
+4. When PR review feedback is detected, the session is re-dispatched with a PR-specific prompt that instructs copilot to address the feedback; when a trusted issue comment triggers the re-dispatch instead, the normal issue-feedback resume prompt is used
 5. The existing worktree is refreshed (`git fetch` + `git pull --ff-only`) rather than recreated, preserving any local state
 6. Copilot addresses the feedback, pushes changes to the existing PR, and calls `session pr` again to continue the loop
 7. If the PR is merged or closed, the session is automatically completed
 
-The default prompt instructs copilot sessions to use `session pr` after creating a pull request. Multiple review rounds are supported — the session resumes with `--resume` for full conversation context continuity.
+The default prompt instructs copilot sessions to use `session pr` after creating a pull request. Multiple review rounds are supported — the session resumes with `--resume` for full conversation context continuity. For the issue-comment paths above, the lifecycle reaction follows the latest trusted issue comment; full PR-feedback anchoring remains future work.
 
 When re-dispatched for PR review, copilot is instructed to interact with the PR directly:
 - **General comments** — posted to the PR via `gh pr comment`

--- a/src/copilotd/Commands/SessionCommand.cs
+++ b/src/copilotd/Commands/SessionCommand.cs
@@ -365,6 +365,7 @@ public static class SessionCommand
                 string? expectedSessionId = null;
                 string? errorMessage = null;
                 long? oldReactionId = null;
+                var oldReactionAnchor = ReactionAnchor.IssueBody;
                 string? ruleName = null;
                 string? machineIdentifier = null;
 
@@ -386,6 +387,7 @@ public static class SessionCommand
                     issueNumber = session.IssueNumber;
                     expectedSessionId = session.CopilotSessionId;
                     oldReactionId = session.IssueReactionId;
+                    oldReactionAnchor = session.GetReactionAnchor();
                     ruleName = session.RuleName;
 
                     machineIdentifier = stateStore.EnsureMachineIdentifier(ct);
@@ -444,7 +446,7 @@ public static class SessionCommand
 
                 // Best-effort reaction transition: 🚀 → 👀 (waiting for feedback)
                 TransitionReactionBestEffort(stateStore, ghCli, config, issueKey, expectedSessionId!,
-                    repo!, issueNumber, ruleName!, oldReactionId,
+                    repo!, issueNumber, ruleName!, oldReactionAnchor, oldReactionId, ReactionAnchor.IssueBody,
                     GhCliService.ReactionEyes, ct);
 
                 return 0;
@@ -482,6 +484,7 @@ public static class SessionCommand
                 string? reactionRepo = null;
                 int reactionIssueNumber = 0;
                 long? oldReactionId = null;
+                var oldReactionAnchor = ReactionAnchor.IssueBody;
                 string? reactionSessionId = null;
                 string? reactionRuleName = null;
 
@@ -510,6 +513,7 @@ public static class SessionCommand
                     reactionRepo = session.Repo;
                     reactionIssueNumber = session.IssueNumber;
                     oldReactionId = session.IssueReactionId;
+                    oldReactionAnchor = session.GetReactionAnchor();
                     reactionSessionId = session.CopilotSessionId;
                     reactionRuleName = session.RuleName;
 
@@ -533,7 +537,7 @@ public static class SessionCommand
 
                 // Best-effort reaction transition: 🚀 → 👍
                 TransitionReactionBestEffort(stateStore, ghCli, config, issueKey, reactionSessionId!,
-                    reactionRepo!, reactionIssueNumber, reactionRuleName!, oldReactionId,
+                    reactionRepo!, reactionIssueNumber, reactionRuleName!, oldReactionAnchor, oldReactionId, oldReactionAnchor,
                     GhCliService.ReactionThumbsUp, ct);
 
                 return 0;
@@ -581,6 +585,7 @@ public static class SessionCommand
                 string? reactionRepo = null;
                 int reactionIssueNumber = 0;
                 long? oldReactionId = null;
+                var oldReactionAnchor = ReactionAnchor.IssueBody;
                 string? reactionSessionId = null;
                 string? reactionRuleName = null;
 
@@ -610,6 +615,7 @@ public static class SessionCommand
                     reactionRepo = session.Repo;
                     reactionIssueNumber = session.IssueNumber;
                     oldReactionId = session.IssueReactionId;
+                    oldReactionAnchor = session.GetReactionAnchor();
                     reactionSessionId = session.CopilotSessionId;
                     reactionRuleName = session.RuleName;
 
@@ -627,7 +633,7 @@ public static class SessionCommand
 
                 // Best-effort reaction transition: 🚀 → 👀 (waiting for review)
                 TransitionReactionBestEffort(stateStore, ghCli, config, issueKey, reactionSessionId!,
-                    reactionRepo!, reactionIssueNumber, reactionRuleName!, oldReactionId,
+                    reactionRepo!, reactionIssueNumber, reactionRuleName!, oldReactionAnchor, oldReactionId, ReactionAnchor.IssueBody,
                     GhCliService.ReactionEyes, ct);
 
                 return 0;
@@ -665,6 +671,7 @@ public static class SessionCommand
                 string? reactionRepo = null;
                 int reactionIssueNumber = 0;
                 long? oldReactionId = null;
+                var oldReactionAnchor = ReactionAnchor.IssueBody;
                 string? reactionRuleName = null;
 
                 stateStore.WithStateLock(() =>
@@ -686,6 +693,7 @@ public static class SessionCommand
                     reactionRepo = session.Repo;
                     reactionIssueNumber = session.IssueNumber;
                     oldReactionId = session.IssueReactionId;
+                    oldReactionAnchor = session.GetReactionAnchor();
                     reactionRuleName = session.RuleName;
 
                     processManager.TerminateProcess(session.IssueKey, session.ProcessId, session.ProcessStartTime);
@@ -705,6 +713,7 @@ public static class SessionCommand
                     session.LastRedispatchWasIssueComment = false;
                     session.LastFailureAt = null;
                     session.WaitingSince = null;
+                    session.SetReactionAnchor(ReactionAnchor.IssueBody);
                     session.IssueReactionId = null;
                     session.UpdatedAt = DateTimeOffset.UtcNow;
                     newSessionId = session.CopilotSessionId;
@@ -727,7 +736,7 @@ public static class SessionCommand
 
                 // Best-effort: transition to 👀 (queued) for the reset session
                 TransitionReactionBestEffort(stateStore, ghCli, config, issueKey, newSessionId!,
-                    reactionRepo!, reactionIssueNumber, reactionRuleName!, oldReactionId,
+                    reactionRepo!, reactionIssueNumber, reactionRuleName!, oldReactionAnchor, oldReactionId, ReactionAnchor.IssueBody,
                     GhCliService.ReactionEyes, ct);
 
                 return 0;
@@ -1046,6 +1055,9 @@ public static class SessionCommand
             LastRedispatchWasIssueComment = session.LastRedispatchWasIssueComment,
             WorktreePath = session.WorktreePath,
             BranchName = session.BranchName,
+            IssueReactionId = session.IssueReactionId,
+            ReactionTargetType = session.ReactionTargetType,
+            ReactionTargetCommentId = session.ReactionTargetCommentId,
         };
 
     private static string GetResumeTargetDisplay(DispatchSession session)
@@ -1078,34 +1090,52 @@ public static class SessionCommand
 
     /// <summary>
     /// Best-effort reaction transition for use in session commands. Removes the old reaction,
-    /// adds the new one, and updates <see cref="DispatchSession.IssueReactionId"/> in a
-    /// second state lock with identity verification. Failures are logged but do not
-    /// affect the command's return code.
+    /// adds the new one on the requested anchor, and persists the updated anchor state in a
+    /// second state lock with identity verification. Failures are logged but do not affect
+    /// the command's return code.
     /// </summary>
     private static void TransitionReactionBestEffort(
         StateStore stateStore, GhCliService ghCli, CopilotdConfig config,
         string issueKey, string sessionId, string repo, int issueNumber,
-        string ruleName, long? oldReactionId, string? newContent, CancellationToken ct)
+        string ruleName, ReactionAnchor oldAnchor, long? oldReactionId, ReactionAnchor newAnchor,
+        string? newContent, CancellationToken ct)
     {
         if (!AreReactionsEnabled(config, ruleName))
             return;
 
         if (oldReactionId.HasValue)
-            ghCli.RemoveIssueReaction(repo, issueNumber, oldReactionId.Value);
+            RemoveReactionForAnchor(ghCli, repo, issueNumber, oldAnchor, oldReactionId.Value);
 
         long? newId = null;
         if (newContent is not null)
-            newId = ghCli.AddIssueReaction(repo, issueNumber, newContent);
+            newId = AddReactionForAnchor(ghCli, repo, issueNumber, newAnchor, newContent);
 
-        // Persist the new reaction ID with identity check to avoid clobbering a reset session
+        // Persist the new reaction state with identity check to avoid clobbering a reset session
         stateStore.WithStateLock(() =>
         {
             var state = stateStore.LoadState();
             if (state.Sessions.TryGetValue(issueKey, out var s) && s.CopilotSessionId == sessionId)
             {
+                s.SetReactionAnchor(newAnchor);
                 s.IssueReactionId = newId;
                 stateStore.SaveState(state);
             }
         }, ct);
+    }
+
+    private static long? AddReactionForAnchor(GhCliService ghCli, string repo, int issueNumber, ReactionAnchor anchor, string content)
+        => anchor.TargetType == ReactionTargetType.IssueComment && anchor.IssueCommentId.HasValue
+            ? ghCli.AddIssueCommentReaction(repo, anchor.IssueCommentId.Value, content)
+            : ghCli.AddIssueReaction(repo, issueNumber, content);
+
+    private static void RemoveReactionForAnchor(GhCliService ghCli, string repo, int issueNumber, ReactionAnchor anchor, long reactionId)
+    {
+        if (anchor.TargetType == ReactionTargetType.IssueComment && anchor.IssueCommentId.HasValue)
+        {
+            ghCli.RemoveIssueCommentReaction(repo, anchor.IssueCommentId.Value, reactionId);
+            return;
+        }
+
+        ghCli.RemoveIssueReaction(repo, issueNumber, reactionId);
     }
 }

--- a/src/copilotd/Models/JsonContext.cs
+++ b/src/copilotd/Models/JsonContext.cs
@@ -83,6 +83,41 @@ public sealed class TolerantSessionStatusConverter : JsonConverter<SessionStatus
 }
 
 /// <summary>
+/// AOT-compatible JSON converter for <see cref="ReactionTargetType"/> that gracefully handles
+/// unknown enum values by falling back to <see cref="ReactionTargetType.IssueBody"/>.
+/// </summary>
+public sealed class TolerantReactionTargetTypeConverter : JsonConverter<ReactionTargetType>
+{
+    public override ReactionTargetType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            var value = reader.GetString();
+            if (Enum.TryParse<ReactionTargetType>(value, ignoreCase: true, out var targetType))
+                return targetType;
+
+            return ReactionTargetType.IssueBody;
+        }
+
+        if (reader.TokenType == JsonTokenType.Number)
+        {
+            var intValue = reader.GetInt32();
+            if (Enum.IsDefined(typeof(ReactionTargetType), intValue))
+                return (ReactionTargetType)intValue;
+
+            return ReactionTargetType.IssueBody;
+        }
+
+        return ReactionTargetType.IssueBody;
+    }
+
+    public override void Write(Utf8JsonWriter writer, ReactionTargetType value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToString());
+    }
+}
+
+/// <summary>
 /// AOT-compatible JSON converter for <see cref="UpdateStatus"/> that gracefully handles
 /// unknown enum values by falling back to <see cref="UpdateStatus.None"/>.
 /// </summary>
@@ -227,7 +262,7 @@ public sealed class TolerantControlSessionStatusConverter : JsonConverter<Contro
     WriteIndented = true,
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-    Converters = [typeof(TolerantSessionStatusConverter), typeof(TolerantUpdateStatusConverter), typeof(TolerantPromptModeConverter), typeof(TolerantCommentTrustLevelConverter), typeof(TolerantAuthorModeConverter), typeof(TolerantControlSessionStatusConverter)])]
+    Converters = [typeof(TolerantSessionStatusConverter), typeof(TolerantReactionTargetTypeConverter), typeof(TolerantUpdateStatusConverter), typeof(TolerantPromptModeConverter), typeof(TolerantCommentTrustLevelConverter), typeof(TolerantAuthorModeConverter), typeof(TolerantControlSessionStatusConverter)])]
 [JsonSerializable(typeof(CopilotdConfig))]
 [JsonSerializable(typeof(DaemonState))]
 [JsonSerializable(typeof(DispatchRule))]

--- a/src/copilotd/Models/SessionState.cs
+++ b/src/copilotd/Models/SessionState.cs
@@ -73,6 +73,30 @@ public enum SessionStatus
 }
 
 /// <summary>
+/// The GitHub object currently hosting a session's lifecycle reaction.
+/// </summary>
+[JsonConverter(typeof(TolerantReactionTargetTypeConverter))]
+public enum ReactionTargetType
+{
+    /// <summary>The issue body is the current lifecycle anchor.</summary>
+    IssueBody,
+
+    /// <summary>A specific issue comment is the current lifecycle anchor.</summary>
+    IssueComment
+}
+
+/// <summary>
+/// Identifies the GitHub object that should host a session's lifecycle reaction.
+/// </summary>
+public readonly record struct ReactionAnchor(ReactionTargetType TargetType, long? IssueCommentId)
+{
+    public static ReactionAnchor IssueBody => new(ReactionTargetType.IssueBody, null);
+
+    public static ReactionAnchor ForIssueComment(long issueCommentId)
+        => new(ReactionTargetType.IssueComment, issueCommentId);
+}
+
+/// <summary>
 /// Tracks a single dispatched copilot session and its lifecycle.
 /// </summary>
 public sealed class DispatchSession
@@ -189,11 +213,23 @@ public sealed class DispatchSession
     public string? BranchName { get; set; }
 
     /// <summary>
-    /// The GitHub reaction ID currently posted on the issue by copilotd, for lifecycle tracking.
-    /// Used to remove the previous reaction when transitioning to a new state (e.g., 🚀→👍).
-    /// Null when no reaction has been posted or when reactions are disabled.
+    /// The GitHub reaction ID currently posted by copilotd for lifecycle tracking.
+    /// Kept under its legacy name for persisted-state compatibility.
     /// </summary>
     public long? IssueReactionId { get; set; }
+
+    /// <summary>
+    /// The GitHub object currently hosting the lifecycle reaction.
+    /// Defaults to <see cref="Models.ReactionTargetType.IssueBody"/> for compatibility
+    /// with state written before comment-targeted reactions were introduced.
+    /// </summary>
+    public ReactionTargetType ReactionTargetType { get; set; } = ReactionTargetType.IssueBody;
+
+    /// <summary>
+    /// The numeric issue comment ID when <see cref="ReactionTargetType"/> is
+    /// <see cref="Models.ReactionTargetType.IssueComment"/>.
+    /// </summary>
+    public long? ReactionTargetCommentId { get; set; }
 
     /// <summary>Maximum retries before giving up (0 = unlimited).</summary>
     public const int MaxRetries = 3;
@@ -204,6 +240,21 @@ public sealed class DispatchSession
     /// <summary>Whether this session can be re-dispatched.</summary>
     public bool CanRetry => Status is SessionStatus.Orphaned or SessionStatus.Failed
                             && RetryCount < MaxRetries;
+
+    /// <summary>Returns the current lifecycle reaction anchor for this session.</summary>
+    public ReactionAnchor GetReactionAnchor()
+        => ReactionTargetType == Models.ReactionTargetType.IssueComment && ReactionTargetCommentId.HasValue
+            ? ReactionAnchor.ForIssueComment(ReactionTargetCommentId.Value)
+            : ReactionAnchor.IssueBody;
+
+    /// <summary>Updates the current lifecycle reaction anchor.</summary>
+    public void SetReactionAnchor(ReactionAnchor anchor)
+    {
+        ReactionTargetType = anchor.TargetType;
+        ReactionTargetCommentId = anchor.TargetType == Models.ReactionTargetType.IssueComment
+            ? anchor.IssueCommentId
+            : null;
+    }
 }
 
 /// <summary>

--- a/src/copilotd/Services/GhCliService.cs
+++ b/src/copilotd/Services/GhCliService.cs
@@ -476,7 +476,7 @@ public sealed class GhCliService
     /// <summary>
     /// Information about a new comment detected on an issue or PR.
     /// </summary>
-    public sealed record NewCommentInfo(string Author, DateTimeOffset CreatedAt);
+    public sealed record NewCommentInfo(string Author, DateTimeOffset CreatedAt, long? IssueCommentId = null);
 
     /// <summary>
     /// Checks whether there are new comments on an issue since the given timestamp,
@@ -491,7 +491,7 @@ public sealed class GhCliService
     /// </summary>
     public NewCommentInfo? GetNewCommentSince(string repo, int issueNumber, DateTimeOffset since)
     {
-        var args = $"issue view {issueNumber} --repo {repo} --json comments";
+        var args = $"api repos/{repo}/issues/{issueNumber}/comments?per_page=100";
         var (exitCode, output) = RunGh(args);
         if (exitCode != 0)
         {
@@ -502,12 +502,12 @@ public sealed class GhCliService
         try
         {
             using var doc = JsonDocument.Parse(output);
-            if (!doc.RootElement.TryGetProperty("comments", out var comments))
+            if (doc.RootElement.ValueKind != JsonValueKind.Array)
                 return null;
 
-            foreach (var comment in comments.EnumerateArray())
+            foreach (var comment in doc.RootElement.EnumerateArray())
             {
-                if (!comment.TryGetProperty("createdAt", out var createdAtEl))
+                if (!comment.TryGetProperty("created_at", out var createdAtEl))
                     continue;
 
                 var createdAtStr = createdAtEl.GetString();
@@ -525,12 +525,13 @@ public sealed class GhCliService
                         continue;
                 }
 
-                var author = comment.TryGetProperty("author", out var a) && a.TryGetProperty("login", out var l)
+                var author = comment.TryGetProperty("user", out var a) && a.TryGetProperty("login", out var l)
                     ? l.GetString() ?? "unknown"
                     : "unknown";
+                var commentId = comment.TryGetProperty("id", out var idEl) ? idEl.GetInt64() : (long?)null;
 
                 _logger.LogDebug("Found new comment on {Repo}#{Issue} from {Author}", repo, issueNumber, author);
-                return new NewCommentInfo(author, createdAt);
+                return new NewCommentInfo(author, createdAt, commentId);
             }
 
             return null;
@@ -783,16 +784,40 @@ public sealed class GhCliService
     internal const string ReactionThumbsDown = "-1";
 
     /// <summary>
-    /// Adds a reaction emoji to a GitHub issue. Returns the reaction ID for later removal,
+    /// Adds a reaction emoji to a GitHub issue body. Returns the reaction ID for later removal,
     /// or null on failure. Best-effort: failures are logged but do not block session lifecycle.
     /// </summary>
     public long? AddIssueReaction(string repo, int issueNumber, string content)
+        => AddReaction($"repos/{repo}/issues/{issueNumber}/reactions", content, $"{repo}#{issueNumber}");
+
+    /// <summary>
+    /// Adds a reaction emoji to a GitHub issue comment. Returns the reaction ID for later removal,
+    /// or null on failure. Best-effort: failures are logged but do not block session lifecycle.
+    /// </summary>
+    public long? AddIssueCommentReaction(string repo, long issueCommentId, string content)
+        => AddReaction($"repos/{repo}/issues/comments/{issueCommentId}/reactions", content, $"{repo} issue comment {issueCommentId}");
+
+    /// <summary>
+    /// Removes a reaction from a GitHub issue body by reaction ID. Returns true on success.
+    /// Best-effort: failures are logged but do not block session lifecycle.
+    /// </summary>
+    public bool RemoveIssueReaction(string repo, int issueNumber, long reactionId)
+        => RemoveReaction($"repos/{repo}/issues/{issueNumber}/reactions/{reactionId}", reactionId, $"{repo}#{issueNumber}");
+
+    /// <summary>
+    /// Removes a reaction from a GitHub issue comment by reaction ID. Returns true on success.
+    /// Best-effort: failures are logged but do not block session lifecycle.
+    /// </summary>
+    public bool RemoveIssueCommentReaction(string repo, long issueCommentId, long reactionId)
+        => RemoveReaction($"repos/{repo}/issues/comments/{issueCommentId}/reactions/{reactionId}", reactionId, $"{repo} issue comment {issueCommentId}");
+
+    private long? AddReaction(string endpoint, string content, string targetDescription)
     {
-        var args = $"api repos/{repo}/issues/{issueNumber}/reactions -f content={content}";
+        var args = $"api {endpoint} -f content={content}";
         var (exitCode, output) = RunGh(args);
         if (exitCode != 0)
         {
-            _logger.LogWarning("Failed to add {Reaction} reaction on {Repo}#{Issue}: {Output}", content, repo, issueNumber, output);
+            _logger.LogWarning("Failed to add {Reaction} reaction on {Target}: {Output}", content, targetDescription, output);
             return null;
         }
 
@@ -805,24 +830,21 @@ public sealed class GhCliService
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to parse reaction response for {Repo}#{Issue}", repo, issueNumber);
+            _logger.LogWarning(ex, "Failed to parse reaction response for {Target}", targetDescription);
             return null;
         }
     }
 
-    /// <summary>
-    /// Removes a reaction from a GitHub issue by reaction ID. Returns true on success.
-    /// Best-effort: failures are logged but do not block session lifecycle.
-    /// </summary>
-    public bool RemoveIssueReaction(string repo, int issueNumber, long reactionId)
+    private bool RemoveReaction(string endpoint, long reactionId, string targetDescription)
     {
-        var args = $"api repos/{repo}/issues/{issueNumber}/reactions/{reactionId} -X DELETE";
+        var args = $"api {endpoint} -X DELETE";
         var (exitCode, _) = RunGh(args);
         if (exitCode != 0)
         {
-            _logger.LogWarning("Failed to remove reaction {Id} from {Repo}#{Issue}", reactionId, repo, issueNumber);
+            _logger.LogWarning("Failed to remove reaction {Id} from {Target}", reactionId, targetDescription);
             return false;
         }
+
         return true;
     }
 

--- a/src/copilotd/Services/ReconciliationEngine.cs
+++ b/src/copilotd/Services/ReconciliationEngine.cs
@@ -278,7 +278,7 @@ public sealed class ReconciliationEngine
                     session.FailureDetail = null;
                     session.WaitingSince = null;
                     session.UpdatedAt = DateTimeOffset.UtcNow;
-                    TransitionReaction(session, config, null);
+                    TransitionReactionOnCurrentAnchor(session, config, null);
                     _processManager.CleanupWorktree(session, config, state);
                     continue;
                 }
@@ -291,7 +291,7 @@ public sealed class ReconciliationEngine
                     session.FailureDetail = null;
                     session.WaitingSince = null;
                     session.UpdatedAt = DateTimeOffset.UtcNow;
-                    TransitionReaction(session, config, null);
+                    TransitionReactionOnCurrentAnchor(session, config, null);
                     _processManager.CleanupWorktree(session, config, state);
                     continue;
                 }
@@ -314,7 +314,7 @@ public sealed class ReconciliationEngine
                 session.Status = SessionStatus.Completed;
                 session.FailureDetail = null;
                 session.UpdatedAt = DateTimeOffset.UtcNow;
-                TransitionReaction(session, config, null);
+                TransitionReactionOnCurrentAnchor(session, config, null);
                 _processManager.CleanupWorktree(session, config, state);
             }
         }
@@ -387,7 +387,10 @@ public sealed class ReconciliationEngine
                                 existing.ProcessId = null;
                                 existing.ProcessStartTime = null;
                                 existing.UpdatedAt = DateTimeOffset.UtcNow;
-                                // 👀 stays — it was set when entering WaitingForFeedback
+                                if (commentInfo.IssueCommentId.HasValue)
+                                    TransitionReactionToIssueComment(existing, config, commentInfo.IssueCommentId.Value, GhCliService.ReactionEyes);
+                                else
+                                    TransitionReactionToIssue(existing, config, GhCliService.ReactionEyes);
                             }
                             else
                             {
@@ -412,7 +415,7 @@ public sealed class ReconciliationEngine
                                 existing.ProcessId = null;
                                 existing.ProcessStartTime = null;
                                 existing.UpdatedAt = DateTimeOffset.UtcNow;
-                                TransitionReaction(existing, config, GhCliService.ReactionThumbsUp);
+                                TransitionReactionOnCurrentAnchor(existing, config, GhCliService.ReactionThumbsUp);
                                 _processManager.CleanupWorktree(existing, config, state);
                                 continue;
                             }
@@ -513,6 +516,10 @@ public sealed class ReconciliationEngine
                                 existing.ProcessId = null;
                                 existing.ProcessStartTime = null;
                                 existing.UpdatedAt = DateTimeOffset.UtcNow;
+                                if (issueCommentInfo.IssueCommentId.HasValue)
+                                    TransitionReactionToIssueComment(existing, config, issueCommentInfo.IssueCommentId.Value, GhCliService.ReactionEyes);
+                                else
+                                    TransitionReactionToIssue(existing, config, GhCliService.ReactionEyes);
                             }
                             else
                             {
@@ -539,7 +546,7 @@ public sealed class ReconciliationEngine
                         existing.LastVerifiedAt = null;
                         existing.UpdatedAt = DateTimeOffset.UtcNow;
                         existing.LastFailureAt = DateTimeOffset.UtcNow;
-                        TransitionReaction(existing, config, GhCliService.ReactionEyes);
+                        TransitionReactionOnCurrentAnchor(existing, config, GhCliService.ReactionEyes);
                         continue;
 
                     case SessionStatus.Orphaned:
@@ -551,7 +558,7 @@ public sealed class ReconciliationEngine
                             existing.FailureDetail ??= $"The session exceeded the maximum retry count ({DispatchSession.MaxRetries}). " +
                                 $"Resolve the underlying issue, then run 'copilotd session reset {issueKey}'.";
                             existing.UpdatedAt = DateTimeOffset.UtcNow;
-                            TransitionReaction(existing, config, GhCliService.ReactionThumbsDown);
+                            TransitionReactionOnCurrentAnchor(existing, config, GhCliService.ReactionThumbsDown);
                             continue;
                         }
                         continue;
@@ -578,7 +585,7 @@ public sealed class ReconciliationEngine
                         existing.ProcessStartTime = null;
                         existing.LastVerifiedAt = null;
                         existing.UpdatedAt = DateTimeOffset.UtcNow;
-                        TransitionReaction(existing, config, GhCliService.ReactionEyes);
+                        TransitionReactionToIssue(existing, config, GhCliService.ReactionEyes);
                         continue;
                 }
             }
@@ -601,7 +608,7 @@ public sealed class ReconciliationEngine
                 state.Sessions[issueKey] = newSession;
 
                 _logger.LogInformation("New issue {Key} matched by rule '{Rule}', creating pending dispatch", issueKey, ruleName);
-                TransitionReaction(newSession, config, GhCliService.ReactionEyes);
+                TransitionReactionToIssue(newSession, config, GhCliService.ReactionEyes);
             }
         }
     }
@@ -647,7 +654,7 @@ public sealed class ReconciliationEngine
                         _logger.LogWarning("Copilot folder trust missing for {Key}: {Folders}",
                             session.IssueKey, string.Join(", ", trustCheck.MissingFolders));
                         MarkSessionFailed(session, BuildTrustFailureDetail(session, trustCheck));
-                        TransitionReaction(session, config, GhCliService.ReactionThumbsDown);
+                        TransitionReactionOnCurrentAnchor(session, config, GhCliService.ReactionThumbsDown);
                         _stateStore.SaveState(state);
                         continue;
 
@@ -667,7 +674,7 @@ public sealed class ReconciliationEngine
                 _logger.LogWarning("Failed to prepare worktree for {Key}", session.IssueKey);
                 MarkSessionFailed(session,
                     $"Failed to prepare the git worktree for dispatch. Verify the local clone for {session.Repo} is healthy, then run 'copilotd session reset {session.IssueKey}'.");
-                TransitionReaction(session, config, GhCliService.ReactionThumbsDown);
+                TransitionReactionOnCurrentAnchor(session, config, GhCliService.ReactionThumbsDown);
                 _stateStore.SaveState(state);
                 continue;
             }
@@ -701,14 +708,14 @@ public sealed class ReconciliationEngine
                 _logger.LogWarning("Failed to launch copilot for {Key}", session.IssueKey);
                 MarkSessionFailed(session,
                     $"Failed to launch the Copilot CLI process. Review the copilotd logs, then run 'copilotd session reset {session.IssueKey}'.");
-                TransitionReaction(session, config, GhCliService.ReactionThumbsDown);
+                TransitionReactionOnCurrentAnchor(session, config, GhCliService.ReactionThumbsDown);
                 // Clean up the worktree we just created
                 _processManager.CleanupWorktree(session, config, state);
             }
             else
             {
                 // Session launched successfully — indicate active work
-                TransitionReaction(session, config, GhCliService.ReactionRocket);
+                TransitionReactionOnCurrentAnchor(session, config, GhCliService.ReactionRocket);
             }
 
             // Save state after each launch to prevent ghost processes on crash
@@ -828,24 +835,58 @@ public sealed class ReconciliationEngine
     }
 
     /// <summary>
-    /// Transitions the reaction on a session's issue. Removes the existing reaction (if any),
-    /// then adds a new one (if specified). Updates <see cref="DispatchSession.IssueReactionId"/>.
+    /// Transitions the lifecycle reaction while keeping the current anchor.
+    /// </summary>
+    private void TransitionReactionOnCurrentAnchor(DispatchSession session, CopilotdConfig config, string? newContent)
+        => TransitionReaction(session, config, session.GetReactionAnchor(), newContent);
+
+    /// <summary>
+    /// Transitions the lifecycle reaction onto the issue body.
+    /// </summary>
+    private void TransitionReactionToIssue(DispatchSession session, CopilotdConfig config, string? newContent)
+        => TransitionReaction(session, config, ReactionAnchor.IssueBody, newContent);
+
+    /// <summary>
+    /// Transitions the lifecycle reaction onto a specific issue comment.
+    /// </summary>
+    private void TransitionReactionToIssueComment(DispatchSession session, CopilotdConfig config, long issueCommentId, string? newContent)
+        => TransitionReaction(session, config, ReactionAnchor.ForIssueComment(issueCommentId), newContent);
+
+    /// <summary>
+    /// Transitions the lifecycle reaction to the requested anchor and content.
     /// Best-effort: failures are logged but do not block session lifecycle.
     /// </summary>
-    private void TransitionReaction(DispatchSession session, CopilotdConfig config, string? newContent)
+    private void TransitionReaction(DispatchSession session, CopilotdConfig config, ReactionAnchor anchor, string? newContent)
     {
         if (!AreReactionsEnabled(config, session.RuleName))
             return;
 
         if (session.IssueReactionId.HasValue)
         {
-            _ghCli.RemoveIssueReaction(session.Repo, session.IssueNumber, session.IssueReactionId.Value);
+            RemoveReaction(session, session.GetReactionAnchor(), session.IssueReactionId.Value);
             session.IssueReactionId = null;
         }
 
-        if (newContent is not null)
+        session.SetReactionAnchor(anchor);
+        if (newContent is null)
+            return;
+
+        session.IssueReactionId = AddReaction(session, anchor, newContent);
+    }
+
+    private long? AddReaction(DispatchSession session, ReactionAnchor anchor, string content)
+        => anchor.TargetType == ReactionTargetType.IssueComment && anchor.IssueCommentId.HasValue
+            ? _ghCli.AddIssueCommentReaction(session.Repo, anchor.IssueCommentId.Value, content)
+            : _ghCli.AddIssueReaction(session.Repo, session.IssueNumber, content);
+
+    private void RemoveReaction(DispatchSession session, ReactionAnchor anchor, long reactionId)
+    {
+        if (anchor.TargetType == ReactionTargetType.IssueComment && anchor.IssueCommentId.HasValue)
         {
-            session.IssueReactionId = _ghCli.AddIssueReaction(session.Repo, session.IssueNumber, newContent);
+            _ghCli.RemoveIssueCommentReaction(session.Repo, anchor.IssueCommentId.Value, reactionId);
+            return;
         }
+
+        _ghCli.RemoveIssueReaction(session.Repo, session.IssueNumber, reactionId);
     }
 }


### PR DESCRIPTION
## Summary
- track lifecycle reactions against either the issue body or a specific issue comment
- move reactions onto the triggering issue comment when trusted issue comments redispatch sessions from WaitingForFeedback or WaitingForReview
- keep later lifecycle transitions on the current anchor, while fresh lifecycle starts such as new dispatches and resets return to the issue body

Closes #174.

## Validation
- dotnet build src/copilotd/copilotd.csproj -nologo
- live validation against temporary issue #179 with an isolated COPILOTD_HOME: verified WaitingForFeedback and WaitingForReview issue-comment redispatches moved reactions onto the correct comments, completion stayed on the current comment anchor, reset returned the reaction to the issue body, and cleanup artifacts were removed afterward