### PR TITLE
Optimize CI and PR workflow critical paths

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -21,7 +21,7 @@ runs:
     - name: Setup .NET
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
       with:
-        dotnet-version: '10.0.x'
+        global-json-file: global.json
 
     - name: Restore
       shell: bash

--- a/.github/actions/publish-native/action.yml
+++ b/.github/actions/publish-native/action.yml
@@ -21,7 +21,7 @@ runs:
     - name: Setup .NET
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
       with:
-        dotnet-version: '10.0.x'
+        global-json-file: global.json
 
     - name: Publish native asset
       shell: pwsh

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
         with:
-          dotnet-version: '10.0.x'
+          global-json-file: global.json
 
       - name: Calculate new version state
         id: version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
         with:
-          dotnet-version: '10.0.x'
+          global-json-file: global.json
 
       - name: Calculate version
         id: version
@@ -98,23 +98,8 @@ jobs:
         shell: bash
         run: ./scripts/verify-shell-syntax.sh
 
-  build:
-    runs-on: ubuntu-latest
-    needs: [version, validate-powershell-scripts, validate-shell-scripts]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-
-      - name: Build
-        uses: ./.github/actions/build
-        with:
-          version: ${{ needs.version.outputs.version }}
-          validate-native-aot: 'true'
-          aot-runtime-identifier: linux-x64
-
   publish-dev:
-    needs: [version, build]
+    needs: [version, validate-powershell-scripts, validate-shell-scripts]
     strategy:
       fail-fast: false
       matrix:
@@ -152,7 +137,7 @@ jobs:
           artifact-name: native-dev-${{ matrix.rid }}
 
   publish-rc:
-    needs: [version, build]
+    needs: [version, validate-powershell-scripts, validate-shell-scripts]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/install-scripts.yml
+++ b/.github/workflows/install-scripts.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
         with:
-          dotnet-version: '10.0.x'
+          global-json-file: global.json
 
       - name: Stage install script
         shell: pwsh

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,6 +2,8 @@ name: PR
 
 on:
   pull_request:
+    paths-ignore:
+      - '**/*.md'
 
 concurrency:
   group: pr-${{ github.ref }}
@@ -35,26 +37,14 @@ jobs:
         shell: bash
         run: ./scripts/verify-shell-syntax.sh
 
-  build:
-    needs: [validate-powershell-scripts, validate-shell-scripts]
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-
-      - name: Build
-        uses: ./.github/actions/build
-        with:
-          validate-native-aot: 'true'
-          aot-runtime-identifier: linux-x64
-
   publish-aot:
-    needs: [build]
+    needs: [validate-powershell-scripts, validate-shell-scripts]
     strategy:
       fail-fast: false
       matrix:
         include:
+          - runner: ubuntu-22.04
+            rid: linux-x64
           - runner: windows-latest
             rid: win-x64
           - runner: ubuntu-22.04-arm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
         with:
-          dotnet-version: '10.0.x'
+          global-json-file: global.json
 
       - name: Get version state and CI run
         id: version
@@ -185,7 +185,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
         with:
-          dotnet-version: '10.0.x'
+          global-json-file: global.json
 
       - name: Azure login
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43
@@ -255,7 +255,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
         with:
-          dotnet-version: '10.0.x'
+          global-json-file: global.json
 
       - name: Download unsigned release bundle
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c


### PR DESCRIPTION
## Summary
- skip PR workflow runs for markdown-only changes
- remove redundant standalone build gates from PR and CI so publish legs start immediately while preserving native publish verification
- make setup-dotnet honor the repo's global.json across workflow entry points

Closes #114.

## Baseline
- recent PR workflow runs: ~2.65m-3.78m
- run 24941619921 completed in 2.78m with a 0.73m standalone build gate before publish matrix work
- recent CI workflow runs: ~3.43m-7.57m
- run 24941720761 completed in 3.55m with the same redundant build gate before publish matrices

## Verification
- [x] inspected actual prior workflow runs and job timings
- [x] ensured the repository build still succeeds locally
- [x] verified draft PR workflow run 24941911971 succeeded in 2.12m with the expected 6-job shape: 2 script checks + 4 publish-aot legs including linux-x64
- [x] confirmed the redundant PR build gate was removed without reducing native publish verification coverage

## Notes
- ctions/setup-dotnet now honors global.json everywhere touched in this change
- I did not add package caching in this pass because the repo has no packages.lock.json, so the safe, measurable win was removing redundant critical-path work instead