### PR TITLE
Add pull request dispatch rules

### DIFF
--- a/.github/skills/copilotd-e2e-verification/SKILL.md
+++ b/.github/skills/copilotd-e2e-verification/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: copilotd-e2e-verification
+description: Perform real end-to-end validation of copilotd issue and pull request orchestration using live GitHub artifacts.
+---
+
+# copilotd end-to-end verification
+
+Use this skill when validating substantial copilotd orchestration changes, especially changes to dispatch rules, reconciliation, session lifecycle, worktree handling, prompt callbacks, or GitHub issue/PR feedback loops.
+
+## Goal
+
+Verify copilotd as a live reconciliation daemon, not just by build or command smoke tests. A good verification proves that real GitHub issues and pull requests move through the expected lifecycle, Copilot sessions can call back into copilotd, worktrees and state converge correctly, and temporary artifacts are cleaned up.
+
+## Optimum approach
+
+1. **Use an isolated copilotd home.** Set `COPILOTD_HOME` to a disposable directory such as `.\copilotd-home-e2e` or another task-specific path. Do not use the user's normal `~\.copilotd` state.
+2. **Start with local CLI validation.** Build the branch, then verify `config`, `rules add/list/update/delete`, invalid rule arguments, `status`, `session list --all`, and JSON persistence before creating live artifacts.
+3. **Use a real but safe target repository.** Prefer a repo already cloned locally and writable by the user. Configure `repo_home` so copilotd resolves the existing clone and creates sibling `<repo>_sessions` worktrees.
+4. **Create explicit temporary labels.** Use unique labels such as `copilotd-e2e-ready`, `copilotd-e2e-clarify`, and `copilotd-e2e-pr` so rules match only the verification artifacts.
+5. **Create at least two issue scenarios.**
+   - A ready-to-implement issue with small, deterministic acceptance criteria that should lead to a branch, commit, PR, `session pr`, and `WaitingForReview`.
+   - An intentionally ambiguous issue that should lead to `session comment`, `WaitingForFeedback`, a real clarification reply, and re-dispatch.
+6. **Create a PR rule that observes the issue-created PRs.** Add a PR dispatch rule using `--kind pr`, a temporary PR label, `--base`, and a safe branch strategy such as `read-only` for validation-only sessions.
+7. **Drive the full feedback loop.** After issue sessions create PRs, let the PR rule launch PR-root validation sessions. Ensure those sessions comment on the PR. Then add a manual PR comment or review from a trusted user without a copilotd marker so the original issue-owned `WaitingForReview` session re-dispatches, pushes a follow-up commit, and returns to `WaitingForReview`.
+8. **Observe state and GitHub together.** Cross-check `state.json`, `copilotd session list --all`, issue comments, PR comments, PR labels, PR commits, and local git worktrees. Do not trust a single surface.
+9. **Keep a journal.** Record every issue, workaround, and stop-worthy finding as it happens, including exact issue/PR numbers and whether the behavior was expected or a product problem.
+10. **Clean up aggressively.** Close temporary PRs without merging, close temporary issues, delete temporary branches/labels, stop daemon processes, remove isolated homes and temporary publish folders, prune worktrees, and verify the target repo returns to a clean default branch.
+
+## Important setup details
+
+- Run from source via `.\copilotd.ps1` first, as this matches normal development validation.
+- If unattended Copilot sessions block on callback commands like `dotnet run --project <copilotd-source> --no-build -- session ...`, publish copilotd outside the source tree and prepend that publish directory to `PATH`. Starting the daemon from a path outside the source tree makes callback prompts use `copilotd` instead of a `dotnet run --project ...` command outside the target repo trust scope.
+- Ensure Copilot trusted folders include both the target repo and the sibling `<repo>_sessions` directory. Missing trust should be treated as a real preflight/environment finding, then fixed so validation can continue.
+- Disable control sessions in the isolated config unless the control session itself is under test. This avoids extra remote sessions and unrelated worktrees.
+- Use low polling intervals such as `--interval 15` during verification, and enable `--log-level debug` so reconciliation decisions are visible.
+- If testing self-update is not in scope, set `COPILOTD_DISABLE_SELF_UPDATES=1` or pass `--disable-self-updates`.
+
+## Suggested live flow
+
+1. Build the branch under test.
+2. Create isolated `config.json` with:
+   - `repoHome` pointing at the parent folder that contains the target clone.
+   - `maxInstances` set high enough for the planned issue and PR sessions.
+   - `enableControlSession` set to `false` unless needed.
+   - one or more issue rules scoped to temporary labels and the target repo.
+   - one PR rule scoped to a temporary PR label, target repo, and base branch.
+3. Create temporary labels in the target repo.
+4. Create the ready and ambiguous issues.
+5. Start copilotd with the isolated home.
+6. Confirm the daemon matches the issues, creates pending sessions, creates worktrees, and launches Copilot processes.
+7. For the ambiguous issue, confirm a copilotd-authored issue comment appears and state enters `WaitingForFeedback`; reply with precise requirements and confirm re-dispatch.
+8. For ready issue sessions, confirm commits are pushed, PRs are opened, PRs get the PR-rule label, and issue sessions run `session pr` and enter `WaitingForReview`.
+9. Confirm PR-root sessions are created for the PRs and use the expected branch strategy/worktree layout.
+10. Confirm PR-root sessions complete and leave useful validation comments.
+11. Add manual trusted PR feedback to the PRs and confirm the original issue-owned sessions re-dispatch with `RedispatchCount` incremented, pushes follow-up commits, and returns to `WaitingForReview`.
+12. Close PRs and issues, then confirm reconciliation marks sessions completed and cleans up issue and PR worktrees.
+
+## What to inspect
+
+- `copilotd status`
+- `copilotd session list --all`
+- `copilotd session info <owner/repo#number>`
+- `COPILOTD_HOME\state.json`
+- daemon logs under `COPILOTD_HOME\logs\daemon_*`
+- recent Copilot logs under `~\.copilot\logs` when a session appears stuck
+- target repo `git worktree list`
+- target repo branch lists for stale `copilotd/*` branches
+- GitHub issue comments, PR comments, PR labels, PR commits, and PR state
+
+## Success criteria
+
+- Issue rules and PR rules match only intended temporary artifacts.
+- Ready issues produce working branches, commits, PRs, and `WaitingForReview` state.
+- Ambiguous issues ask a clarifying question, wait, and resume from a real issue reply.
+- PR rules dispatch PR-root sessions with the expected PR context and branch strategy.
+- PR feedback from a trusted non-copilotd comment re-dispatches the original issue-owned session.
+- Follow-up commits update the existing PR, not a new PR.
+- Closing or unmatching subjects completes sessions and cleans up local worktrees/branches.
+- All temporary GitHub and local artifacts are removed or explicitly retained for root-cause analysis.
+
+## Cleanup checklist
+
+- Close temporary PRs with a "do not merge" comment.
+- Close temporary issues with a verification cleanup comment.
+- Delete temporary remote branches and run `git fetch --prune`.
+- Delete temporary labels.
+- Stop copilotd and any shell wrappers used to host it.
+- Remove isolated `COPILOTD_HOME` folders and temporary publish folders.
+- Run `git worktree list` in the target repo and remove only worktrees created by this verification.
+- Confirm the target repo and copilotd repo have clean `git status` output.
+
+## Reporting findings
+
+Lead with what was verified, then list findings separately from environment prerequisites. For each issue, include:
+
+- the observed behavior,
+- the expected behavior,
+- whether it was blocking or worked around,
+- the exact workaround used, and
+- any artifacts retained for diagnosis.
+
+Do not fix product bugs during verification unless the user explicitly asks for follow-up implementation work.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # copilotd
 
-**copilotd** is an orchestration daemon that watches GitHub repos for issues matching configurable dispatch rules and automatically spawns remote-enabled [Copilot CLI](https://docs.github.com/copilot/how-tos/copilot-cli) sessions to work on them.
+**copilotd** is an orchestration daemon that watches GitHub repos for issues and pull requests matching configurable dispatch rules and automatically spawns remote-enabled [Copilot CLI](https://docs.github.com/copilot/how-tos/copilot-cli) sessions to work on them.
 
-Instead of waiting for a developer to open a terminal and manually engage Copilot, copilotd continuously monitors your repositories. When an issue matches your rules—by label, assignee, milestone, or type, it automatically dispatches a Copilot CLI agent, creates an isolated worktree, asks clarifying questions via issue comments, writes code, opens a PR, and even responds to PR review feedback. All without human intervention.
+Instead of waiting for a developer to open a terminal and manually engage Copilot, copilotd continuously monitors your repositories. When an issue or pull request matches your rules, it automatically dispatches a Copilot CLI agent, creates an isolated worktree, asks clarifying questions via comments, writes or reviews code, opens or updates PRs, and responds to PR review feedback. All without human intervention.
 
-copilotd sits between GitHub Issues and the Copilot CLI running on your dev machine, acting as an always-on orchestration layer.
+copilotd sits between GitHub Issues, pull requests, and the Copilot CLI running on your dev machine, acting as an always-on orchestration layer.
 
 Available for Windows, macOS, and Linux.
 
@@ -15,7 +15,8 @@ Available for Windows, macOS, and Linux.
 ## Features
 
 - **Issue watching** — polls GitHub repos for issues matching configurable rules (assigned user, labels, milestone, issue type)
-- **Automatic dispatch** — launches `copilot --remote` sessions with templated prompts derived from issue metadata
+- **PR watching** — opt-in pull request rules can dispatch review, validation, or follow-up sessions using PR metadata (labels, assignee, base/head branch, draft state, review decision)
+- **Automatic dispatch** — launches `copilot --remote` sessions with templated prompts derived from issue or PR metadata
 - **Named dispatch rules** — flexible, composable rules with per-rule launch options (`--yolo`, `--allow-all-tools`, `--allow-all-urls`, `--model`, extra prompts, repo assignments)
 - **Session lifecycle** — full state machine with retry, backoff, orphan recovery, investigation feedback loops, PR review monitoring, and explicit completion signaling
 - **PR review feedback** — sessions that create PRs can wait for review comments and automatically re-dispatch to address feedback
@@ -121,7 +122,7 @@ Installed copilotd binaries can self-update in the background: the daemon checks
 | `copilotd config` | Display current configuration |
 | `copilotd config --set key=value` | Set a config value (`repo_home`, `default_model`, `custom_prompt`, `session_name_format`, `max_instances`, `session_shutdown_delay_seconds`) |
 | `copilotd rules list` | List all dispatch rules (`copilotd rule list` also works) |
-| `copilotd rules add <name>` | Add a new dispatch rule (`copilotd rule create <name>` and `copilotd rule new <name>` also work) |
+| `copilotd rules add <name>` | Add a new issue dispatch rule (`copilotd rule create <name>` and `copilotd rule new <name>` also work); use `--kind pr` for pull request rules |
 | `copilotd rules update <name>` | Update an existing rule (`copilotd rule edit <name>` also works) |
 | `copilotd rules delete <name>` | Delete a rule (the `Default` rule cannot be deleted) |
 
@@ -143,7 +144,7 @@ File logs live under `~/.copilotd/logs` by default (or `COPILOTD_HOME/logs`). Ea
 
 ### Rules options
 
-Rules support conditions (`--assignee`, `--label`, `--milestone`, `--type`) and launch options (`--yolo`, `--allow-all-tools`, `--allow-all-urls`, `--model`, `--prompt`, `--custom-prompt`, `--custom-prompt-mode`, `--repo`). All conditions are logical AND.
+Issue rules support conditions (`--assignee`, `--label`, `--milestone`, `--type`) and launch options (`--yolo`, `--allow-all-tools`, `--allow-all-urls`, `--model`, `--prompt`, `--custom-prompt`, `--custom-prompt-mode`, `--repo`). Pull request rules are opt-in with `--kind pr` and support PR-specific conditions (`--base`, `--head`, `--head-repo`, `--draft`, `--review-decision`) plus `--branch-strategy`. All conditions are logical AND. `copilotd init` creates only the default issue rule; no PR rule is created by default.
 
 Aliases: `rule` for `rules`, `create`/`new` for `add`, and `edit` for `update`.
 
@@ -156,6 +157,9 @@ copilotd rules add "Complex tasks" --label complexity-high --model "claude-sonne
 
 # Add a rule with a per-rule custom prompt that overrides the global custom prompt
 copilotd rules add "Backend" --label area-backend --custom-prompt "Focus on API design" --custom-prompt-mode override
+
+# Add a PR review/validation rule
+copilotd rules add "PR validation" --kind pr --label needs-validation --base main --branch-strategy read-only --repo "org/repo"
 
 # Update labels on a rule
 copilotd rules update Default --delete-label copilotd --add-label dispatch
@@ -186,7 +190,15 @@ The built-in prompt and `session_name_format` support token replacement:
 | `$(issue.id)` | Issue number |
 | `$(issue.type)` | Issue type (e.g., `bug`) |
 | `$(issue.milestone)` | Milestone title |
-| `$(pr.id)` | Pull request number (available in PR review re-dispatch prompts) |
+| `$(subject.id)` | Root issue or pull request number |
+| `$(subject.kind)` | Root subject kind (`issue` or `pullrequest`) |
+| `$(subject.title)` | Root subject title when available |
+| `$(pr.id)` | Pull request number (the root PR for PR-dispatched sessions, or the review PR for issue-owned PR review prompts) |
+| `$(pr.title)` | Pull request title for PR-dispatched sessions |
+| `$(pr.base)` | Pull request base branch for PR-dispatched sessions |
+| `$(pr.head)` | Pull request head branch for PR-dispatched sessions |
+| `$(pr.head_repo)` | Pull request head repository for PR-dispatched sessions |
+| `$(pr.head_sha)` | Pull request head SHA for PR-dispatched sessions |
 | `$(org)` | Repository owner / organization |
 | `$(repo)` | Repository name only |
 | `$(issue_id)` | Issue number |
@@ -206,18 +218,18 @@ older persisted sessions that already have a resume ID continue to resume by ID.
 
 ## Session lifecycle
 
-Each dispatched copilot session follows a state machine:
+Each dispatched copilot session follows the same state machine whether the root subject is an issue or a pull request. Issue-root sessions can additionally enter `WaitingForReview` after they create a PR; PR-root sessions can be re-dispatched by trusted PR comments/reviews or by a new PR head SHA.
 
 ```mermaid
 stateDiagram-v2
-    [*] --> Pending : Issue matches rule
+    [*] --> Pending : Issue/PR matches rule
 
     Pending --> Dispatching : Launch
     Dispatching --> Running : Process alive
     Dispatching --> Failed : Launch failed
 
     Running --> Orphaned : Process died
-    Running --> Completed : Issue closed/unmatched (auto)
+    Running --> Completed : Subject closed/unmatched (auto)
     Running --> WaitingForFeedback : session comment
     Running --> WaitingForReview : session pr
 
@@ -240,11 +252,11 @@ stateDiagram-v2
 
 | From | To | Trigger |
 |------|----|---------|
-| *(new)* | **Pending** | Issue matches a dispatch rule |
+| *(new)* | **Pending** | Issue or pull request matches a dispatch rule |
 | **Pending** | **Dispatching** | Daemon launches copilot process (respects `max_instances` limit and retry backoff) |
 | **Dispatching** | **Running** | Process successfully started, PID tracked |
 | **Dispatching** | **Failed** | Process launch failed (increments retry count) |
-| **Running** | **Completed** | Issue no longer matches rules (closed, relabeled, etc.) — process gracefully terminated |
+| **Running** | **Completed** | Root issue or PR no longer matches rules (closed, relabeled, merged, etc.) — process gracefully terminated |
 | **Running** | **WaitingForFeedback** | Copilot calls `copilotd session comment` — process exits, session waits for new issue comments |
 | **Running** | **WaitingForReview** | Copilot calls `copilotd session pr <pr-number>` — process exits, session waits for PR review feedback |
 | **Running** | **Orphaned** | Process died unexpectedly (PID gone or reused) |
@@ -253,7 +265,7 @@ stateDiagram-v2
 | **Failed** | **Pending** | Issue still matches and retry count < 3 |
 | **WaitingForFeedback** | **Pending** | New comment detected from a trusted author (not posted by copilotd) — re-dispatched with same session ID for `--resume` context continuity, and the lifecycle reaction moves to that triggering issue comment. Author trust is controlled by `trust_level` rule setting |
 | **WaitingForFeedback** | **Completed** | Issue no longer matches rules while waiting |
-| **WaitingForReview** | **Pending** | New review comment or changes-requested review detected on the PR, or a new trusted issue comment is added while review is pending — re-dispatched with the appropriate resume prompt. Issue-comment redispatches move the lifecycle reaction to the triggering issue comment |
+| **WaitingForReview** | **Pending** | New review-thread reply, PR comment, or changes-requested/commented review detected on the PR, or a new trusted issue comment is added while review is pending — re-dispatched with the appropriate resume prompt. Issue-comment redispatches move the lifecycle reaction to the triggering issue comment |
 | **WaitingForReview** | **Completed** | PR is merged or closed, or issue no longer matches rules |
 | **Completed** | **Pending** | Issue re-matches rules (e.g., reopened) — only if not explicitly completed by copilot |
 | Any non-terminal | **Completed** | Copilot calls `copilotd session complete` — sets `CompletedBySession` flag, prevents re-dispatch |
@@ -294,6 +306,18 @@ When a copilot session creates a pull request, it can enter a review monitoring 
 7. If the PR is merged or closed, the session is automatically completed
 
 The default prompt instructs copilot sessions to use `session pr` after creating a pull request. Multiple review rounds are supported — the session resumes with `--resume` for full conversation context continuity. For the issue-comment paths above, the lifecycle reaction follows the latest trusted issue comment; full PR-feedback anchoring remains future work.
+
+### PR dispatch rules
+
+Pull request dispatch rules live in the separate `pull_request_rules` config collection and are not created by default. They use the same `org/repo#number` session key format as issue sessions, with a stored subject kind to distinguish PR-root sessions from issue-root sessions.
+
+PR rules support three worktree strategies:
+
+| Strategy | Behavior |
+|----------|----------|
+| `source-branch` | Default. For same-repo PRs, checks out a local `copilotd/pr-<N>-...` branch from the PR head and pushes changes back to the PR source branch. Fork PRs fail closed instead of pushing to an unintended remote. |
+| `child-branch` | Creates a new `copilotd/pr-<N>-...` branch from the PR head SHA and pushes that branch; the agent should explain how to use it from the PR. |
+| `read-only` | Creates a detached worktree at the PR head for review/validation/comment-only workflows and skips pushing. |
 
 When re-dispatched for PR review, copilot is instructed to interact with the PR directly:
 - **General comments** — posted to the PR via `gh pr comment`
@@ -424,6 +448,17 @@ When running from a source checkout via `copilotd.sh`, `copilotd.ps1`, or `copil
 | `custom_prompt_mode` | `append` | How rule custom prompt interacts with global: `append` or `override` |
 | `trust_level` | `collaborators` | Which comment authors can trigger session re-dispatch: `collaborators` (write access required), `all`, `issueAuthor`, `assignees`, `issueAuthorAndCollaborators`, or `matchDispatchRule` |
 
+Pull request rules support the shared settings above except issue-only `milestone` and `type`, and add these PR-specific settings:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `base_branch` | *(any)* | PR base branch to match |
+| `head_branch` | *(any)* | PR head branch to match |
+| `head_repo` | *(any)* | PR head repository in `org/repo` format |
+| `draft` | *(any)* | Match only draft (`true`) or ready (`false`) PRs |
+| `review_decision` | *(any)* | PR review decision to match, such as `CHANGES_REQUESTED`, `REVIEW_REQUIRED`, or `APPROVED` |
+| `branch_strategy` | `sourceBranch` | PR worktree/push behavior: `sourceBranch`, `childBranch`, or `readOnly` |
+
 File logs are written under `~/.copilotd/logs/` by default (or `COPILOTD_HOME\logs\` when `COPILOTD_HOME` is set):
 
 - Each daemon `run` instance writes to its own `logs\daemon_<uuid>\` folder
@@ -446,10 +481,10 @@ File logs are written under `~/.copilotd/logs/` by default (or `COPILOTD_HOME\lo
 
 ### Worktree isolation
 
-Each dispatched session works in its own git worktree on a new branch, ensuring:
+Each dispatched session works in its own git worktree, ensuring:
 - **No conflicts** between concurrent sessions on the same repo
-- **Clean starting state** from the latest default branch HEAD
-- **Isolated branches** — each session creates `copilotd/issue-<N>`
+- **Clean starting state** from the right source: issue sessions start from the latest default branch HEAD; PR sessions start from the PR head
+- **Isolated branches** — issue sessions create `copilotd/issue-<N>`; PR sessions use their configured branch strategy
 
 Directory layout:
 
@@ -457,6 +492,7 @@ Directory layout:
 <repo_home>/org/repo/                    ← main checkout (fetch-only base)
 <repo_home>/org/repo_sessions/issue-1/   ← worktree for issue #1
 <repo_home>/org/repo_sessions/issue-5/   ← worktree for issue #5
+<repo_home>/org/repo_sessions/pr-7/      ← worktree for pull request #7
 ```
 
 Worktrees are created before dispatch (`git fetch` + `git worktree add`) and cleaned up

--- a/README.md
+++ b/README.md
@@ -63,9 +63,10 @@ The `init` command is an interactive wizard that walks you through:
 1. **Dependency & auth checks** — verifies `gh` and `copilot` CLIs are installed (showing versions) and authenticated
 2. **Repo home** — where your repository clones live on disk
 3. **Global settings** — max concurrent sessions, default model
-4. **Default rule** — author filtering, required labels, tool permissions (yolo/allow-all-tools/allow-all-urls), model override
-5. **Repository selection** — pick which repos to watch (shows clone status)
-6. **Folder trust checks** — for cloned repos, prompts to add the repo path and daemon worktree root to Copilot's trusted folders when needed for unattended dispatch
+4. **Dispatch sources** — choose whether to dispatch from issues, pull requests, or both
+5. **Default issue and/or PR rules** — author filtering, required labels, tool permissions (yolo/allow-all-tools/allow-all-urls), model override, plus PR-specific branch settings when PR dispatch is enabled
+6. **Repository selection** — pick which repos to watch (shows clone status)
+7. **Folder trust checks** — for cloned repos, prompts to add the repo path and daemon worktree root to Copilot's trusted folders when needed for unattended dispatch
 
 After setup, a configuration summary and concrete next-step commands are displayed.
 
@@ -144,7 +145,7 @@ File logs live under `~/.copilotd/logs` by default (or `COPILOTD_HOME/logs`). Ea
 
 ### Rules options
 
-Issue rules support conditions (`--assignee`, `--label`, `--milestone`, `--type`) and launch options (`--yolo`, `--allow-all-tools`, `--allow-all-urls`, `--model`, `--prompt`, `--custom-prompt`, `--custom-prompt-mode`, `--repo`). Pull request rules are opt-in with `--kind pr` and support PR-specific conditions (`--base`, `--head`, `--head-repo`, `--draft`, `--review-decision`) plus `--branch-strategy`. All conditions are logical AND. `copilotd init` creates only the default issue rule; no PR rule is created by default.
+Issue rules support conditions (`--assignee`, `--label`, `--milestone`, `--type`) and launch options (`--yolo`, `--allow-all-tools`, `--allow-all-urls`, `--model`, `--prompt`, `--custom-prompt`, `--custom-prompt-mode`, `--repo`). Pull request rules are opt-in with `--kind pr` and support PR-specific conditions (`--base`, `--head`, `--head-repo`, `--draft`, `--review-decision`) plus `--branch-strategy`. All conditions are logical AND. `copilotd init` asks whether to create a default issue rule, a default PR rule, or both.
 
 Aliases: `rule` for `rules`, `create`/`new` for `add`, and `edit` for `update`.
 
@@ -309,7 +310,7 @@ The default prompt instructs copilot sessions to use `session pr` after creating
 
 ### PR dispatch rules
 
-Pull request dispatch rules live in the separate `pull_request_rules` config collection and are not created by default. They use the same `org/repo#number` session key format as issue sessions, with a stored subject kind to distinguish PR-root sessions from issue-root sessions.
+Pull request dispatch rules live in the separate `pull_request_rules` config collection and are opt-in. They can be created from `copilotd init` when you choose PR dispatch, or later with `copilotd rules add <name> --kind pr`. They use the same `org/repo#number` session key format as issue sessions, with a stored subject kind to distinguish PR-root sessions from issue-root sessions.
 
 PR rules support three worktree strategies:
 

--- a/src/copilotd/Commands/ConfigCommand.cs
+++ b/src/copilotd/Commands/ConfigCommand.cs
@@ -45,60 +45,60 @@ public static class ConfigCommand
                     table.AddRow("current_user", Markup.Escape(config.CurrentUser ?? "(not set)"));
                     table.AddRow("max_instances", Markup.Escape(config.MaxInstances.ToString()));
                     table.AddRow("session_shutdown_delay_seconds", Markup.Escape(config.SessionShutdownDelaySeconds.ToString()));
-                    table.AddRow("issue_rules", Markup.Escape($"{config.Rules.Count} rule(s)"));
+                    table.AddRow("issue_rules", Markup.Escape($"{config.IssueRules.Count} rule(s)"));
                     table.AddRow("pull_request_rules", Markup.Escape($"{config.PullRequestRules.Count} rule(s)"));
 
-                    if (config.Rules.Count > 0)
+                    if (config.IssueRules.Count > 0)
                     {
-                        foreach (var (name, rule) in config.Rules)
+                        foreach (var (name, issueRule) in config.IssueRules)
                         {
                             var details = new List<string>();
-                            if (rule.Assignee is not null) details.Add($"assignee={rule.Assignee}");
-                            if (rule.Labels.Count > 0) details.Add($"labels={string.Join(",", rule.Labels)}");
-                            if (rule.Milestone is not null) details.Add($"milestone={rule.Milestone}");
-                            if (rule.Type is not null) details.Add($"type={rule.Type}");
-                            if (rule.Repos.Count > 0) details.Add($"repos={string.Join(",", rule.Repos)}");
-                            if (rule.Yolo) details.Add("yolo=true");
+                            if (issueRule.Assignee is not null) details.Add($"assignee={issueRule.Assignee}");
+                            if (issueRule.Labels.Count > 0) details.Add($"labels={string.Join(",", issueRule.Labels)}");
+                            if (issueRule.Milestone is not null) details.Add($"milestone={issueRule.Milestone}");
+                            if (issueRule.Type is not null) details.Add($"type={issueRule.Type}");
+                            if (issueRule.Repos.Count > 0) details.Add($"repos={string.Join(",", issueRule.Repos)}");
+                            if (issueRule.Yolo) details.Add("yolo=true");
                             else
                             {
-                                if (rule.AllowAllTools) details.Add("allow_all_tools=true");
-                                if (rule.AllowAllUrls) details.Add("allow_all_urls=true");
+                                if (issueRule.AllowAllTools) details.Add("allow_all_tools=true");
+                                if (issueRule.AllowAllUrls) details.Add("allow_all_urls=true");
                             }
-                            if (rule.Model is not null) details.Add($"model={rule.Model}");
-                            if (rule.ExtraPrompt is not null) details.Add($"extra_prompt={rule.ExtraPrompt}");
-                            if (rule.CustomPrompt is not null) details.Add($"custom_prompt={rule.CustomPrompt}");
-                            if (rule.CustomPrompt is not null) details.Add($"custom_prompt_mode={rule.CustomPromptMode.ToString().ToLowerInvariant()}");
+                            if (issueRule.Model is not null) details.Add($"model={issueRule.Model}");
+                            if (issueRule.ExtraPrompt is not null) details.Add($"extra_prompt={issueRule.ExtraPrompt}");
+                            if (issueRule.CustomPrompt is not null) details.Add($"custom_prompt={issueRule.CustomPrompt}");
+                            if (issueRule.CustomPrompt is not null) details.Add($"custom_prompt_mode={issueRule.CustomPromptMode.ToString().ToLowerInvariant()}");
 
                             table.AddRow(
-                                Markup.Escape($"  rule[{name}]"),
+                                Markup.Escape($"  issue_rule[{name}]"),
                                 Markup.Escape(details.Count > 0 ? string.Join(", ", details) : "(no conditions)"));
                         }
                     }
 
                     if (config.PullRequestRules.Count > 0)
                     {
-                        foreach (var (name, rule) in config.PullRequestRules)
+                        foreach (var (name, pullRequestRule) in config.PullRequestRules)
                         {
                             var details = new List<string>();
-                            if (rule.Assignee is not null) details.Add($"assignee={rule.Assignee}");
-                            if (rule.Labels.Count > 0) details.Add($"labels={string.Join(",", rule.Labels)}");
-                            if (rule.BaseBranch is not null) details.Add($"base={rule.BaseBranch}");
-                            if (rule.HeadBranch is not null) details.Add($"head={rule.HeadBranch}");
-                            if (rule.HeadRepo is not null) details.Add($"head_repo={rule.HeadRepo}");
-                            if (rule.Draft is not null) details.Add($"draft={rule.Draft.Value.ToString().ToLowerInvariant()}");
-                            if (rule.ReviewDecision is not null) details.Add($"review_decision={rule.ReviewDecision}");
-                            details.Add($"branch_strategy={rule.BranchStrategy.ToString().ToLowerInvariant()}");
-                            if (rule.Repos.Count > 0) details.Add($"repos={string.Join(",", rule.Repos)}");
-                            if (rule.Yolo) details.Add("yolo=true");
+                            if (pullRequestRule.Assignee is not null) details.Add($"assignee={pullRequestRule.Assignee}");
+                            if (pullRequestRule.Labels.Count > 0) details.Add($"labels={string.Join(",", pullRequestRule.Labels)}");
+                            if (pullRequestRule.BaseBranch is not null) details.Add($"base={pullRequestRule.BaseBranch}");
+                            if (pullRequestRule.HeadBranch is not null) details.Add($"head={pullRequestRule.HeadBranch}");
+                            if (pullRequestRule.HeadRepo is not null) details.Add($"head_repo={pullRequestRule.HeadRepo}");
+                            if (pullRequestRule.Draft is not null) details.Add($"draft={pullRequestRule.Draft.Value.ToString().ToLowerInvariant()}");
+                            if (pullRequestRule.ReviewDecision is not null) details.Add($"review_decision={pullRequestRule.ReviewDecision}");
+                            details.Add($"branch_strategy={pullRequestRule.BranchStrategy.ToString().ToLowerInvariant()}");
+                            if (pullRequestRule.Repos.Count > 0) details.Add($"repos={string.Join(",", pullRequestRule.Repos)}");
+                            if (pullRequestRule.Yolo) details.Add("yolo=true");
                             else
                             {
-                                if (rule.AllowAllTools) details.Add("allow_all_tools=true");
-                                if (rule.AllowAllUrls) details.Add("allow_all_urls=true");
+                                if (pullRequestRule.AllowAllTools) details.Add("allow_all_tools=true");
+                                if (pullRequestRule.AllowAllUrls) details.Add("allow_all_urls=true");
                             }
-                            if (rule.Model is not null) details.Add($"model={rule.Model}");
-                            if (rule.ExtraPrompt is not null) details.Add($"extra_prompt={rule.ExtraPrompt}");
-                            if (rule.CustomPrompt is not null) details.Add($"custom_prompt={rule.CustomPrompt}");
-                            if (rule.CustomPrompt is not null) details.Add($"custom_prompt_mode={rule.CustomPromptMode.ToString().ToLowerInvariant()}");
+                            if (pullRequestRule.Model is not null) details.Add($"model={pullRequestRule.Model}");
+                            if (pullRequestRule.ExtraPrompt is not null) details.Add($"extra_prompt={pullRequestRule.ExtraPrompt}");
+                            if (pullRequestRule.CustomPrompt is not null) details.Add($"custom_prompt={pullRequestRule.CustomPrompt}");
+                            if (pullRequestRule.CustomPrompt is not null) details.Add($"custom_prompt_mode={pullRequestRule.CustomPromptMode.ToString().ToLowerInvariant()}");
 
                             table.AddRow(
                                 Markup.Escape($"  pr_rule[{name}]"),
@@ -135,9 +135,9 @@ public static class ConfigCommand
                             copilotCli,
                             cfg,
                             stateStore.LoadState(),
-                                cfg.Rules.Values.Cast<DispatchRuleOptions>()
+                                cfg.IssueRules.Values.Cast<DispatchRuleOptions>()
                                     .Concat(cfg.PullRequestRules.Values)
-                                    .SelectMany(rule => rule.Repos)
+                                    .SelectMany(dispatchRule => dispatchRule.Repos)
                                 .Distinct(StringComparer.OrdinalIgnoreCase)
                                 .ToList());
                         ConsoleOutput.Success($"repo_home set to: {cfg.RepoHome}");

--- a/src/copilotd/Commands/ConfigCommand.cs
+++ b/src/copilotd/Commands/ConfigCommand.cs
@@ -1,5 +1,6 @@
 using System.CommandLine;
 using Copilotd.Infrastructure;
+using Copilotd.Models;
 using Copilotd.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -44,14 +45,15 @@ public static class ConfigCommand
                     table.AddRow("current_user", Markup.Escape(config.CurrentUser ?? "(not set)"));
                     table.AddRow("max_instances", Markup.Escape(config.MaxInstances.ToString()));
                     table.AddRow("session_shutdown_delay_seconds", Markup.Escape(config.SessionShutdownDelaySeconds.ToString()));
-                    table.AddRow("rules", Markup.Escape($"{config.Rules.Count} rule(s)"));
+                    table.AddRow("issue_rules", Markup.Escape($"{config.Rules.Count} rule(s)"));
+                    table.AddRow("pull_request_rules", Markup.Escape($"{config.PullRequestRules.Count} rule(s)"));
 
                     if (config.Rules.Count > 0)
                     {
                         foreach (var (name, rule) in config.Rules)
                         {
                             var details = new List<string>();
-                            if (rule.User is not null) details.Add($"user={rule.User}");
+                            if (rule.Assignee is not null) details.Add($"assignee={rule.Assignee}");
                             if (rule.Labels.Count > 0) details.Add($"labels={string.Join(",", rule.Labels)}");
                             if (rule.Milestone is not null) details.Add($"milestone={rule.Milestone}");
                             if (rule.Type is not null) details.Add($"type={rule.Type}");
@@ -69,6 +71,37 @@ public static class ConfigCommand
 
                             table.AddRow(
                                 Markup.Escape($"  rule[{name}]"),
+                                Markup.Escape(details.Count > 0 ? string.Join(", ", details) : "(no conditions)"));
+                        }
+                    }
+
+                    if (config.PullRequestRules.Count > 0)
+                    {
+                        foreach (var (name, rule) in config.PullRequestRules)
+                        {
+                            var details = new List<string>();
+                            if (rule.Assignee is not null) details.Add($"assignee={rule.Assignee}");
+                            if (rule.Labels.Count > 0) details.Add($"labels={string.Join(",", rule.Labels)}");
+                            if (rule.BaseBranch is not null) details.Add($"base={rule.BaseBranch}");
+                            if (rule.HeadBranch is not null) details.Add($"head={rule.HeadBranch}");
+                            if (rule.HeadRepo is not null) details.Add($"head_repo={rule.HeadRepo}");
+                            if (rule.Draft is not null) details.Add($"draft={rule.Draft.Value.ToString().ToLowerInvariant()}");
+                            if (rule.ReviewDecision is not null) details.Add($"review_decision={rule.ReviewDecision}");
+                            details.Add($"branch_strategy={rule.BranchStrategy.ToString().ToLowerInvariant()}");
+                            if (rule.Repos.Count > 0) details.Add($"repos={string.Join(",", rule.Repos)}");
+                            if (rule.Yolo) details.Add("yolo=true");
+                            else
+                            {
+                                if (rule.AllowAllTools) details.Add("allow_all_tools=true");
+                                if (rule.AllowAllUrls) details.Add("allow_all_urls=true");
+                            }
+                            if (rule.Model is not null) details.Add($"model={rule.Model}");
+                            if (rule.ExtraPrompt is not null) details.Add($"extra_prompt={rule.ExtraPrompt}");
+                            if (rule.CustomPrompt is not null) details.Add($"custom_prompt={rule.CustomPrompt}");
+                            if (rule.CustomPrompt is not null) details.Add($"custom_prompt_mode={rule.CustomPromptMode.ToString().ToLowerInvariant()}");
+
+                            table.AddRow(
+                                Markup.Escape($"  pr_rule[{name}]"),
                                 Markup.Escape(details.Count > 0 ? string.Join(", ", details) : "(no conditions)"));
                         }
                     }
@@ -102,8 +135,9 @@ public static class ConfigCommand
                             copilotCli,
                             cfg,
                             stateStore.LoadState(),
-                            cfg.Rules.Values
-                                .SelectMany(rule => rule.Repos)
+                                cfg.Rules.Values.Cast<DispatchRuleOptions>()
+                                    .Concat(cfg.PullRequestRules.Values)
+                                    .SelectMany(rule => rule.Repos)
                                 .Distinct(StringComparer.OrdinalIgnoreCase)
                                 .ToList());
                         ConsoleOutput.Success($"repo_home set to: {cfg.RepoHome}");

--- a/src/copilotd/Commands/InitCommand.cs
+++ b/src/copilotd/Commands/InitCommand.cs
@@ -12,6 +12,8 @@ namespace Copilotd.Commands;
 
 public static class InitCommand
 {
+    private const string DefaultPullRequestRuleName = "Default PR";
+
     public static Command Create(IServiceProvider services)
     {
         var command = new Command("init", "Initialize copilotd configuration (first-run setup)");
@@ -134,122 +136,323 @@ public static class InitCommand
                 config.DefaultModel = string.IsNullOrWhiteSpace(modelInput) ? null : modelInput.Trim();
                 AnsiConsole.WriteLine();
 
-                // ── Phase 4: Default Rule Setup ───────────────────────────
-                AnsiConsole.Write(new Rule("[bold blue]Default Dispatch Rule[/]").LeftJustified());
+                // ── Phase 4: Dispatch Source Selection ─────────────────────
+                AnsiConsole.Write(new Rule("[bold blue]Dispatch Sources[/]").LeftJustified());
                 AnsiConsole.WriteLine();
-                AnsiConsole.MarkupLine("[grey]The default rule controls which issues copilotd will pick up and dispatch.[/]");
+                AnsiConsole.MarkupLine("[grey]Choose which GitHub subjects copilotd should dispatch from by default.[/]");
+                var dispatchSource = AnsiConsole.Prompt(
+                    new SelectionPrompt<DispatchSourceSelection>()
+                        .Title("What should copilotd dispatch from?")
+                        .AddChoices(DispatchSourceSelection.Issues, DispatchSourceSelection.PullRequests, DispatchSourceSelection.Both)
+                        .UseConverter(FormatDispatchSourceSelection)
+                        .HighlightStyle(new Style(Color.Blue)));
+                var configureIssueDispatch = dispatchSource is DispatchSourceSelection.Issues or DispatchSourceSelection.Both;
+                var configurePullRequestDispatch = dispatchSource is DispatchSourceSelection.PullRequests or DispatchSourceSelection.Both;
                 AnsiConsole.WriteLine();
 
+                IssueDispatchRule? defaultIssueRule = null;
+                PullRequestDispatchRule? defaultPullRequestRule = null;
                 var existingIssueRule = config.IssueRules.GetValueOrDefault(CopilotdConfig.DefaultRuleName);
 
-                // Author filtering
-                const string AuthorAny = "Any author";
-                const string AuthorWriteAccess = "Only authors with write access to the repo";
-                var authorOnlyMe = $"Only me ({Markup.Escape(username ?? "unknown")})";
+                if (!configureIssueDispatch && config.IssueRules.Remove(CopilotdConfig.DefaultRuleName))
+                    ConsoleOutput.Info("Removed the default issue dispatch rule because issue dispatch was not selected.");
+                if (!configurePullRequestDispatch && config.PullRequestRules.Remove(DefaultPullRequestRuleName))
+                    ConsoleOutput.Info("Removed the default PR dispatch rule because PR dispatch was not selected.");
 
-                // Determine existing selection for re-run and build choices with it first
-                var authorDefault = existingIssueRule?.AuthorMode switch
+                if (configureIssueDispatch)
                 {
-                    AuthorMode.Allowed when existingIssueRule.Authors.Count == 1
-                        && string.Equals(existingIssueRule.Authors[0], username, StringComparison.OrdinalIgnoreCase)
-                        => authorOnlyMe,
-                    AuthorMode.WriteAccess => AuthorWriteAccess,
-                    _ => AuthorAny
-                };
+                    // ── Phase 5a: Default Issue Dispatch Rule Setup ────────────
+                    AnsiConsole.Write(new Rule("[bold blue]Default Issue Dispatch Rule[/]").LeftJustified());
+                    AnsiConsole.WriteLine();
+                    AnsiConsole.MarkupLine("[grey]The default issue rule controls which issues copilotd will pick up and dispatch.[/]");
+                    AnsiConsole.WriteLine();
 
-                // Build choices with the current/default selection first so Spectre highlights it
-                var authorChoices = new List<string> { authorDefault };
-                foreach (var c in new[] { AuthorAny, authorOnlyMe, AuthorWriteAccess })
-                {
-                    if (c != authorDefault) authorChoices.Add(c);
+                    // Author filtering
+                    const string AuthorAny = "Any author";
+                    const string AuthorWriteAccess = "Only authors with write access to the repo";
+                    var authorOnlyMe = $"Only me ({Markup.Escape(username ?? "unknown")})";
+
+                    // Determine existing selection for re-run and build choices with it first
+                    var authorDefault = existingIssueRule?.AuthorMode switch
+                    {
+                        AuthorMode.Allowed when existingIssueRule.Authors.Count == 1
+                            && string.Equals(existingIssueRule.Authors[0], username, StringComparison.OrdinalIgnoreCase)
+                            => authorOnlyMe,
+                        AuthorMode.WriteAccess => AuthorWriteAccess,
+                        _ => AuthorAny
+                    };
+
+                    // Build choices with the current/default selection first so Spectre highlights it
+                    var authorChoices = new List<string> { authorDefault };
+                    foreach (var c in new[] { AuthorAny, authorOnlyMe, AuthorWriteAccess })
+                    {
+                        if (c != authorDefault) authorChoices.Add(c);
+                    }
+
+                    // Don't offer "Only me" if username couldn't be determined
+                    if (username is null)
+                        authorChoices.Remove(authorOnlyMe);
+
+                    var authorChoice = AnsiConsole.Prompt(
+                        new SelectionPrompt<string>()
+                            .Title("Who can create issues that copilotd will dispatch?")
+                            .AddChoices(authorChoices)
+                            .HighlightStyle(new Style(Color.Blue)));
+                    AnsiConsole.MarkupLine($"  Issue authors: [blue]{Markup.Escape(authorChoice)}[/]");
+
+                    AuthorMode authorMode;
+                    List<string> authors = [];
+                    if (authorChoice == authorOnlyMe)
+                    {
+                        authorMode = AuthorMode.Allowed;
+                        authors = [username!];
+                    }
+                    else if (authorChoice == AuthorWriteAccess)
+                    {
+                        authorMode = AuthorMode.WriteAccess;
+                    }
+                    else
+                    {
+                        authorMode = AuthorMode.Any;
+                    }
+                    AnsiConsole.WriteLine();
+
+                    // Labels
+                    AnsiConsole.MarkupLine("[grey]Issues must have ALL of these labels to be dispatched.[/]");
+                    var existingLabels = existingIssueRule?.Labels.Count > 0
+                        ? string.Join(", ", existingIssueRule.Labels)
+                        : "copilotd";
+                    var labelsInput = AnsiConsole.Prompt(
+                        new TextPrompt<string>("Required label(s) (comma-separated):")
+                            .DefaultValue(existingLabels));
+                    var labels = labelsInput
+                        .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .ToList();
+                    AnsiConsole.MarkupLine($"  Labels: [blue]{Markup.Escape(string.Join(", ", labels))}[/]");
+                    AnsiConsole.WriteLine();
+
+                    // Yolo / tool permissions
+                    AnsiConsole.MarkupLine("[grey]Yolo mode skips all confirmation prompts (implies --allow-all-tools and --allow-all-urls).[/]");
+                    var existingYolo = existingIssueRule?.Yolo ?? false;
+                    var yolo = AnsiConsole.Confirm("Enable yolo mode?", existingYolo);
+                    AnsiConsole.MarkupLine($"  Yolo mode: [blue]{(yolo ? "yes" : "no")}[/]");
+
+                    bool allowAllTools = true;
+                    bool allowAllUrls = false;
+                    if (!yolo)
+                    {
+                        AnsiConsole.MarkupLine("[grey]Allow copilot to use all available tools without prompting.[/]");
+                        allowAllTools = AnsiConsole.Confirm("Allow all tools?", existingIssueRule?.AllowAllTools ?? true);
+                        AnsiConsole.MarkupLine($"  Allow all tools: [blue]{(allowAllTools ? "yes" : "no")}[/]");
+                        AnsiConsole.MarkupLine("[grey]Allow copilot to access any URL without prompting.[/]");
+                        allowAllUrls = AnsiConsole.Confirm("Allow all URLs?", existingIssueRule?.AllowAllUrls ?? false);
+                        AnsiConsole.MarkupLine($"  Allow all URLs: [blue]{(allowAllUrls ? "yes" : "no")}[/]");
+                    }
+                    AnsiConsole.WriteLine();
+
+                    // Rule model override
+                    AnsiConsole.MarkupLine("[grey]Optionally override the default model for sessions matching this rule.[/]");
+                    var existingRuleModel = existingIssueRule?.Model ?? "";
+                    var ruleModelInput = AnsiConsole.Prompt(
+                        new TextPrompt<string>("Model override for default rule (empty to inherit global):")
+                            .DefaultValue(existingRuleModel)
+                            .AllowEmpty());
+                    var ruleModel = string.IsNullOrWhiteSpace(ruleModelInput) ? null : ruleModelInput.Trim();
+                    AnsiConsole.MarkupLine($"  Model override: [blue]{Markup.Escape(ruleModel ?? "(inherit global)")}[/]");
+                    AnsiConsole.WriteLine();
+
+                    // Build the default rule
+                    defaultIssueRule = existingIssueRule ?? new IssueDispatchRule();
+                    defaultIssueRule.Assignee = username;
+                    defaultIssueRule.Labels = labels;
+                    defaultIssueRule.AuthorMode = authorMode;
+                    defaultIssueRule.Authors = authors;
+                    defaultIssueRule.Yolo = yolo;
+                    defaultIssueRule.AllowAllTools = yolo || allowAllTools;
+                    defaultIssueRule.AllowAllUrls = yolo || allowAllUrls;
+                    defaultIssueRule.Model = ruleModel;
+                    config.IssueRules[CopilotdConfig.DefaultRuleName] = defaultIssueRule;
                 }
 
-                // Don't offer "Only me" if username couldn't be determined
-                if (username is null)
-                    authorChoices.Remove(authorOnlyMe);
-
-                var authorChoice = AnsiConsole.Prompt(
-                    new SelectionPrompt<string>()
-                        .Title("Who can create issues that copilotd will dispatch?")
-                        .AddChoices(authorChoices)
-                        .HighlightStyle(new Style(Color.Blue)));
-                AnsiConsole.MarkupLine($"  Issue authors: [blue]{Markup.Escape(authorChoice)}[/]");
-
-                AuthorMode authorMode;
-                List<string> authors = [];
-                if (authorChoice == authorOnlyMe)
+                if (configurePullRequestDispatch)
                 {
-                    authorMode = AuthorMode.Allowed;
-                    authors = [username!];
+                    // ── Phase 5b: Default Pull Request Dispatch Rule Setup ─────
+                    AnsiConsole.Write(new Rule("[bold blue]Default Pull Request Dispatch Rule[/]").LeftJustified());
+                    AnsiConsole.WriteLine();
+                    AnsiConsole.MarkupLine("[grey]The default PR rule controls which pull requests copilotd will pick up and dispatch.[/]");
+                    AnsiConsole.WriteLine();
+
+                    var existingPullRequestRule = config.PullRequestRules.GetValueOrDefault(DefaultPullRequestRuleName);
+
+                    const string PrAuthorAny = "Any author";
+                    const string PrAuthorWriteAccess = "Only authors with write access to the repo";
+                    var prAuthorOnlyMe = $"Only me ({Markup.Escape(username ?? "unknown")})";
+                    var prAuthorDefault = existingPullRequestRule?.AuthorMode switch
+                    {
+                        AuthorMode.Allowed when existingPullRequestRule.Authors.Count == 1
+                            && string.Equals(existingPullRequestRule.Authors[0], username, StringComparison.OrdinalIgnoreCase)
+                            => prAuthorOnlyMe,
+                        AuthorMode.WriteAccess => PrAuthorWriteAccess,
+                        _ => PrAuthorAny
+                    };
+
+                    var prAuthorChoices = new List<string> { prAuthorDefault };
+                    foreach (var c in new[] { PrAuthorAny, prAuthorOnlyMe, PrAuthorWriteAccess })
+                    {
+                        if (c != prAuthorDefault) prAuthorChoices.Add(c);
+                    }
+
+                    if (username is null)
+                        prAuthorChoices.Remove(prAuthorOnlyMe);
+
+                    var prAuthorChoice = AnsiConsole.Prompt(
+                        new SelectionPrompt<string>()
+                            .Title("Who can create pull requests that copilotd will dispatch?")
+                            .AddChoices(prAuthorChoices)
+                            .HighlightStyle(new Style(Color.Blue)));
+                    AnsiConsole.MarkupLine($"  PR authors: [blue]{Markup.Escape(prAuthorChoice)}[/]");
+
+                    AuthorMode prAuthorMode;
+                    List<string> prAuthors = [];
+                    if (prAuthorChoice == prAuthorOnlyMe)
+                    {
+                        prAuthorMode = AuthorMode.Allowed;
+                        prAuthors = [username!];
+                    }
+                    else if (prAuthorChoice == PrAuthorWriteAccess)
+                    {
+                        prAuthorMode = AuthorMode.WriteAccess;
+                    }
+                    else
+                    {
+                        prAuthorMode = AuthorMode.Any;
+                    }
+                    AnsiConsole.WriteLine();
+
+                    AnsiConsole.MarkupLine("[grey]Pull requests must have ALL of these labels to be dispatched. Leave empty for any label set.[/]");
+                    var existingPrLabels = existingPullRequestRule?.Labels.Count > 0
+                        ? string.Join(", ", existingPullRequestRule.Labels)
+                        : "";
+                    var prLabelsInput = AnsiConsole.Prompt(
+                        new TextPrompt<string>("Required PR label(s) (comma-separated, empty for none):")
+                            .DefaultValue(existingPrLabels)
+                            .AllowEmpty());
+                    var prLabels = prLabelsInput
+                        .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .ToList();
+                    AnsiConsole.MarkupLine($"  PR labels: [blue]{Markup.Escape(prLabels.Count > 0 ? string.Join(", ", prLabels) : "(none)")}[/]");
+                    AnsiConsole.WriteLine();
+
+                    AnsiConsole.MarkupLine("[grey]Optionally restrict PR dispatch to a target/base branch, e.g. main. Leave empty for any base branch.[/]");
+                    var prBaseBranchInput = AnsiConsole.Prompt(
+                        new TextPrompt<string>("PR base branch:")
+                            .DefaultValue(existingPullRequestRule?.BaseBranch ?? "")
+                            .AllowEmpty());
+                    var prBaseBranch = string.IsNullOrWhiteSpace(prBaseBranchInput) ? null : prBaseBranchInput.Trim();
+                    AnsiConsole.MarkupLine($"  PR base branch: [blue]{Markup.Escape(prBaseBranch ?? "(any)")}[/]");
+                    AnsiConsole.WriteLine();
+
+                    const string DraftAny = "Any draft state";
+                    const string DraftOnly = "Draft PRs only";
+                    const string ReadyOnly = "Ready PRs only";
+                    var draftDefault = existingPullRequestRule?.Draft switch
+                    {
+                        true => DraftOnly,
+                        false => ReadyOnly,
+                        _ => DraftAny
+                    };
+                    var draftChoices = new List<string> { draftDefault };
+                    foreach (var c in new[] { DraftAny, DraftOnly, ReadyOnly })
+                    {
+                        if (c != draftDefault) draftChoices.Add(c);
+                    }
+                    var draftChoice = AnsiConsole.Prompt(
+                        new SelectionPrompt<string>()
+                            .Title("Which PR draft state should be dispatched?")
+                            .AddChoices(draftChoices)
+                            .HighlightStyle(new Style(Color.Blue)));
+                    bool? draft = draftChoice switch
+                    {
+                        DraftOnly => true,
+                        ReadyOnly => false,
+                        _ => null
+                    };
+                    AnsiConsole.MarkupLine($"  PR draft state: [blue]{Markup.Escape(draftChoice)}[/]");
+                    AnsiConsole.WriteLine();
+
+                    const string SourceBranch = "Update the PR source branch (same-repo PRs only)";
+                    const string ChildBranch = "Create a new child branch from the PR";
+                    const string ReadOnly = "Read-only review/validation";
+                    var branchStrategyDefault = existingPullRequestRule?.BranchStrategy switch
+                    {
+                        PullRequestBranchStrategy.ChildBranch => ChildBranch,
+                        PullRequestBranchStrategy.ReadOnly => ReadOnly,
+                        _ => SourceBranch
+                    };
+                    var branchStrategyChoices = new List<string> { branchStrategyDefault };
+                    foreach (var c in new[] { SourceBranch, ChildBranch, ReadOnly })
+                    {
+                        if (c != branchStrategyDefault) branchStrategyChoices.Add(c);
+                    }
+                    var branchStrategyChoice = AnsiConsole.Prompt(
+                        new SelectionPrompt<string>()
+                            .Title("How should PR-dispatched sessions handle branches?")
+                            .AddChoices(branchStrategyChoices)
+                            .HighlightStyle(new Style(Color.Blue)));
+                    var branchStrategy = branchStrategyChoice switch
+                    {
+                        ChildBranch => PullRequestBranchStrategy.ChildBranch,
+                        ReadOnly => PullRequestBranchStrategy.ReadOnly,
+                        _ => PullRequestBranchStrategy.SourceBranch
+                    };
+                    AnsiConsole.MarkupLine($"  PR branch strategy: [blue]{Markup.Escape(branchStrategyChoice)}[/]");
+                    AnsiConsole.WriteLine();
+
+                    AnsiConsole.MarkupLine("[grey]Yolo mode skips all confirmation prompts (implies --allow-all-tools and --allow-all-urls).[/]");
+                    var existingPrYolo = existingPullRequestRule?.Yolo ?? false;
+                    var prYolo = AnsiConsole.Confirm("Enable yolo mode for PR sessions?", existingPrYolo);
+                    AnsiConsole.MarkupLine($"  Yolo mode: [blue]{(prYolo ? "yes" : "no")}[/]");
+
+                    bool prAllowAllTools = true;
+                    bool prAllowAllUrls = false;
+                    if (!prYolo)
+                    {
+                        AnsiConsole.MarkupLine("[grey]Allow copilot to use all available tools without prompting.[/]");
+                        prAllowAllTools = AnsiConsole.Confirm("Allow all tools for PR sessions?", existingPullRequestRule?.AllowAllTools ?? true);
+                        AnsiConsole.MarkupLine($"  Allow all tools: [blue]{(prAllowAllTools ? "yes" : "no")}[/]");
+                        AnsiConsole.MarkupLine("[grey]Allow copilot to access any URL without prompting.[/]");
+                        prAllowAllUrls = AnsiConsole.Confirm("Allow all URLs for PR sessions?", existingPullRequestRule?.AllowAllUrls ?? false);
+                        AnsiConsole.MarkupLine($"  Allow all URLs: [blue]{(prAllowAllUrls ? "yes" : "no")}[/]");
+                    }
+                    AnsiConsole.WriteLine();
+
+                    AnsiConsole.MarkupLine("[grey]Optionally override the default model for PR sessions matching this rule.[/]");
+                    var existingPrRuleModel = existingPullRequestRule?.Model ?? "";
+                    var prRuleModelInput = AnsiConsole.Prompt(
+                        new TextPrompt<string>("Model override for default PR rule (empty to inherit global):")
+                            .DefaultValue(existingPrRuleModel)
+                            .AllowEmpty());
+                    var prRuleModel = string.IsNullOrWhiteSpace(prRuleModelInput) ? null : prRuleModelInput.Trim();
+                    AnsiConsole.MarkupLine($"  Model override: [blue]{Markup.Escape(prRuleModel ?? "(inherit global)")}[/]");
+                    AnsiConsole.WriteLine();
+
+                    defaultPullRequestRule = existingPullRequestRule ?? new PullRequestDispatchRule();
+                    defaultPullRequestRule.Labels = prLabels;
+                    defaultPullRequestRule.BaseBranch = prBaseBranch;
+                    defaultPullRequestRule.Draft = draft;
+                    defaultPullRequestRule.AuthorMode = prAuthorMode;
+                    defaultPullRequestRule.Authors = prAuthors;
+                    defaultPullRequestRule.BranchStrategy = branchStrategy;
+                    defaultPullRequestRule.Yolo = prYolo;
+                    defaultPullRequestRule.AllowAllTools = prYolo || prAllowAllTools;
+                    defaultPullRequestRule.AllowAllUrls = prYolo || prAllowAllUrls;
+                    defaultPullRequestRule.Model = prRuleModel;
+                    config.PullRequestRules[DefaultPullRequestRuleName] = defaultPullRequestRule;
                 }
-                else if (authorChoice == AuthorWriteAccess)
-                {
-                    authorMode = AuthorMode.WriteAccess;
-                }
-                else
-                {
-                    authorMode = AuthorMode.Any;
-                }
-                AnsiConsole.WriteLine();
 
-                // Labels
-                AnsiConsole.MarkupLine("[grey]Issues must have ALL of these labels to be dispatched.[/]");
-                var existingLabels = existingIssueRule?.Labels.Count > 0
-                    ? string.Join(", ", existingIssueRule.Labels)
-                    : "copilotd";
-                var labelsInput = AnsiConsole.Prompt(
-                    new TextPrompt<string>("Required label(s) (comma-separated):")
-                        .DefaultValue(existingLabels));
-                var labels = labelsInput
-                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                    .Distinct(StringComparer.OrdinalIgnoreCase)
-                    .ToList();
-                AnsiConsole.MarkupLine($"  Labels: [blue]{Markup.Escape(string.Join(", ", labels))}[/]");
-                AnsiConsole.WriteLine();
-
-                // Yolo / tool permissions
-                AnsiConsole.MarkupLine("[grey]Yolo mode skips all confirmation prompts (implies --allow-all-tools and --allow-all-urls).[/]");
-                var existingYolo = existingIssueRule?.Yolo ?? false;
-                var yolo = AnsiConsole.Confirm("Enable yolo mode?", existingYolo);
-                AnsiConsole.MarkupLine($"  Yolo mode: [blue]{(yolo ? "yes" : "no")}[/]");
-
-                bool allowAllTools = true;
-                bool allowAllUrls = false;
-                if (!yolo)
-                {
-                    AnsiConsole.MarkupLine("[grey]Allow copilot to use all available tools without prompting.[/]");
-                    allowAllTools = AnsiConsole.Confirm("Allow all tools?", existingIssueRule?.AllowAllTools ?? true);
-                    AnsiConsole.MarkupLine($"  Allow all tools: [blue]{(allowAllTools ? "yes" : "no")}[/]");
-                    AnsiConsole.MarkupLine("[grey]Allow copilot to access any URL without prompting.[/]");
-                    allowAllUrls = AnsiConsole.Confirm("Allow all URLs?", existingIssueRule?.AllowAllUrls ?? false);
-                    AnsiConsole.MarkupLine($"  Allow all URLs: [blue]{(allowAllUrls ? "yes" : "no")}[/]");
-                }
-                AnsiConsole.WriteLine();
-
-                // Rule model override
-                AnsiConsole.MarkupLine("[grey]Optionally override the default model for sessions matching this rule.[/]");
-                var existingRuleModel = existingIssueRule?.Model ?? "";
-                var ruleModelInput = AnsiConsole.Prompt(
-                    new TextPrompt<string>("Model override for default rule (empty to inherit global):")
-                        .DefaultValue(existingRuleModel)
-                        .AllowEmpty());
-                var ruleModel = string.IsNullOrWhiteSpace(ruleModelInput) ? null : ruleModelInput.Trim();
-                AnsiConsole.MarkupLine($"  Model override: [blue]{Markup.Escape(ruleModel ?? "(inherit global)")}[/]");
-                AnsiConsole.WriteLine();
-
-                // Build the default rule
-                var defaultIssueRule = existingIssueRule ?? new IssueDispatchRule();
-                defaultIssueRule.Assignee = username;
-                defaultIssueRule.Labels = labels;
-                defaultIssueRule.AuthorMode = authorMode;
-                defaultIssueRule.Authors = authors;
-                defaultIssueRule.Yolo = yolo;
-                defaultIssueRule.AllowAllTools = yolo || allowAllTools;
-                defaultIssueRule.AllowAllUrls = yolo || allowAllUrls;
-                defaultIssueRule.Model = ruleModel;
-                config.IssueRules[CopilotdConfig.DefaultRuleName] = defaultIssueRule;
-
-                // ── Phase 5: Repo Selection ───────────────────────────────
+                // ── Phase 6: Repo Selection ───────────────────────────────
                 AnsiConsole.Write(new Rule("[bold blue]Repository Selection[/]").LeftJustified());
                 AnsiConsole.WriteLine();
 
@@ -279,7 +482,13 @@ public static class InitCommand
                     }
                 }
 
-                MergeExistingRepos(repos, existingIssueRule?.Repos ?? [], username);
+                var existingDefaultRuleRepos = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                if (defaultIssueRule is not null)
+                    existingDefaultRuleRepos.UnionWith(defaultIssueRule.Repos);
+                if (defaultPullRequestRule is not null)
+                    existingDefaultRuleRepos.UnionWith(defaultPullRequestRule.Repos);
+
+                MergeExistingRepos(repos, existingDefaultRuleRepos.ToList(), username);
                 repos = repos
                     .DistinctBy(repo => repo.NameWithOwner, StringComparer.OrdinalIgnoreCase)
                     .OrderBy(repo => repo.NameWithOwner, StringComparer.OrdinalIgnoreCase)
@@ -304,7 +513,7 @@ public static class InitCommand
                     AnsiConsole.MarkupLine("[grey]Use the group picker to edit one slice at a time. Only cloned repos can dispatch — repos are not auto-cloned.[/]");
                     AnsiConsole.WriteLine();
 
-                    var selected = PromptForRepoSelection(repos, clonedRepoSlugs, existingIssueRule?.Repos ?? [], ghCli, username);
+                    var selected = PromptForRepoSelection(repos, clonedRepoSlugs, existingDefaultRuleRepos.ToList(), ghCli, username);
 
                     var notClonedSelected = selected.Where(r => !cloneStatus.GetValueOrDefault(r)).ToList();
                     if (notClonedSelected.Count > 0)
@@ -321,7 +530,10 @@ public static class InitCommand
                         ConsoleOutput.Warning("No repos selected. You can add repos to rules later.");
                     }
 
-                    defaultIssueRule.Repos = selected;
+                    if (defaultIssueRule is not null)
+                        defaultIssueRule.Repos = selected;
+                    if (defaultPullRequestRule is not null)
+                        defaultPullRequestRule.Repos = selected;
                     CopilotTrustCommandHelper.EnsureTrustedFoldersForRepositories(
                         copilotTrust,
                         repoResolver,
@@ -332,7 +544,7 @@ public static class InitCommand
                 }
                 AnsiConsole.WriteLine();
 
-                // ── Phase 6: Save & Summary ───────────────────────────────
+                // ── Phase 7: Save & Summary ───────────────────────────────
                 stateStore.SaveConfig(config);
 
                 AnsiConsole.Write(new Rule("[bold green]Configuration Saved[/]").LeftJustified());
@@ -351,14 +563,31 @@ public static class InitCommand
                 summaryTable.AddRow("[blue]Max concurrent sessions[/]", Markup.Escape(config.MaxInstances.ToString()));
                 summaryTable.AddRow("[blue]Default model[/]", Markup.Escape(config.DefaultModel ?? "(copilot default)"));
                 summaryTable.AddRow("", "");
-                summaryTable.AddRow("[bold blue]Default Rule[/]", "");
-                summaryTable.AddRow("[blue]  Assignee[/]", Markup.Escape(defaultIssueRule.Assignee ?? "*"));
-                summaryTable.AddRow("[blue]  Author filter[/]", Markup.Escape(FormatAuthorMode(defaultIssueRule)));
-                summaryTable.AddRow("[blue]  Labels[/]", Markup.Escape(string.Join(", ", defaultIssueRule.Labels)));
-                summaryTable.AddRow("[blue]  Permissions[/]", Markup.Escape(FormatPermissions(defaultIssueRule)));
-                summaryTable.AddRow("[blue]  Model override[/]", Markup.Escape(defaultIssueRule.Model ?? "(inherit global)"));
-                summaryTable.AddRow("[blue]  Repos[/]", Markup.Escape(
-                    defaultIssueRule.Repos.Count > 0 ? string.Join(", ", defaultIssueRule.Repos) : "(none)"));
+                if (defaultIssueRule is not null)
+                {
+                    summaryTable.AddRow("[bold blue]Default Issue Rule[/]", "");
+                    summaryTable.AddRow("[blue]  Assignee[/]", Markup.Escape(defaultIssueRule.Assignee ?? "*"));
+                    summaryTable.AddRow("[blue]  Author filter[/]", Markup.Escape(FormatAuthorMode(defaultIssueRule)));
+                    summaryTable.AddRow("[blue]  Labels[/]", Markup.Escape(string.Join(", ", defaultIssueRule.Labels)));
+                    summaryTable.AddRow("[blue]  Permissions[/]", Markup.Escape(FormatPermissions(defaultIssueRule)));
+                    summaryTable.AddRow("[blue]  Model override[/]", Markup.Escape(defaultIssueRule.Model ?? "(inherit global)"));
+                    summaryTable.AddRow("[blue]  Repos[/]", Markup.Escape(
+                        defaultIssueRule.Repos.Count > 0 ? string.Join(", ", defaultIssueRule.Repos) : "(none)"));
+                }
+
+                if (defaultPullRequestRule is not null)
+                {
+                    summaryTable.AddRow("[bold blue]Default Pull Request Rule[/]", Markup.Escape(DefaultPullRequestRuleName));
+                    summaryTable.AddRow("[blue]  Author filter[/]", Markup.Escape(FormatAuthorMode(defaultPullRequestRule)));
+                    summaryTable.AddRow("[blue]  Labels[/]", Markup.Escape(defaultPullRequestRule.Labels.Count > 0 ? string.Join(", ", defaultPullRequestRule.Labels) : "(none)"));
+                    summaryTable.AddRow("[blue]  Base branch[/]", Markup.Escape(defaultPullRequestRule.BaseBranch ?? "(any)"));
+                    summaryTable.AddRow("[blue]  Draft state[/]", Markup.Escape(FormatDraftState(defaultPullRequestRule.Draft)));
+                    summaryTable.AddRow("[blue]  Branch strategy[/]", Markup.Escape(defaultPullRequestRule.BranchStrategy.ToString()));
+                    summaryTable.AddRow("[blue]  Permissions[/]", Markup.Escape(FormatPermissions(defaultPullRequestRule)));
+                    summaryTable.AddRow("[blue]  Model override[/]", Markup.Escape(defaultPullRequestRule.Model ?? "(inherit global)"));
+                    summaryTable.AddRow("[blue]  Repos[/]", Markup.Escape(
+                        defaultPullRequestRule.Repos.Count > 0 ? string.Join(", ", defaultPullRequestRule.Repos) : "(none)"));
+                }
 
                 AnsiConsole.Write(summaryTable);
                 AnsiConsole.WriteLine();
@@ -368,8 +597,12 @@ public static class InitCommand
                 AnsiConsole.WriteLine();
                 AnsiConsole.MarkupLine("  [blue]copilotd run[/]                                           Start the daemon");
                 AnsiConsole.MarkupLine("  [blue]copilotd run --interval 15 --log-level debug[/]           Start with verbose logging");
-                AnsiConsole.MarkupLine("  [blue]copilotd rules update Default --add-repo org/repo[/]      Add another repo to the default rule");
-                AnsiConsole.MarkupLine("  [blue]copilotd rules add MyRule --label bug --yolo[/]           Create a new dispatch rule");
+                if (defaultIssueRule is not null)
+                    AnsiConsole.MarkupLine("  [blue]copilotd rules update Default --add-repo org/repo[/]     Add a repo to the default issue rule");
+                if (defaultPullRequestRule is not null)
+                    AnsiConsole.MarkupLine("  [blue]copilotd rules update \"Default PR\" --add-repo org/repo[/]  Add a repo to the default PR rule");
+                AnsiConsole.MarkupLine("  [blue]copilotd rules add MyRule --kind issue --label bug --yolo[/]       Create a new issue dispatch rule");
+                AnsiConsole.MarkupLine("  [blue]copilotd rules add MyPrRule --kind pr --label review[/]            Create a new PR dispatch rule");
                 AnsiConsole.MarkupLine("  [blue]copilotd config --set max_instances=5[/]                  Change concurrency limit");
                 AnsiConsole.MarkupLine("  [blue]copilotd config --set default_model=claude-sonnet-4[/]    Set the default model");
                 AnsiConsole.MarkupLine("  [blue]copilotd status[/]                                        Check daemon health and sessions");
@@ -389,6 +622,37 @@ public static class InitCommand
             AuthorMode.Allowed => string.Join(", ", rule.Authors),
             AuthorMode.WriteAccess => "(write access only)",
             _ => "(any)",
+        };
+    }
+
+    private static string FormatAuthorMode(PullRequestDispatchRule rule)
+    {
+        return rule.AuthorMode switch
+        {
+            AuthorMode.Allowed => string.Join(", ", rule.Authors),
+            AuthorMode.WriteAccess => "(write access only)",
+            _ => "(any)",
+        };
+    }
+
+    private static string FormatDraftState(bool? draft)
+    {
+        return draft switch
+        {
+            true => "Draft PRs only",
+            false => "Ready PRs only",
+            _ => "(any)",
+        };
+    }
+
+    private static string FormatDispatchSourceSelection(DispatchSourceSelection selection)
+    {
+        return selection switch
+        {
+            DispatchSourceSelection.Issues => "Issues",
+            DispatchSourceSelection.PullRequests => "Pull requests",
+            DispatchSourceSelection.Both => "Issues and pull requests",
+            _ => selection.ToString(),
         };
     }
 
@@ -900,6 +1164,13 @@ public static class InitCommand
         OpenWriteAccessNotCloned,
         ReviewSelected,
         Done,
+    }
+
+    private enum DispatchSourceSelection
+    {
+        Issues,
+        PullRequests,
+        Both,
     }
 
     private enum WriteAccessNotClonedMenuAction

--- a/src/copilotd/Commands/InitCommand.cs
+++ b/src/copilotd/Commands/InitCommand.cs
@@ -238,8 +238,8 @@ public static class InitCommand
                 AnsiConsole.WriteLine();
 
                 // Build the default rule
-                var defaultRule = existingRule ?? new DispatchRule();
-                defaultRule.User = username;
+                var defaultRule = existingRule ?? new IssueDispatchRule();
+                defaultRule.Assignee = username;
                 defaultRule.Labels = labels;
                 defaultRule.AuthorMode = authorMode;
                 defaultRule.Authors = authors;
@@ -352,7 +352,7 @@ public static class InitCommand
                 summaryTable.AddRow("[blue]Default model[/]", Markup.Escape(config.DefaultModel ?? "(copilot default)"));
                 summaryTable.AddRow("", "");
                 summaryTable.AddRow("[bold blue]Default Rule[/]", "");
-                summaryTable.AddRow("[blue]  Assignee[/]", Markup.Escape(defaultRule.User ?? "*"));
+                summaryTable.AddRow("[blue]  Assignee[/]", Markup.Escape(defaultRule.Assignee ?? "*"));
                 summaryTable.AddRow("[blue]  Author filter[/]", Markup.Escape(FormatAuthorMode(defaultRule)));
                 summaryTable.AddRow("[blue]  Labels[/]", Markup.Escape(string.Join(", ", defaultRule.Labels)));
                 summaryTable.AddRow("[blue]  Permissions[/]", Markup.Escape(FormatPermissions(defaultRule)));
@@ -382,7 +382,7 @@ public static class InitCommand
         return command;
     }
 
-    private static string FormatAuthorMode(DispatchRule rule)
+    private static string FormatAuthorMode(IssueDispatchRule rule)
     {
         return rule.AuthorMode switch
         {
@@ -392,7 +392,7 @@ public static class InitCommand
         };
     }
 
-    private static string FormatPermissions(DispatchRule rule)
+    private static string FormatPermissions(DispatchRuleOptions rule)
     {
         if (rule.Yolo) return "--yolo";
         var parts = new List<string>();

--- a/src/copilotd/Commands/InitCommand.cs
+++ b/src/copilotd/Commands/InitCommand.cs
@@ -595,17 +595,25 @@ public static class InitCommand
                 // Next steps
                 AnsiConsole.Write(new Rule("[bold blue]Next Steps[/]").LeftJustified());
                 AnsiConsole.WriteLine();
-                AnsiConsole.MarkupLine("  [blue]copilotd run[/]                                           Start the daemon");
-                AnsiConsole.MarkupLine("  [blue]copilotd run --interval 15 --log-level debug[/]           Start with verbose logging");
+
+                var nextStepsTable = new Table()
+                    .Border(TableBorder.None)
+                    .HideHeaders();
+                nextStepsTable.AddColumn(new TableColumn("").NoWrap());
+                nextStepsTable.AddColumn("");
+
+                AddNextStep(nextStepsTable, "copilotd run", "Start the daemon");
+                AddNextStep(nextStepsTable, "copilotd run --interval 15 --log-level debug", "Start with verbose logging");
                 if (defaultIssueRule is not null)
-                    AnsiConsole.MarkupLine("  [blue]copilotd rules update Default --add-repo org/repo[/]     Add a repo to the default issue rule");
+                    AddNextStep(nextStepsTable, "copilotd rules update Default --add-repo org/repo", "Add a repo to the default issue rule");
                 if (defaultPullRequestRule is not null)
-                    AnsiConsole.MarkupLine("  [blue]copilotd rules update \"Default PR\" --add-repo org/repo[/]  Add a repo to the default PR rule");
-                AnsiConsole.MarkupLine("  [blue]copilotd rules add MyRule --kind issue --label bug --yolo[/]       Create a new issue dispatch rule");
-                AnsiConsole.MarkupLine("  [blue]copilotd rules add MyPrRule --kind pr --label review[/]            Create a new PR dispatch rule");
-                AnsiConsole.MarkupLine("  [blue]copilotd config --set max_instances=5[/]                  Change concurrency limit");
-                AnsiConsole.MarkupLine("  [blue]copilotd config --set default_model=claude-sonnet-4[/]    Set the default model");
-                AnsiConsole.MarkupLine("  [blue]copilotd status[/]                                        Check daemon health and sessions");
+                    AddNextStep(nextStepsTable, "copilotd rules update \"Default PR\" --add-repo org/repo", "Add a repo to the default PR rule");
+                AddNextStep(nextStepsTable, "copilotd rules add MyRule --kind issue --label bug --yolo", "Create a new issue dispatch rule");
+                AddNextStep(nextStepsTable, "copilotd rules add MyPrRule --kind pr --label review", "Create a new PR dispatch rule");
+                AddNextStep(nextStepsTable, "copilotd config --set max_instances=5", "Change concurrency limit");
+                AddNextStep(nextStepsTable, "copilotd config --set default_model=claude-sonnet-4", "Set the default model");
+                AddNextStep(nextStepsTable, "copilotd status", "Check daemon health and sessions");
+                AnsiConsole.Write(nextStepsTable);
                 AnsiConsole.WriteLine();
 
                 return 0;
@@ -623,6 +631,11 @@ public static class InitCommand
             AuthorMode.WriteAccess => "(write access only)",
             _ => "(any)",
         };
+    }
+
+    private static void AddNextStep(Table table, string command, string description)
+    {
+        table.AddRow($"  [blue]{Markup.Escape(command)}[/]", Markup.Escape(description));
     }
 
     private static string FormatAuthorMode(PullRequestDispatchRule rule)

--- a/src/copilotd/Commands/InitCommand.cs
+++ b/src/copilotd/Commands/InitCommand.cs
@@ -140,7 +140,7 @@ public static class InitCommand
                 AnsiConsole.MarkupLine("[grey]The default rule controls which issues copilotd will pick up and dispatch.[/]");
                 AnsiConsole.WriteLine();
 
-                var existingRule = config.Rules.GetValueOrDefault(CopilotdConfig.DefaultRuleName);
+                var existingIssueRule = config.IssueRules.GetValueOrDefault(CopilotdConfig.DefaultRuleName);
 
                 // Author filtering
                 const string AuthorAny = "Any author";
@@ -148,10 +148,10 @@ public static class InitCommand
                 var authorOnlyMe = $"Only me ({Markup.Escape(username ?? "unknown")})";
 
                 // Determine existing selection for re-run and build choices with it first
-                var authorDefault = existingRule?.AuthorMode switch
+                var authorDefault = existingIssueRule?.AuthorMode switch
                 {
-                    AuthorMode.Allowed when existingRule.Authors.Count == 1
-                        && string.Equals(existingRule.Authors[0], username, StringComparison.OrdinalIgnoreCase)
+                    AuthorMode.Allowed when existingIssueRule.Authors.Count == 1
+                        && string.Equals(existingIssueRule.Authors[0], username, StringComparison.OrdinalIgnoreCase)
                         => authorOnlyMe,
                     AuthorMode.WriteAccess => AuthorWriteAccess,
                     _ => AuthorAny
@@ -194,8 +194,8 @@ public static class InitCommand
 
                 // Labels
                 AnsiConsole.MarkupLine("[grey]Issues must have ALL of these labels to be dispatched.[/]");
-                var existingLabels = existingRule?.Labels.Count > 0
-                    ? string.Join(", ", existingRule.Labels)
+                var existingLabels = existingIssueRule?.Labels.Count > 0
+                    ? string.Join(", ", existingIssueRule.Labels)
                     : "copilotd";
                 var labelsInput = AnsiConsole.Prompt(
                     new TextPrompt<string>("Required label(s) (comma-separated):")
@@ -209,7 +209,7 @@ public static class InitCommand
 
                 // Yolo / tool permissions
                 AnsiConsole.MarkupLine("[grey]Yolo mode skips all confirmation prompts (implies --allow-all-tools and --allow-all-urls).[/]");
-                var existingYolo = existingRule?.Yolo ?? false;
+                var existingYolo = existingIssueRule?.Yolo ?? false;
                 var yolo = AnsiConsole.Confirm("Enable yolo mode?", existingYolo);
                 AnsiConsole.MarkupLine($"  Yolo mode: [blue]{(yolo ? "yes" : "no")}[/]");
 
@@ -218,17 +218,17 @@ public static class InitCommand
                 if (!yolo)
                 {
                     AnsiConsole.MarkupLine("[grey]Allow copilot to use all available tools without prompting.[/]");
-                    allowAllTools = AnsiConsole.Confirm("Allow all tools?", existingRule?.AllowAllTools ?? true);
+                    allowAllTools = AnsiConsole.Confirm("Allow all tools?", existingIssueRule?.AllowAllTools ?? true);
                     AnsiConsole.MarkupLine($"  Allow all tools: [blue]{(allowAllTools ? "yes" : "no")}[/]");
                     AnsiConsole.MarkupLine("[grey]Allow copilot to access any URL without prompting.[/]");
-                    allowAllUrls = AnsiConsole.Confirm("Allow all URLs?", existingRule?.AllowAllUrls ?? false);
+                    allowAllUrls = AnsiConsole.Confirm("Allow all URLs?", existingIssueRule?.AllowAllUrls ?? false);
                     AnsiConsole.MarkupLine($"  Allow all URLs: [blue]{(allowAllUrls ? "yes" : "no")}[/]");
                 }
                 AnsiConsole.WriteLine();
 
                 // Rule model override
                 AnsiConsole.MarkupLine("[grey]Optionally override the default model for sessions matching this rule.[/]");
-                var existingRuleModel = existingRule?.Model ?? "";
+                var existingRuleModel = existingIssueRule?.Model ?? "";
                 var ruleModelInput = AnsiConsole.Prompt(
                     new TextPrompt<string>("Model override for default rule (empty to inherit global):")
                         .DefaultValue(existingRuleModel)
@@ -238,16 +238,16 @@ public static class InitCommand
                 AnsiConsole.WriteLine();
 
                 // Build the default rule
-                var defaultRule = existingRule ?? new IssueDispatchRule();
-                defaultRule.Assignee = username;
-                defaultRule.Labels = labels;
-                defaultRule.AuthorMode = authorMode;
-                defaultRule.Authors = authors;
-                defaultRule.Yolo = yolo;
-                defaultRule.AllowAllTools = yolo || allowAllTools;
-                defaultRule.AllowAllUrls = yolo || allowAllUrls;
-                defaultRule.Model = ruleModel;
-                config.Rules[CopilotdConfig.DefaultRuleName] = defaultRule;
+                var defaultIssueRule = existingIssueRule ?? new IssueDispatchRule();
+                defaultIssueRule.Assignee = username;
+                defaultIssueRule.Labels = labels;
+                defaultIssueRule.AuthorMode = authorMode;
+                defaultIssueRule.Authors = authors;
+                defaultIssueRule.Yolo = yolo;
+                defaultIssueRule.AllowAllTools = yolo || allowAllTools;
+                defaultIssueRule.AllowAllUrls = yolo || allowAllUrls;
+                defaultIssueRule.Model = ruleModel;
+                config.IssueRules[CopilotdConfig.DefaultRuleName] = defaultIssueRule;
 
                 // ── Phase 5: Repo Selection ───────────────────────────────
                 AnsiConsole.Write(new Rule("[bold blue]Repository Selection[/]").LeftJustified());
@@ -279,7 +279,7 @@ public static class InitCommand
                     }
                 }
 
-                MergeExistingRepos(repos, existingRule?.Repos ?? [], username);
+                MergeExistingRepos(repos, existingIssueRule?.Repos ?? [], username);
                 repos = repos
                     .DistinctBy(repo => repo.NameWithOwner, StringComparer.OrdinalIgnoreCase)
                     .OrderBy(repo => repo.NameWithOwner, StringComparer.OrdinalIgnoreCase)
@@ -304,7 +304,7 @@ public static class InitCommand
                     AnsiConsole.MarkupLine("[grey]Use the group picker to edit one slice at a time. Only cloned repos can dispatch — repos are not auto-cloned.[/]");
                     AnsiConsole.WriteLine();
 
-                    var selected = PromptForRepoSelection(repos, clonedRepoSlugs, existingRule?.Repos ?? [], ghCli, username);
+                    var selected = PromptForRepoSelection(repos, clonedRepoSlugs, existingIssueRule?.Repos ?? [], ghCli, username);
 
                     var notClonedSelected = selected.Where(r => !cloneStatus.GetValueOrDefault(r)).ToList();
                     if (notClonedSelected.Count > 0)
@@ -321,7 +321,7 @@ public static class InitCommand
                         ConsoleOutput.Warning("No repos selected. You can add repos to rules later.");
                     }
 
-                    defaultRule.Repos = selected;
+                    defaultIssueRule.Repos = selected;
                     CopilotTrustCommandHelper.EnsureTrustedFoldersForRepositories(
                         copilotTrust,
                         repoResolver,
@@ -352,13 +352,13 @@ public static class InitCommand
                 summaryTable.AddRow("[blue]Default model[/]", Markup.Escape(config.DefaultModel ?? "(copilot default)"));
                 summaryTable.AddRow("", "");
                 summaryTable.AddRow("[bold blue]Default Rule[/]", "");
-                summaryTable.AddRow("[blue]  Assignee[/]", Markup.Escape(defaultRule.Assignee ?? "*"));
-                summaryTable.AddRow("[blue]  Author filter[/]", Markup.Escape(FormatAuthorMode(defaultRule)));
-                summaryTable.AddRow("[blue]  Labels[/]", Markup.Escape(string.Join(", ", defaultRule.Labels)));
-                summaryTable.AddRow("[blue]  Permissions[/]", Markup.Escape(FormatPermissions(defaultRule)));
-                summaryTable.AddRow("[blue]  Model override[/]", Markup.Escape(defaultRule.Model ?? "(inherit global)"));
+                summaryTable.AddRow("[blue]  Assignee[/]", Markup.Escape(defaultIssueRule.Assignee ?? "*"));
+                summaryTable.AddRow("[blue]  Author filter[/]", Markup.Escape(FormatAuthorMode(defaultIssueRule)));
+                summaryTable.AddRow("[blue]  Labels[/]", Markup.Escape(string.Join(", ", defaultIssueRule.Labels)));
+                summaryTable.AddRow("[blue]  Permissions[/]", Markup.Escape(FormatPermissions(defaultIssueRule)));
+                summaryTable.AddRow("[blue]  Model override[/]", Markup.Escape(defaultIssueRule.Model ?? "(inherit global)"));
                 summaryTable.AddRow("[blue]  Repos[/]", Markup.Escape(
-                    defaultRule.Repos.Count > 0 ? string.Join(", ", defaultRule.Repos) : "(none)"));
+                    defaultIssueRule.Repos.Count > 0 ? string.Join(", ", defaultIssueRule.Repos) : "(none)"));
 
                 AnsiConsole.Write(summaryTable);
                 AnsiConsole.WriteLine();

--- a/src/copilotd/Commands/RulesCommand.cs
+++ b/src/copilotd/Commands/RulesCommand.cs
@@ -76,18 +76,29 @@ public static class RulesCommand
     private static int RenderRulesList(CopilotdConfig config, string? repoFilter, string? assigneeFilter, bool assigneeFlagPresent)
     {
         var rules = config.Rules.AsEnumerable();
+        var prRules = config.PullRequestRules.AsEnumerable();
 
         if (repoFilter is not null)
+        {
             rules = rules.Where(r => r.Value.Repos.Contains(repoFilter, StringComparer.OrdinalIgnoreCase));
+            prRules = prRules.Where(r => r.Value.Repos.Contains(repoFilter, StringComparer.OrdinalIgnoreCase));
+        }
 
         if (assigneeFlagPresent)
         {
             if (assigneeFilter is not null)
-                rules = rules.Where(r => string.Equals(r.Value.User, assigneeFilter, StringComparison.OrdinalIgnoreCase));
+            {
+                rules = rules.Where(r => string.Equals(r.Value.Assignee, assigneeFilter, StringComparison.OrdinalIgnoreCase));
+                prRules = prRules.Where(r => string.Equals(r.Value.Assignee, assigneeFilter, StringComparison.OrdinalIgnoreCase));
+            }
             else
-                rules = rules.Where(r => r.Value.User is not null);
+            {
+                rules = rules.Where(r => r.Value.Assignee is not null);
+                prRules = prRules.Where(r => r.Value.Assignee is not null);
+            }
         }
 
+        AnsiConsole.MarkupLine("[bold]Issue dispatch rules[/]");
         var table = new Table();
         table.ShowRowSeparators = true;
         table.AddColumn(new TableColumn("[bold]Name[/]"));
@@ -105,7 +116,7 @@ public static class RulesCommand
             var rule = kvp.Value;
             table.AddRow(
                 Markup.Escape(name),
-                Markup.Escape(rule.User ?? "*"),
+                Markup.Escape(rule.Assignee ?? "*"),
                 Markup.Escape(FormatAuthorMode(rule)),
                 Markup.Escape(string.Join(", ", rule.Labels)),
                 Markup.Escape(rule.Milestone ?? "*"),
@@ -115,10 +126,44 @@ public static class RulesCommand
         }
 
         AnsiConsole.Write(table);
+
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine("[bold]Pull request dispatch rules[/]");
+        var prTable = new Table();
+        prTable.ShowRowSeparators = true;
+        prTable.AddColumn(new TableColumn("[bold]Name[/]"));
+        prTable.AddColumn(new TableColumn("[bold]Assignee[/]"));
+        prTable.AddColumn(new TableColumn("[bold]Authors[/]"));
+        prTable.AddColumn(new TableColumn("[bold]Labels[/]"));
+        prTable.AddColumn(new TableColumn("[bold]Base[/]"));
+        prTable.AddColumn(new TableColumn("[bold]Draft[/]"));
+        prTable.AddColumn(new TableColumn("[bold]Review[/]"));
+        prTable.AddColumn(new TableColumn("[bold]Branch[/]"));
+        prTable.AddColumn(new TableColumn("[bold]Repos[/]"));
+        prTable.AddColumn(new TableColumn("[bold]Launch Options[/]"));
+
+        foreach (var kvp in prRules)
+        {
+            var name = kvp.Key;
+            var rule = kvp.Value;
+            prTable.AddRow(
+                Markup.Escape(name),
+                Markup.Escape(rule.Assignee ?? "*"),
+                Markup.Escape(FormatAuthorMode(rule)),
+                Markup.Escape(string.Join(", ", rule.Labels)),
+                Markup.Escape(rule.BaseBranch ?? "*"),
+                Markup.Escape(rule.Draft?.ToString() ?? "*"),
+                Markup.Escape(rule.ReviewDecision ?? "*"),
+                Markup.Escape(rule.BranchStrategy.ToString()),
+                Markup.Escape(string.Join(", ", rule.Repos)),
+                Markup.Escape(FormatLaunchOptions(rule)));
+        }
+
+        AnsiConsole.Write(prTable);
         return 0;
     }
 
-    private static string FormatLaunchOptions(DispatchRule rule)
+    private static string FormatLaunchOptions(DispatchRuleOptions rule)
     {
         var parts = new List<string>();
 
@@ -138,7 +183,17 @@ public static class RulesCommand
         return parts.Count > 0 ? string.Join(", ", parts) : "(defaults)";
     }
 
-    private static string FormatAuthorMode(DispatchRule rule)
+    private static string FormatAuthorMode(IssueDispatchRule rule)
+    {
+        return rule.AuthorMode switch
+        {
+            AuthorMode.Allowed => string.Join(", ", rule.Authors),
+            AuthorMode.WriteAccess => "(write access)",
+            _ => "*",
+        };
+    }
+
+    private static string FormatAuthorMode(PullRequestDispatchRule rule)
     {
         return rule.AuthorMode switch
         {
@@ -154,6 +209,7 @@ public static class RulesCommand
         command.Aliases.Add("new");
         command.Aliases.Add("create");
         var nameArg = new Argument<string>("name");
+        var kindOption = new Option<string>("--kind") { Description = "Rule kind: issue (default) or pr" };
         var assigneeOption = new Option<string?>("--assignee") { Description = "Assignee condition" };
         var labelOption = new Option<string[]>("--label") { Description = "Label condition (can be specified multiple times)", AllowMultipleArgumentsPerToken = true };
         var milestoneOption = new Option<string?>("--milestone") { Description = "Milestone condition" };
@@ -169,8 +225,15 @@ public static class RulesCommand
         var addAuthorOption = new Option<string[]>("--add-author") { Description = "Add an allowed issue author (can be specified multiple times)", AllowMultipleArgumentsPerToken = true };
         var writeOnlyAuthorsOption = new Option<bool>("--write-only-authors") { Description = "Only dispatch issues from authors with write access to the repo" };
         var anyAuthorOption = new Option<bool>("--any-author") { Description = "Allow issues from any author (default)" };
+        var baseOption = new Option<string?>("--base") { Description = "PR base branch condition (PR rules only)" };
+        var headOption = new Option<string?>("--head") { Description = "PR head branch condition (PR rules only)" };
+        var headRepoOption = new Option<string?>("--head-repo") { Description = "PR head repo condition (PR rules only)" };
+        var draftOption = new Option<bool?>("--draft") { Description = "PR draft-state condition (PR rules only)" };
+        var reviewDecisionOption = new Option<string?>("--review-decision") { Description = "PR review decision condition (PR rules only)" };
+        var branchStrategyOption = new Option<string?>("--branch-strategy") { Description = "PR branch strategy: source-branch, child-branch, or read-only" };
 
         command.Arguments.Add(nameArg);
+        command.Options.Add(kindOption);
         command.Options.Add(assigneeOption);
         command.Options.Add(labelOption);
         command.Options.Add(milestoneOption);
@@ -186,6 +249,12 @@ public static class RulesCommand
         command.Options.Add(addAuthorOption);
         command.Options.Add(writeOnlyAuthorsOption);
         command.Options.Add(anyAuthorOption);
+        command.Options.Add(baseOption);
+        command.Options.Add(headOption);
+        command.Options.Add(headRepoOption);
+        command.Options.Add(draftOption);
+        command.Options.Add(reviewDecisionOption);
+        command.Options.Add(branchStrategyOption);
 
         command.SetAction(async (ParseResult parseResult, CancellationToken ct) =>
         {
@@ -201,15 +270,90 @@ public static class RulesCommand
 
                 var name = parseResult.GetValue(nameArg)!;
 
-                if (config.Rules.ContainsKey(name))
+                if (config.Rules.ContainsKey(name) || config.PullRequestRules.ContainsKey(name))
                 {
                     ConsoleOutput.Error($"Rule '{name}' already exists. Use 'rules update' to modify it.");
                     return 1;
                 }
 
-                var rule = new DispatchRule
+                var kind = parseResult.GetValue(kindOption);
+                var isPrRule = string.Equals(kind, "pr", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(kind, "pull-request", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(kind, "pullrequest", StringComparison.OrdinalIgnoreCase);
+
+                if (!isPrRule && !string.IsNullOrWhiteSpace(kind) && !string.Equals(kind, "issue", StringComparison.OrdinalIgnoreCase))
                 {
-                    User = parseResult.GetValue(assigneeOption),
+                    ConsoleOutput.Error("Invalid --kind. Use 'issue' or 'pr'.");
+                    return 1;
+                }
+
+                if (isPrRule)
+                {
+                    if (parseResult.GetResult(milestoneOption) is not null || parseResult.GetResult(typeOption) is not null)
+                    {
+                        ConsoleOutput.Error("--milestone and --type apply only to issue rules.");
+                        return 1;
+                    }
+
+                    var branchStrategyValue = parseResult.GetValue(branchStrategyOption);
+                    if (!TryParseBranchStrategy(branchStrategyValue, out var branchStrategy))
+                    {
+                        ConsoleOutput.Error("Invalid --branch-strategy. Use 'source-branch', 'child-branch', or 'read-only'.");
+                        return 1;
+                    }
+
+                    var prRule = new PullRequestDispatchRule
+                    {
+                        Assignee = parseResult.GetValue(assigneeOption),
+                        Labels = [.. parseResult.GetValue(labelOption) ?? []],
+                        BaseBranch = parseResult.GetValue(baseOption),
+                        HeadBranch = parseResult.GetValue(headOption),
+                        HeadRepo = parseResult.GetValue(headRepoOption),
+                        Draft = parseResult.GetValue(draftOption),
+                        ReviewDecision = parseResult.GetValue(reviewDecisionOption),
+                        BranchStrategy = branchStrategy,
+                        Yolo = parseResult.GetValue(yoloOption),
+                        AllowAllTools = parseResult.GetValue(allowAllToolsOption) ?? true,
+                        AllowAllUrls = parseResult.GetValue(allowAllUrlsOption) ?? false,
+                        Model = string.IsNullOrWhiteSpace(parseResult.GetValue(modelOption)) ? null : parseResult.GetValue(modelOption),
+                        ExtraPrompt = parseResult.GetValue(promptOption),
+                        CustomPrompt = parseResult.GetValue(customPromptOption),
+                        Repos = [.. parseResult.GetValue(repoOption) ?? []],
+                        Authors = [.. parseResult.GetValue(addAuthorOption) ?? []],
+                    };
+
+                    if (parseResult.GetValue(writeOnlyAuthorsOption))
+                        prRule.AuthorMode = AuthorMode.WriteAccess;
+                    else if (prRule.Authors.Count > 0)
+                        prRule.AuthorMode = AuthorMode.Allowed;
+
+                    var prModeValue = parseResult.GetValue(customPromptModeOption);
+                    if (prModeValue is not null)
+                    {
+                        if (!TryParsePromptMode(prModeValue, out var prMode))
+                        {
+                            ConsoleOutput.Error("Invalid --custom-prompt-mode. Use 'append' or 'override'.");
+                            return 1;
+                        }
+                        prRule.CustomPromptMode = prMode;
+                    }
+
+                    config.PullRequestRules[name] = prRule;
+                    CopilotTrustCommandHelper.EnsureTrustedFoldersForRepositories(
+                        copilotTrust,
+                        repoResolver,
+                        copilotCli,
+                        config,
+                        state,
+                        prRule.Repos);
+                    stateStore.SaveConfig(config);
+                    ConsoleOutput.Success($"Pull request rule '{name}' added.");
+                    return 0;
+                }
+
+                var rule = new IssueDispatchRule
+                {
+                    Assignee = parseResult.GetValue(assigneeOption),
                     Labels = [.. parseResult.GetValue(labelOption) ?? []],
                     Milestone = parseResult.GetValue(milestoneOption),
                     Type = parseResult.GetValue(typeOption),
@@ -285,6 +429,12 @@ public static class RulesCommand
         var deleteAuthorOption = new Option<string[]>("--delete-author") { Description = "Remove an allowed issue author", AllowMultipleArgumentsPerToken = true };
         var writeOnlyAuthorsOption = new Option<bool>("--write-only-authors") { Description = "Only dispatch issues from authors with write access to the repo" };
         var anyAuthorOption = new Option<bool>("--any-author") { Description = "Allow issues from any author (clears author list)" };
+        var baseOption = new Option<string?>("--base") { Description = "Update PR base branch condition (PR rules only)" };
+        var headOption = new Option<string?>("--head") { Description = "Update PR head branch condition (PR rules only)" };
+        var headRepoOption = new Option<string?>("--head-repo") { Description = "Update PR head repo condition (PR rules only)" };
+        var draftOption = new Option<bool?>("--draft") { Description = "Update PR draft-state condition (PR rules only)" };
+        var reviewDecisionOption = new Option<string?>("--review-decision") { Description = "Update PR review decision condition (PR rules only)" };
+        var branchStrategyOption = new Option<string?>("--branch-strategy") { Description = "Update PR branch strategy: source-branch, child-branch, or read-only" };
 
         command.Arguments.Add(nameArg);
         command.Options.Add(assigneeOption);
@@ -305,6 +455,12 @@ public static class RulesCommand
         command.Options.Add(deleteAuthorOption);
         command.Options.Add(writeOnlyAuthorsOption);
         command.Options.Add(anyAuthorOption);
+        command.Options.Add(baseOption);
+        command.Options.Add(headOption);
+        command.Options.Add(headRepoOption);
+        command.Options.Add(draftOption);
+        command.Options.Add(reviewDecisionOption);
+        command.Options.Add(branchStrategyOption);
 
         command.SetAction(async (ParseResult parseResult, CancellationToken ct) =>
         {
@@ -322,12 +478,142 @@ public static class RulesCommand
 
                 if (!config.Rules.TryGetValue(name, out var rule))
                 {
-                    ConsoleOutput.Error($"Rule '{name}' not found.");
-                    return 1;
+                    if (!config.PullRequestRules.TryGetValue(name, out var prRule))
+                    {
+                        ConsoleOutput.Error($"Rule '{name}' not found.");
+                        return 1;
+                    }
+
+                    if (parseResult.GetResult(milestoneOption) is not null || parseResult.GetResult(typeOption) is not null)
+                    {
+                        ConsoleOutput.Error("--milestone and --type apply only to issue rules.");
+                        return 1;
+                    }
+
+                    if (parseResult.GetResult(assigneeOption) is not null)
+                        prRule.Assignee = parseResult.GetValue(assigneeOption);
+
+                    var prAddLabels = parseResult.GetValue(addLabelOption) ?? [];
+                    var prDeleteLabels = parseResult.GetValue(deleteLabelOption) ?? [];
+                    foreach (var label in prDeleteLabels)
+                        prRule.Labels.Remove(label);
+                    foreach (var label in prAddLabels)
+                    {
+                        if (!prRule.Labels.Contains(label, StringComparer.OrdinalIgnoreCase))
+                            prRule.Labels.Add(label);
+                    }
+
+                    if (parseResult.GetResult(baseOption) is not null)
+                        prRule.BaseBranch = parseResult.GetValue(baseOption);
+
+                    if (parseResult.GetResult(headOption) is not null)
+                        prRule.HeadBranch = parseResult.GetValue(headOption);
+
+                    if (parseResult.GetResult(headRepoOption) is not null)
+                        prRule.HeadRepo = parseResult.GetValue(headRepoOption);
+
+                    if (parseResult.GetResult(draftOption) is not null)
+                        prRule.Draft = parseResult.GetValue(draftOption);
+
+                    if (parseResult.GetResult(reviewDecisionOption) is not null)
+                        prRule.ReviewDecision = parseResult.GetValue(reviewDecisionOption);
+
+                    if (parseResult.GetResult(branchStrategyOption) is not null)
+                    {
+                        if (!TryParseBranchStrategy(parseResult.GetValue(branchStrategyOption), out var branchStrategy))
+                        {
+                            ConsoleOutput.Error("Invalid --branch-strategy. Use 'source-branch', 'child-branch', or 'read-only'.");
+                            return 1;
+                        }
+                        prRule.BranchStrategy = branchStrategy;
+                    }
+
+                    if (parseResult.GetResult(yoloOption) is not null)
+                        prRule.Yolo = parseResult.GetValue(yoloOption) ?? false;
+
+                    if (parseResult.GetResult(allowAllToolsOption) is not null)
+                        prRule.AllowAllTools = parseResult.GetValue(allowAllToolsOption) ?? true;
+
+                    if (parseResult.GetResult(allowAllUrlsOption) is not null)
+                        prRule.AllowAllUrls = parseResult.GetValue(allowAllUrlsOption) ?? false;
+
+                    if (parseResult.GetResult(promptOption) is not null)
+                        prRule.ExtraPrompt = parseResult.GetValue(promptOption);
+
+                    if (parseResult.GetResult(modelOption) is not null)
+                    {
+                        var modelValue = parseResult.GetValue(modelOption);
+                        prRule.Model = string.IsNullOrWhiteSpace(modelValue) ? null : modelValue;
+                    }
+
+                    if (parseResult.GetResult(customPromptOption) is not null)
+                        prRule.CustomPrompt = parseResult.GetValue(customPromptOption);
+
+                    if (parseResult.GetResult(customPromptModeOption) is not null)
+                    {
+                        var modeValue = parseResult.GetValue(customPromptModeOption);
+                        if (!TryParsePromptMode(modeValue, out var mode))
+                        {
+                            ConsoleOutput.Error("Invalid --custom-prompt-mode. Use 'append' or 'override'.");
+                            return 1;
+                        }
+                        prRule.CustomPromptMode = mode;
+                    }
+
+                    var prAddRepos = parseResult.GetValue(addRepoOption) ?? [];
+                    var prDeleteRepos = parseResult.GetValue(deleteRepoOption) ?? [];
+                    foreach (var repo in prDeleteRepos)
+                        prRule.Repos.RemoveAll(r => string.Equals(r, repo, StringComparison.OrdinalIgnoreCase));
+                    foreach (var repo in prAddRepos)
+                    {
+                        if (!prRule.Repos.Contains(repo, StringComparer.OrdinalIgnoreCase))
+                            prRule.Repos.Add(repo);
+                    }
+
+                    if (parseResult.GetValue(anyAuthorOption))
+                    {
+                        prRule.AuthorMode = AuthorMode.Any;
+                        prRule.Authors.Clear();
+                    }
+                    else if (parseResult.GetValue(writeOnlyAuthorsOption))
+                    {
+                        prRule.AuthorMode = AuthorMode.WriteAccess;
+                        prRule.Authors.Clear();
+                    }
+
+                    var prAddAuthors = parseResult.GetValue(addAuthorOption) ?? [];
+                    var prDeleteAuthors = parseResult.GetValue(deleteAuthorOption) ?? [];
+                    foreach (var author in prDeleteAuthors)
+                        prRule.Authors.RemoveAll(a => string.Equals(a, author, StringComparison.OrdinalIgnoreCase));
+                    foreach (var author in prAddAuthors)
+                    {
+                        if (!prRule.Authors.Contains(author, StringComparer.OrdinalIgnoreCase))
+                            prRule.Authors.Add(author);
+                    }
+
+                    if (prRule.Authors.Count > 0 && prRule.AuthorMode == AuthorMode.Any)
+                    {
+                        prRule.AuthorMode = AuthorMode.Allowed;
+                    }
+
+                    if (prAddRepos.Length > 0)
+                    {
+                        CopilotTrustCommandHelper.EnsureTrustedFoldersForRepositories(
+                            copilotTrust,
+                            repoResolver,
+                            copilotCli,
+                            config,
+                            state,
+                            prAddRepos);
+                    }
+
+                    stateStore.SaveConfig(config);
+                    ConsoleOutput.Success($"Pull request rule '{name}' updated.");
+                    return 0;
                 }
 
                 if (parseResult.GetResult(assigneeOption) is not null)
-                    rule.User = parseResult.GetValue(assigneeOption);
+                    rule.Assignee = parseResult.GetValue(assigneeOption);
 
                 var addLabels = parseResult.GetValue(addLabelOption) ?? [];
                 var deleteLabels = parseResult.GetValue(deleteLabelOption) ?? [];
@@ -458,7 +744,11 @@ public static class RulesCommand
                     return 1;
                 }
 
-                if (!config.Rules.Remove(name))
+                var removed = config.Rules.Remove(name);
+                if (!removed)
+                    removed = config.PullRequestRules.Remove(name);
+
+                if (!removed)
                 {
                     ConsoleOutput.Error($"Rule '{name}' not found.");
                     return 1;
@@ -488,6 +778,39 @@ public static class RulesCommand
         if (string.Equals(value, "override", StringComparison.OrdinalIgnoreCase))
         {
             mode = PromptMode.Override;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryParseBranchStrategy(string? value, out PullRequestBranchStrategy strategy)
+    {
+        strategy = PullRequestBranchStrategy.SourceBranch;
+        if (string.IsNullOrWhiteSpace(value))
+            return true;
+
+        if (string.Equals(value, "source-branch", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(value, "source", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(value, nameof(PullRequestBranchStrategy.SourceBranch), StringComparison.OrdinalIgnoreCase))
+        {
+            strategy = PullRequestBranchStrategy.SourceBranch;
+            return true;
+        }
+
+        if (string.Equals(value, "child-branch", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(value, "child", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(value, nameof(PullRequestBranchStrategy.ChildBranch), StringComparison.OrdinalIgnoreCase))
+        {
+            strategy = PullRequestBranchStrategy.ChildBranch;
+            return true;
+        }
+
+        if (string.Equals(value, "read-only", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(value, "readonly", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(value, nameof(PullRequestBranchStrategy.ReadOnly), StringComparison.OrdinalIgnoreCase))
+        {
+            strategy = PullRequestBranchStrategy.ReadOnly;
             return true;
         }
 

--- a/src/copilotd/Commands/RulesCommand.cs
+++ b/src/copilotd/Commands/RulesCommand.cs
@@ -75,26 +75,26 @@ public static class RulesCommand
 
     private static int RenderRulesList(CopilotdConfig config, string? repoFilter, string? assigneeFilter, bool assigneeFlagPresent)
     {
-        var rules = config.Rules.AsEnumerable();
-        var prRules = config.PullRequestRules.AsEnumerable();
+        var issueRules = config.IssueRules.AsEnumerable();
+        var pullRequestRules = config.PullRequestRules.AsEnumerable();
 
         if (repoFilter is not null)
         {
-            rules = rules.Where(r => r.Value.Repos.Contains(repoFilter, StringComparer.OrdinalIgnoreCase));
-            prRules = prRules.Where(r => r.Value.Repos.Contains(repoFilter, StringComparer.OrdinalIgnoreCase));
+            issueRules = issueRules.Where(r => r.Value.Repos.Contains(repoFilter, StringComparer.OrdinalIgnoreCase));
+            pullRequestRules = pullRequestRules.Where(r => r.Value.Repos.Contains(repoFilter, StringComparer.OrdinalIgnoreCase));
         }
 
         if (assigneeFlagPresent)
         {
             if (assigneeFilter is not null)
             {
-                rules = rules.Where(r => string.Equals(r.Value.Assignee, assigneeFilter, StringComparison.OrdinalIgnoreCase));
-                prRules = prRules.Where(r => string.Equals(r.Value.Assignee, assigneeFilter, StringComparison.OrdinalIgnoreCase));
+                issueRules = issueRules.Where(r => string.Equals(r.Value.Assignee, assigneeFilter, StringComparison.OrdinalIgnoreCase));
+                pullRequestRules = pullRequestRules.Where(r => string.Equals(r.Value.Assignee, assigneeFilter, StringComparison.OrdinalIgnoreCase));
             }
             else
             {
-                rules = rules.Where(r => r.Value.Assignee is not null);
-                prRules = prRules.Where(r => r.Value.Assignee is not null);
+                issueRules = issueRules.Where(r => r.Value.Assignee is not null);
+                pullRequestRules = pullRequestRules.Where(r => r.Value.Assignee is not null);
             }
         }
 
@@ -110,19 +110,19 @@ public static class RulesCommand
         table.AddColumn(new TableColumn("[bold]Repos[/]"));
         table.AddColumn(new TableColumn("[bold]Launch Options[/]"));
 
-        foreach (var kvp in rules)
+        foreach (var kvp in issueRules)
         {
             var name = kvp.Key;
-            var rule = kvp.Value;
+            var issueRule = kvp.Value;
             table.AddRow(
                 Markup.Escape(name),
-                Markup.Escape(rule.Assignee ?? "*"),
-                Markup.Escape(FormatAuthorMode(rule)),
-                Markup.Escape(string.Join(", ", rule.Labels)),
-                Markup.Escape(rule.Milestone ?? "*"),
-                Markup.Escape(rule.Type ?? "*"),
-                Markup.Escape(string.Join(", ", rule.Repos)),
-                Markup.Escape(FormatLaunchOptions(rule)));
+                Markup.Escape(issueRule.Assignee ?? "*"),
+                Markup.Escape(FormatAuthorMode(issueRule)),
+                Markup.Escape(string.Join(", ", issueRule.Labels)),
+                Markup.Escape(issueRule.Milestone ?? "*"),
+                Markup.Escape(issueRule.Type ?? "*"),
+                Markup.Escape(string.Join(", ", issueRule.Repos)),
+                Markup.Escape(FormatLaunchOptions(issueRule)));
         }
 
         AnsiConsole.Write(table);
@@ -142,62 +142,62 @@ public static class RulesCommand
         prTable.AddColumn(new TableColumn("[bold]Repos[/]"));
         prTable.AddColumn(new TableColumn("[bold]Launch Options[/]"));
 
-        foreach (var kvp in prRules)
+        foreach (var kvp in pullRequestRules)
         {
             var name = kvp.Key;
-            var rule = kvp.Value;
+            var pullRequestRule = kvp.Value;
             prTable.AddRow(
                 Markup.Escape(name),
-                Markup.Escape(rule.Assignee ?? "*"),
-                Markup.Escape(FormatAuthorMode(rule)),
-                Markup.Escape(string.Join(", ", rule.Labels)),
-                Markup.Escape(rule.BaseBranch ?? "*"),
-                Markup.Escape(rule.Draft?.ToString() ?? "*"),
-                Markup.Escape(rule.ReviewDecision ?? "*"),
-                Markup.Escape(rule.BranchStrategy.ToString()),
-                Markup.Escape(string.Join(", ", rule.Repos)),
-                Markup.Escape(FormatLaunchOptions(rule)));
+                Markup.Escape(pullRequestRule.Assignee ?? "*"),
+                Markup.Escape(FormatAuthorMode(pullRequestRule)),
+                Markup.Escape(string.Join(", ", pullRequestRule.Labels)),
+                Markup.Escape(pullRequestRule.BaseBranch ?? "*"),
+                Markup.Escape(pullRequestRule.Draft?.ToString() ?? "*"),
+                Markup.Escape(pullRequestRule.ReviewDecision ?? "*"),
+                Markup.Escape(pullRequestRule.BranchStrategy.ToString()),
+                Markup.Escape(string.Join(", ", pullRequestRule.Repos)),
+                Markup.Escape(FormatLaunchOptions(pullRequestRule)));
         }
 
         AnsiConsole.Write(prTable);
         return 0;
     }
 
-    private static string FormatLaunchOptions(DispatchRuleOptions rule)
+    private static string FormatLaunchOptions(DispatchRuleOptions dispatchRule)
     {
         var parts = new List<string>();
 
-        if (rule.Yolo)
+        if (dispatchRule.Yolo)
         {
             parts.Add("--yolo");
         }
         else
         {
-            if (rule.AllowAllTools) parts.Add("--allow-all-tools");
-            if (rule.AllowAllUrls) parts.Add("--allow-all-urls");
+            if (dispatchRule.AllowAllTools) parts.Add("--allow-all-tools");
+            if (dispatchRule.AllowAllUrls) parts.Add("--allow-all-urls");
         }
 
-        if (rule.Model is not null)
-            parts.Add($"--model={rule.Model}");
+        if (dispatchRule.Model is not null)
+            parts.Add($"--model={dispatchRule.Model}");
 
         return parts.Count > 0 ? string.Join(", ", parts) : "(defaults)";
     }
 
-    private static string FormatAuthorMode(IssueDispatchRule rule)
+    private static string FormatAuthorMode(IssueDispatchRule issueRule)
     {
-        return rule.AuthorMode switch
+        return issueRule.AuthorMode switch
         {
-            AuthorMode.Allowed => string.Join(", ", rule.Authors),
+            AuthorMode.Allowed => string.Join(", ", issueRule.Authors),
             AuthorMode.WriteAccess => "(write access)",
             _ => "*",
         };
     }
 
-    private static string FormatAuthorMode(PullRequestDispatchRule rule)
+    private static string FormatAuthorMode(PullRequestDispatchRule pullRequestRule)
     {
-        return rule.AuthorMode switch
+        return pullRequestRule.AuthorMode switch
         {
-            AuthorMode.Allowed => string.Join(", ", rule.Authors),
+            AuthorMode.Allowed => string.Join(", ", pullRequestRule.Authors),
             AuthorMode.WriteAccess => "(write access)",
             _ => "*",
         };
@@ -270,7 +270,7 @@ public static class RulesCommand
 
                 var name = parseResult.GetValue(nameArg)!;
 
-                if (config.Rules.ContainsKey(name) || config.PullRequestRules.ContainsKey(name))
+                if (config.IssueRules.ContainsKey(name) || config.PullRequestRules.ContainsKey(name))
                 {
                     ConsoleOutput.Error($"Rule '{name}' already exists. Use 'rules update' to modify it.");
                     return 1;
@@ -302,7 +302,7 @@ public static class RulesCommand
                         return 1;
                     }
 
-                    var prRule = new PullRequestDispatchRule
+                    var pullRequestRule = new PullRequestDispatchRule
                     {
                         Assignee = parseResult.GetValue(assigneeOption),
                         Labels = [.. parseResult.GetValue(labelOption) ?? []],
@@ -323,9 +323,9 @@ public static class RulesCommand
                     };
 
                     if (parseResult.GetValue(writeOnlyAuthorsOption))
-                        prRule.AuthorMode = AuthorMode.WriteAccess;
-                    else if (prRule.Authors.Count > 0)
-                        prRule.AuthorMode = AuthorMode.Allowed;
+                        pullRequestRule.AuthorMode = AuthorMode.WriteAccess;
+                    else if (pullRequestRule.Authors.Count > 0)
+                        pullRequestRule.AuthorMode = AuthorMode.Allowed;
 
                     var prModeValue = parseResult.GetValue(customPromptModeOption);
                     if (prModeValue is not null)
@@ -335,23 +335,23 @@ public static class RulesCommand
                             ConsoleOutput.Error("Invalid --custom-prompt-mode. Use 'append' or 'override'.");
                             return 1;
                         }
-                        prRule.CustomPromptMode = prMode;
+                        pullRequestRule.CustomPromptMode = prMode;
                     }
 
-                    config.PullRequestRules[name] = prRule;
+                    config.PullRequestRules[name] = pullRequestRule;
                     CopilotTrustCommandHelper.EnsureTrustedFoldersForRepositories(
                         copilotTrust,
                         repoResolver,
                         copilotCli,
                         config,
                         state,
-                        prRule.Repos);
+                        pullRequestRule.Repos);
                     stateStore.SaveConfig(config);
                     ConsoleOutput.Success($"Pull request rule '{name}' added.");
                     return 0;
                 }
 
-                var rule = new IssueDispatchRule
+                var issueRule = new IssueDispatchRule
                 {
                     Assignee = parseResult.GetValue(assigneeOption),
                     Labels = [.. parseResult.GetValue(labelOption) ?? []],
@@ -370,11 +370,11 @@ public static class RulesCommand
                 // Author mode: --write-only-authors wins over --add-author, --any-author is default
                 if (parseResult.GetValue(writeOnlyAuthorsOption))
                 {
-                    rule.AuthorMode = AuthorMode.WriteAccess;
+                    issueRule.AuthorMode = AuthorMode.WriteAccess;
                 }
-                else if (rule.Authors.Count > 0)
+                else if (issueRule.Authors.Count > 0)
                 {
-                    rule.AuthorMode = AuthorMode.Allowed;
+                    issueRule.AuthorMode = AuthorMode.Allowed;
                 }
                 // else: AuthorMode.Any (default)
 
@@ -386,17 +386,17 @@ public static class RulesCommand
                         ConsoleOutput.Error("Invalid --custom-prompt-mode. Use 'append' or 'override'.");
                         return 1;
                     }
-                    rule.CustomPromptMode = mode;
+                    issueRule.CustomPromptMode = mode;
                 }
 
-                config.Rules[name] = rule;
+                config.IssueRules[name] = issueRule;
                 CopilotTrustCommandHelper.EnsureTrustedFoldersForRepositories(
                     copilotTrust,
                     repoResolver,
                     copilotCli,
                     config,
                     state,
-                    rule.Repos);
+                    issueRule.Repos);
                 stateStore.SaveConfig(config);
                 ConsoleOutput.Success($"Rule '{name}' added.");
                 return 0;
@@ -476,9 +476,9 @@ public static class RulesCommand
 
                 var name = parseResult.GetValue(nameArg)!;
 
-                if (!config.Rules.TryGetValue(name, out var rule))
+                if (!config.IssueRules.TryGetValue(name, out var issueRule))
                 {
-                    if (!config.PullRequestRules.TryGetValue(name, out var prRule))
+                    if (!config.PullRequestRules.TryGetValue(name, out var pullRequestRule))
                     {
                         ConsoleOutput.Error($"Rule '{name}' not found.");
                         return 1;
@@ -491,32 +491,32 @@ public static class RulesCommand
                     }
 
                     if (parseResult.GetResult(assigneeOption) is not null)
-                        prRule.Assignee = parseResult.GetValue(assigneeOption);
+                        pullRequestRule.Assignee = parseResult.GetValue(assigneeOption);
 
                     var prAddLabels = parseResult.GetValue(addLabelOption) ?? [];
                     var prDeleteLabels = parseResult.GetValue(deleteLabelOption) ?? [];
                     foreach (var label in prDeleteLabels)
-                        prRule.Labels.Remove(label);
+                        pullRequestRule.Labels.Remove(label);
                     foreach (var label in prAddLabels)
                     {
-                        if (!prRule.Labels.Contains(label, StringComparer.OrdinalIgnoreCase))
-                            prRule.Labels.Add(label);
+                        if (!pullRequestRule.Labels.Contains(label, StringComparer.OrdinalIgnoreCase))
+                            pullRequestRule.Labels.Add(label);
                     }
 
                     if (parseResult.GetResult(baseOption) is not null)
-                        prRule.BaseBranch = parseResult.GetValue(baseOption);
+                        pullRequestRule.BaseBranch = parseResult.GetValue(baseOption);
 
                     if (parseResult.GetResult(headOption) is not null)
-                        prRule.HeadBranch = parseResult.GetValue(headOption);
+                        pullRequestRule.HeadBranch = parseResult.GetValue(headOption);
 
                     if (parseResult.GetResult(headRepoOption) is not null)
-                        prRule.HeadRepo = parseResult.GetValue(headRepoOption);
+                        pullRequestRule.HeadRepo = parseResult.GetValue(headRepoOption);
 
                     if (parseResult.GetResult(draftOption) is not null)
-                        prRule.Draft = parseResult.GetValue(draftOption);
+                        pullRequestRule.Draft = parseResult.GetValue(draftOption);
 
                     if (parseResult.GetResult(reviewDecisionOption) is not null)
-                        prRule.ReviewDecision = parseResult.GetValue(reviewDecisionOption);
+                        pullRequestRule.ReviewDecision = parseResult.GetValue(reviewDecisionOption);
 
                     if (parseResult.GetResult(branchStrategyOption) is not null)
                     {
@@ -525,29 +525,29 @@ public static class RulesCommand
                             ConsoleOutput.Error("Invalid --branch-strategy. Use 'source-branch', 'child-branch', or 'read-only'.");
                             return 1;
                         }
-                        prRule.BranchStrategy = branchStrategy;
+                        pullRequestRule.BranchStrategy = branchStrategy;
                     }
 
                     if (parseResult.GetResult(yoloOption) is not null)
-                        prRule.Yolo = parseResult.GetValue(yoloOption) ?? false;
+                        pullRequestRule.Yolo = parseResult.GetValue(yoloOption) ?? false;
 
                     if (parseResult.GetResult(allowAllToolsOption) is not null)
-                        prRule.AllowAllTools = parseResult.GetValue(allowAllToolsOption) ?? true;
+                        pullRequestRule.AllowAllTools = parseResult.GetValue(allowAllToolsOption) ?? true;
 
                     if (parseResult.GetResult(allowAllUrlsOption) is not null)
-                        prRule.AllowAllUrls = parseResult.GetValue(allowAllUrlsOption) ?? false;
+                        pullRequestRule.AllowAllUrls = parseResult.GetValue(allowAllUrlsOption) ?? false;
 
                     if (parseResult.GetResult(promptOption) is not null)
-                        prRule.ExtraPrompt = parseResult.GetValue(promptOption);
+                        pullRequestRule.ExtraPrompt = parseResult.GetValue(promptOption);
 
                     if (parseResult.GetResult(modelOption) is not null)
                     {
                         var modelValue = parseResult.GetValue(modelOption);
-                        prRule.Model = string.IsNullOrWhiteSpace(modelValue) ? null : modelValue;
+                        pullRequestRule.Model = string.IsNullOrWhiteSpace(modelValue) ? null : modelValue;
                     }
 
                     if (parseResult.GetResult(customPromptOption) is not null)
-                        prRule.CustomPrompt = parseResult.GetValue(customPromptOption);
+                        pullRequestRule.CustomPrompt = parseResult.GetValue(customPromptOption);
 
                     if (parseResult.GetResult(customPromptModeOption) is not null)
                     {
@@ -557,43 +557,43 @@ public static class RulesCommand
                             ConsoleOutput.Error("Invalid --custom-prompt-mode. Use 'append' or 'override'.");
                             return 1;
                         }
-                        prRule.CustomPromptMode = mode;
+                        pullRequestRule.CustomPromptMode = mode;
                     }
 
                     var prAddRepos = parseResult.GetValue(addRepoOption) ?? [];
                     var prDeleteRepos = parseResult.GetValue(deleteRepoOption) ?? [];
                     foreach (var repo in prDeleteRepos)
-                        prRule.Repos.RemoveAll(r => string.Equals(r, repo, StringComparison.OrdinalIgnoreCase));
+                        pullRequestRule.Repos.RemoveAll(r => string.Equals(r, repo, StringComparison.OrdinalIgnoreCase));
                     foreach (var repo in prAddRepos)
                     {
-                        if (!prRule.Repos.Contains(repo, StringComparer.OrdinalIgnoreCase))
-                            prRule.Repos.Add(repo);
+                        if (!pullRequestRule.Repos.Contains(repo, StringComparer.OrdinalIgnoreCase))
+                            pullRequestRule.Repos.Add(repo);
                     }
 
                     if (parseResult.GetValue(anyAuthorOption))
                     {
-                        prRule.AuthorMode = AuthorMode.Any;
-                        prRule.Authors.Clear();
+                        pullRequestRule.AuthorMode = AuthorMode.Any;
+                        pullRequestRule.Authors.Clear();
                     }
                     else if (parseResult.GetValue(writeOnlyAuthorsOption))
                     {
-                        prRule.AuthorMode = AuthorMode.WriteAccess;
-                        prRule.Authors.Clear();
+                        pullRequestRule.AuthorMode = AuthorMode.WriteAccess;
+                        pullRequestRule.Authors.Clear();
                     }
 
                     var prAddAuthors = parseResult.GetValue(addAuthorOption) ?? [];
                     var prDeleteAuthors = parseResult.GetValue(deleteAuthorOption) ?? [];
                     foreach (var author in prDeleteAuthors)
-                        prRule.Authors.RemoveAll(a => string.Equals(a, author, StringComparison.OrdinalIgnoreCase));
+                        pullRequestRule.Authors.RemoveAll(a => string.Equals(a, author, StringComparison.OrdinalIgnoreCase));
                     foreach (var author in prAddAuthors)
                     {
-                        if (!prRule.Authors.Contains(author, StringComparer.OrdinalIgnoreCase))
-                            prRule.Authors.Add(author);
+                        if (!pullRequestRule.Authors.Contains(author, StringComparer.OrdinalIgnoreCase))
+                            pullRequestRule.Authors.Add(author);
                     }
 
-                    if (prRule.Authors.Count > 0 && prRule.AuthorMode == AuthorMode.Any)
+                    if (pullRequestRule.Authors.Count > 0 && pullRequestRule.AuthorMode == AuthorMode.Any)
                     {
-                        prRule.AuthorMode = AuthorMode.Allowed;
+                        pullRequestRule.AuthorMode = AuthorMode.Allowed;
                     }
 
                     if (prAddRepos.Length > 0)
@@ -613,44 +613,44 @@ public static class RulesCommand
                 }
 
                 if (parseResult.GetResult(assigneeOption) is not null)
-                    rule.Assignee = parseResult.GetValue(assigneeOption);
+                    issueRule.Assignee = parseResult.GetValue(assigneeOption);
 
                 var addLabels = parseResult.GetValue(addLabelOption) ?? [];
                 var deleteLabels = parseResult.GetValue(deleteLabelOption) ?? [];
                 foreach (var label in deleteLabels)
-                    rule.Labels.Remove(label);
+                    issueRule.Labels.Remove(label);
                 foreach (var label in addLabels)
                 {
-                    if (!rule.Labels.Contains(label, StringComparer.OrdinalIgnoreCase))
-                        rule.Labels.Add(label);
+                    if (!issueRule.Labels.Contains(label, StringComparer.OrdinalIgnoreCase))
+                        issueRule.Labels.Add(label);
                 }
 
                 if (parseResult.GetResult(milestoneOption) is not null)
-                    rule.Milestone = parseResult.GetValue(milestoneOption);
+                    issueRule.Milestone = parseResult.GetValue(milestoneOption);
 
                 if (parseResult.GetResult(typeOption) is not null)
-                    rule.Type = parseResult.GetValue(typeOption);
+                    issueRule.Type = parseResult.GetValue(typeOption);
 
                 if (parseResult.GetResult(yoloOption) is not null)
-                    rule.Yolo = parseResult.GetValue(yoloOption) ?? false;
+                    issueRule.Yolo = parseResult.GetValue(yoloOption) ?? false;
 
                 if (parseResult.GetResult(allowAllToolsOption) is not null)
-                    rule.AllowAllTools = parseResult.GetValue(allowAllToolsOption) ?? true;
+                    issueRule.AllowAllTools = parseResult.GetValue(allowAllToolsOption) ?? true;
 
                 if (parseResult.GetResult(allowAllUrlsOption) is not null)
-                    rule.AllowAllUrls = parseResult.GetValue(allowAllUrlsOption) ?? false;
+                    issueRule.AllowAllUrls = parseResult.GetValue(allowAllUrlsOption) ?? false;
 
                 if (parseResult.GetResult(promptOption) is not null)
-                    rule.ExtraPrompt = parseResult.GetValue(promptOption);
+                    issueRule.ExtraPrompt = parseResult.GetValue(promptOption);
 
                 if (parseResult.GetResult(modelOption) is not null)
                 {
                     var modelValue = parseResult.GetValue(modelOption);
-                    rule.Model = string.IsNullOrWhiteSpace(modelValue) ? null : modelValue;
+                    issueRule.Model = string.IsNullOrWhiteSpace(modelValue) ? null : modelValue;
                 }
 
                 if (parseResult.GetResult(customPromptOption) is not null)
-                    rule.CustomPrompt = parseResult.GetValue(customPromptOption);
+                    issueRule.CustomPrompt = parseResult.GetValue(customPromptOption);
 
                 if (parseResult.GetResult(customPromptModeOption) is not null)
                 {
@@ -660,46 +660,46 @@ public static class RulesCommand
                         ConsoleOutput.Error("Invalid --custom-prompt-mode. Use 'append' or 'override'.");
                         return 1;
                     }
-                    rule.CustomPromptMode = mode;
+                    issueRule.CustomPromptMode = mode;
                 }
 
                 var addRepos = parseResult.GetValue(addRepoOption) ?? [];
                 var deleteRepos = parseResult.GetValue(deleteRepoOption) ?? [];
                 foreach (var repo in deleteRepos)
-                    rule.Repos.RemoveAll(r => string.Equals(r, repo, StringComparison.OrdinalIgnoreCase));
+                    issueRule.Repos.RemoveAll(r => string.Equals(r, repo, StringComparison.OrdinalIgnoreCase));
                 foreach (var repo in addRepos)
                 {
-                    if (!rule.Repos.Contains(repo, StringComparer.OrdinalIgnoreCase))
-                        rule.Repos.Add(repo);
+                    if (!issueRule.Repos.Contains(repo, StringComparer.OrdinalIgnoreCase))
+                        issueRule.Repos.Add(repo);
                 }
 
                 // Author mode updates: --any-author and --write-only-authors change the mode;
                 // --add-author/--delete-author modify the allowed list (and imply Allowed mode)
                 if (parseResult.GetValue(anyAuthorOption))
                 {
-                    rule.AuthorMode = AuthorMode.Any;
-                    rule.Authors.Clear();
+                    issueRule.AuthorMode = AuthorMode.Any;
+                    issueRule.Authors.Clear();
                 }
                 else if (parseResult.GetValue(writeOnlyAuthorsOption))
                 {
-                    rule.AuthorMode = AuthorMode.WriteAccess;
-                    rule.Authors.Clear();
+                    issueRule.AuthorMode = AuthorMode.WriteAccess;
+                    issueRule.Authors.Clear();
                 }
 
                 var addAuthors = parseResult.GetValue(addAuthorOption) ?? [];
                 var deleteAuthors = parseResult.GetValue(deleteAuthorOption) ?? [];
                 foreach (var author in deleteAuthors)
-                    rule.Authors.RemoveAll(a => string.Equals(a, author, StringComparison.OrdinalIgnoreCase));
+                    issueRule.Authors.RemoveAll(a => string.Equals(a, author, StringComparison.OrdinalIgnoreCase));
                 foreach (var author in addAuthors)
                 {
-                    if (!rule.Authors.Contains(author, StringComparer.OrdinalIgnoreCase))
-                        rule.Authors.Add(author);
+                    if (!issueRule.Authors.Contains(author, StringComparer.OrdinalIgnoreCase))
+                        issueRule.Authors.Add(author);
                 }
 
                 // If authors were added and mode is still Any, switch to Allowed
-                if (rule.Authors.Count > 0 && rule.AuthorMode == AuthorMode.Any)
+                if (issueRule.Authors.Count > 0 && issueRule.AuthorMode == AuthorMode.Any)
                 {
-                    rule.AuthorMode = AuthorMode.Allowed;
+                    issueRule.AuthorMode = AuthorMode.Allowed;
                 }
 
                 if (addRepos.Length > 0)
@@ -744,7 +744,7 @@ public static class RulesCommand
                     return 1;
                 }
 
-                var removed = config.Rules.Remove(name);
+                var removed = config.IssueRules.Remove(name);
                 if (!removed)
                     removed = config.PullRequestRules.Remove(name);
 

--- a/src/copilotd/Commands/RulesCommand.cs
+++ b/src/copilotd/Commands/RulesCommand.cs
@@ -75,6 +75,8 @@ public static class RulesCommand
 
     private static int RenderRulesList(CopilotdConfig config, string? repoFilter, string? assigneeFilter, bool assigneeFlagPresent)
     {
+        var issueRuleCount = config.IssueRules.Count;
+        var pullRequestRuleCount = config.PullRequestRules.Count;
         var issueRules = config.IssueRules.AsEnumerable();
         var pullRequestRules = config.PullRequestRules.AsEnumerable();
 
@@ -98,69 +100,94 @@ public static class RulesCommand
             }
         }
 
+        var issueRuleList = issueRules.ToList();
+        var pullRequestRuleList = pullRequestRules.ToList();
+
         AnsiConsole.MarkupLine("[bold]Issue dispatch rules[/]");
-        var table = new Table();
-        table.ShowRowSeparators = true;
-        table.AddColumn(new TableColumn("[bold]Name[/]"));
-        table.AddColumn(new TableColumn("[bold]Assignee[/]"));
-        table.AddColumn(new TableColumn("[bold]Authors[/]"));
-        table.AddColumn(new TableColumn("[bold]Labels[/]"));
-        table.AddColumn(new TableColumn("[bold]Milestone[/]"));
-        table.AddColumn(new TableColumn("[bold]Type[/]"));
-        table.AddColumn(new TableColumn("[bold]Repos[/]"));
-        table.AddColumn(new TableColumn("[bold]Launch Options[/]"));
-
-        foreach (var kvp in issueRules)
+        if (issueRuleList.Count == 0)
         {
-            var name = kvp.Key;
-            var issueRule = kvp.Value;
-            table.AddRow(
-                Markup.Escape(name),
-                Markup.Escape(issueRule.Assignee ?? "*"),
-                Markup.Escape(FormatAuthorMode(issueRule)),
-                Markup.Escape(string.Join(", ", issueRule.Labels)),
-                Markup.Escape(issueRule.Milestone ?? "*"),
-                Markup.Escape(issueRule.Type ?? "*"),
-                Markup.Escape(string.Join(", ", issueRule.Repos)),
-                Markup.Escape(FormatLaunchOptions(issueRule)));
+            RenderNoRulesMessage("issue", issueRuleCount == 0, "copilotd rules add --kind issue <name>");
         }
+        else
+        {
+            var table = new Table();
+            table.ShowRowSeparators = true;
+            table.AddColumn(new TableColumn("[bold]Name[/]"));
+            table.AddColumn(new TableColumn("[bold]Assignee[/]"));
+            table.AddColumn(new TableColumn("[bold]Authors[/]"));
+            table.AddColumn(new TableColumn("[bold]Labels[/]"));
+            table.AddColumn(new TableColumn("[bold]Milestone[/]"));
+            table.AddColumn(new TableColumn("[bold]Type[/]"));
+            table.AddColumn(new TableColumn("[bold]Repos[/]"));
+            table.AddColumn(new TableColumn("[bold]Launch Options[/]"));
 
-        AnsiConsole.Write(table);
+            foreach (var kvp in issueRuleList)
+            {
+                var name = kvp.Key;
+                var issueRule = kvp.Value;
+                table.AddRow(
+                    Markup.Escape(name),
+                    Markup.Escape(issueRule.Assignee ?? "*"),
+                    Markup.Escape(FormatAuthorMode(issueRule)),
+                    Markup.Escape(string.Join(", ", issueRule.Labels)),
+                    Markup.Escape(issueRule.Milestone ?? "*"),
+                    Markup.Escape(issueRule.Type ?? "*"),
+                    Markup.Escape(string.Join(", ", issueRule.Repos)),
+                    Markup.Escape(FormatLaunchOptions(issueRule)));
+            }
+
+            AnsiConsole.Write(table);
+        }
 
         AnsiConsole.WriteLine();
         AnsiConsole.MarkupLine("[bold]Pull request dispatch rules[/]");
-        var prTable = new Table();
-        prTable.ShowRowSeparators = true;
-        prTable.AddColumn(new TableColumn("[bold]Name[/]"));
-        prTable.AddColumn(new TableColumn("[bold]Assignee[/]"));
-        prTable.AddColumn(new TableColumn("[bold]Authors[/]"));
-        prTable.AddColumn(new TableColumn("[bold]Labels[/]"));
-        prTable.AddColumn(new TableColumn("[bold]Base[/]"));
-        prTable.AddColumn(new TableColumn("[bold]Draft[/]"));
-        prTable.AddColumn(new TableColumn("[bold]Review[/]"));
-        prTable.AddColumn(new TableColumn("[bold]Branch[/]"));
-        prTable.AddColumn(new TableColumn("[bold]Repos[/]"));
-        prTable.AddColumn(new TableColumn("[bold]Launch Options[/]"));
-
-        foreach (var kvp in pullRequestRules)
+        if (pullRequestRuleList.Count == 0)
         {
-            var name = kvp.Key;
-            var pullRequestRule = kvp.Value;
-            prTable.AddRow(
-                Markup.Escape(name),
-                Markup.Escape(pullRequestRule.Assignee ?? "*"),
-                Markup.Escape(FormatAuthorMode(pullRequestRule)),
-                Markup.Escape(string.Join(", ", pullRequestRule.Labels)),
-                Markup.Escape(pullRequestRule.BaseBranch ?? "*"),
-                Markup.Escape(pullRequestRule.Draft?.ToString() ?? "*"),
-                Markup.Escape(pullRequestRule.ReviewDecision ?? "*"),
-                Markup.Escape(pullRequestRule.BranchStrategy.ToString()),
-                Markup.Escape(string.Join(", ", pullRequestRule.Repos)),
-                Markup.Escape(FormatLaunchOptions(pullRequestRule)));
+            RenderNoRulesMessage("pull request", pullRequestRuleCount == 0, "copilotd rules add --kind pr <name>");
         }
+        else
+        {
+            var prTable = new Table();
+            prTable.ShowRowSeparators = true;
+            prTable.AddColumn(new TableColumn("[bold]Name[/]"));
+            prTable.AddColumn(new TableColumn("[bold]Assignee[/]"));
+            prTable.AddColumn(new TableColumn("[bold]Authors[/]"));
+            prTable.AddColumn(new TableColumn("[bold]Labels[/]"));
+            prTable.AddColumn(new TableColumn("[bold]Base[/]"));
+            prTable.AddColumn(new TableColumn("[bold]Draft[/]"));
+            prTable.AddColumn(new TableColumn("[bold]Review[/]"));
+            prTable.AddColumn(new TableColumn("[bold]Branch[/]"));
+            prTable.AddColumn(new TableColumn("[bold]Repos[/]"));
+            prTable.AddColumn(new TableColumn("[bold]Launch Options[/]"));
 
-        AnsiConsole.Write(prTable);
+            foreach (var kvp in pullRequestRuleList)
+            {
+                var name = kvp.Key;
+                var pullRequestRule = kvp.Value;
+                prTable.AddRow(
+                    Markup.Escape(name),
+                    Markup.Escape(pullRequestRule.Assignee ?? "*"),
+                    Markup.Escape(FormatAuthorMode(pullRequestRule)),
+                    Markup.Escape(string.Join(", ", pullRequestRule.Labels)),
+                    Markup.Escape(pullRequestRule.BaseBranch ?? "*"),
+                    Markup.Escape(pullRequestRule.Draft?.ToString() ?? "*"),
+                    Markup.Escape(pullRequestRule.ReviewDecision ?? "*"),
+                    Markup.Escape(pullRequestRule.BranchStrategy.ToString()),
+                    Markup.Escape(string.Join(", ", pullRequestRule.Repos)),
+                    Markup.Escape(FormatLaunchOptions(pullRequestRule)));
+            }
+
+            AnsiConsole.Write(prTable);
+        }
         return 0;
+    }
+
+    private static void RenderNoRulesMessage(string dispatchType, bool noneDefined, string addCommand)
+    {
+        var reason = noneDefined
+            ? $"No {dispatchType} dispatch rules are currently defined."
+            : $"No {dispatchType} dispatch rules match the current filters.";
+        AnsiConsole.MarkupLine($"[grey]{Markup.Escape(reason)} Run [blue]{Markup.Escape(addCommand)}[/] to define one.[/]");
     }
 
     private static string FormatLaunchOptions(DispatchRuleOptions dispatchRule)

--- a/src/copilotd/Commands/RulesCommand.cs
+++ b/src/copilotd/Commands/RulesCommand.cs
@@ -106,7 +106,7 @@ public static class RulesCommand
         AnsiConsole.MarkupLine("[bold]Issue dispatch rules[/]");
         if (issueRuleList.Count == 0)
         {
-            RenderNoRulesMessage("issue", issueRuleCount == 0, "copilotd rules add --kind issue <name>");
+            RenderNoRulesMessage("issue", issueRuleCount == 0, "copilotd rules add <name> --kind issue");
         }
         else
         {
@@ -143,7 +143,7 @@ public static class RulesCommand
         AnsiConsole.MarkupLine("[bold]Pull request dispatch rules[/]");
         if (pullRequestRuleList.Count == 0)
         {
-            RenderNoRulesMessage("pull request", pullRequestRuleCount == 0, "copilotd rules add --kind pr <name>");
+            RenderNoRulesMessage("pull request", pullRequestRuleCount == 0, "copilotd rules add <name> --kind pr");
         }
         else
         {

--- a/src/copilotd/Commands/SessionCommand.cs
+++ b/src/copilotd/Commands/SessionCommand.cs
@@ -1100,10 +1100,15 @@ public static class SessionCommand
     /// <summary>
     /// Checks whether reactions are enabled for a session based on rule + global config.
     /// </summary>
-    private static bool AreReactionsEnabled(CopilotdConfig config, string ruleName)
+    private static bool AreReactionsEnabled(CopilotdConfig config, string dispatchRuleName)
     {
-        if (config.Rules.TryGetValue(ruleName, out var rule) && rule.EnableReactions.HasValue)
-            return rule.EnableReactions.Value;
+        var ruleOptions = config.IssueRules.TryGetValue(dispatchRuleName, out var issueRule)
+            ? (DispatchRuleOptions)issueRule
+            : config.PullRequestRules.GetValueOrDefault(dispatchRuleName);
+
+        if (ruleOptions?.EnableReactions is { } enableReactions)
+            return enableReactions;
+
         return config.EnableReactions;
     }
 

--- a/src/copilotd/Commands/SessionCommand.cs
+++ b/src/copilotd/Commands/SessionCommand.cs
@@ -835,7 +835,7 @@ public static class SessionCommand
 
         ConsoleOutput.Info($"{list.Count} session(s)");
         Console.WriteLine();
-        ConsoleOutput.Info("Use 'copilotd session connect <issue>' to connect to a running remote session.");
+        ConsoleOutput.Info("Use 'copilotd session connect <subject>' to connect to a running remote session.");
 
         return 0;
     }
@@ -847,7 +847,8 @@ public static class SessionCommand
     {
         var table = new Table();
         table.Border(TableBorder.Rounded);
-        table.AddColumn("Issue");
+        table.AddColumn("Subject");
+        table.AddColumn("Kind");
         table.AddColumn("Rule");
         table.AddColumn("Status");
         table.AddColumn("PID");
@@ -877,7 +878,8 @@ public static class SessionCommand
                 : s.WorktreePath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
 
             table.AddRow(
-                Markup.Escape(s.IssueKey),
+                Markup.Escape(s.SubjectKey),
+                Markup.Escape(s.SubjectKind.ToString()),
                 Markup.Escape(s.RuleName),
                 statusMarkup,
                 Markup.Escape(pid),
@@ -895,7 +897,7 @@ public static class SessionCommand
     {
         var failedSessions = sessions
             .Where(session => session.Status == SessionStatus.Failed)
-            .Select(session => session.IssueKey)
+            .Select(session => session.SubjectKey)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
         if (failedSessions.Count == 0)
@@ -915,7 +917,7 @@ public static class SessionCommand
         {
             var url = remoteSessionUrls.TryResolve(session, currentUser)
                 ?? GetUnavailableRemoteSessionUrlMessage(session);
-            ConsoleOutput.Info($"  {session.IssueKey}:");
+            ConsoleOutput.Info($"  {session.SubjectKey}:");
             ConsoleOutput.Info($"    {url}");
         }
 
@@ -942,12 +944,14 @@ public static class SessionCommand
         table.AddColumn(new TableColumn("[bold]Field[/]").NoWrap());
         table.AddColumn(new TableColumn("[bold]Value[/]"));
 
-        table.AddRow("Issue", Markup.Escape(session.IssueKey));
+        table.AddRow("Subject", Markup.Escape(session.SubjectKey));
+        table.AddRow("Subject kind", Markup.Escape(session.SubjectKind.ToString()));
         table.AddRow("Repo", Markup.Escape(session.Repo));
-        table.AddRow("Issue number", Markup.Escape(session.IssueNumber.ToString()));
+        table.AddRow("Subject number", Markup.Escape(session.SubjectNumber.ToString()));
+        table.AddRow("Subject title", Markup.Escape(session.SubjectTitle ?? "(unknown)"));
         table.AddRow("Rule", Markup.Escape(session.RuleName));
         table.AddRow("Status", Markup.Escape(session.Status.ToString()));
-        table.AddRow("Issue author", Markup.Escape(session.IssueAuthor ?? "(unknown)"));
+        table.AddRow("Subject author", Markup.Escape(session.SubjectAuthor ?? "(unknown)"));
         table.AddRow("Created", Markup.Escape(session.CreatedAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss zzz")));
         table.AddRow("Updated", Markup.Escape(session.UpdatedAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss zzz")));
         table.AddRow("Last verified", Markup.Escape(FormatOptionalTime(session.LastVerifiedAt)));
@@ -956,7 +960,15 @@ public static class SessionCommand
         table.AddRow("Redispatch count", Markup.Escape(session.RedispatchCount.ToString()));
         table.AddRow("Completed by session", Markup.Escape(session.CompletedBySession ? "yes" : "no"));
         table.AddRow("Waiting since", Markup.Escape(FormatOptionalTime(session.WaitingSince)));
-        table.AddRow("Pull request", Markup.Escape(session.PullRequestNumber?.ToString() ?? "-"));
+        table.AddRow("Review pull request", Markup.Escape(session.ReviewPullRequestNumber?.ToString() ?? "-"));
+        if (session.SubjectKind == DispatchSubjectKind.PullRequest)
+        {
+            table.AddRow("PR base", Markup.Escape(session.PullRequestBaseBranch ?? "-"));
+            table.AddRow("PR head", Markup.Escape(session.PullRequestHeadBranch ?? "-"));
+            table.AddRow("PR head repo", Markup.Escape(session.PullRequestHeadRepo ?? "-"));
+            table.AddRow("PR head SHA", Markup.Escape(session.PullRequestHeadSha ?? "-"));
+            table.AddRow("PR branch strategy", Markup.Escape(session.PullRequestBranchStrategy?.ToString() ?? "-"));
+        }
         table.AddRow("Process ID", Markup.Escape(session.ProcessId?.ToString() ?? "-"));
         table.AddRow("Process start", Markup.Escape(FormatOptionalTime(session.ProcessStartTime)));
         table.AddRow("Process liveness", Markup.Escape(FormatOptionalLiveness(liveness)));
@@ -974,7 +986,7 @@ public static class SessionCommand
         if (session.Status == SessionStatus.Failed && !string.IsNullOrWhiteSpace(session.FailureDetail))
         {
             Console.WriteLine();
-            ConsoleOutput.Warning($"After resolving the issue above, run 'copilotd session reset {session.IssueKey}' to queue a new dispatch.");
+            ConsoleOutput.Warning($"After resolving the problem above, run 'copilotd session reset {session.SubjectKey}' to queue a new dispatch.");
         }
     }
 
@@ -1032,6 +1044,8 @@ public static class SessionCommand
         => new()
         {
             IssueKey = session.IssueKey,
+            SubjectKind = session.SubjectKind,
+            SubjectTitle = session.SubjectTitle,
             Repo = session.Repo,
             IssueNumber = session.IssueNumber,
             RuleName = session.RuleName,
@@ -1051,6 +1065,11 @@ public static class SessionCommand
             CompletedBySession = session.CompletedBySession,
             WaitingSince = session.WaitingSince,
             PullRequestNumber = session.PullRequestNumber,
+            PullRequestBaseBranch = session.PullRequestBaseBranch,
+            PullRequestHeadBranch = session.PullRequestHeadBranch,
+            PullRequestHeadRepo = session.PullRequestHeadRepo,
+            PullRequestHeadSha = session.PullRequestHeadSha,
+            PullRequestBranchStrategy = session.PullRequestBranchStrategy,
             RedispatchCount = session.RedispatchCount,
             LastRedispatchWasIssueComment = session.LastRedispatchWasIssueComment,
             WorktreePath = session.WorktreePath,

--- a/src/copilotd/Commands/StatusCommand.cs
+++ b/src/copilotd/Commands/StatusCommand.cs
@@ -72,7 +72,8 @@ public static class StatusCommand
                     ConsoleOutput.Info($"  Last poll: {SessionCommand.FormatTime(state.LastPollTime.Value)}");
                 }
 
-                var watchedRepos = config.Rules.Values
+                var watchedRepos = config.IssueRules.Values.Cast<DispatchRuleOptions>()
+                    .Concat(config.PullRequestRules.Values)
                     .SelectMany(r => r.Repos)
                     .Distinct(StringComparer.OrdinalIgnoreCase)
                     .ToList();
@@ -81,7 +82,8 @@ public static class StatusCommand
                     ConsoleOutput.Info($"  Watching:  {string.Join(", ", watchedRepos)}");
                 }
 
-                ConsoleOutput.Info($"  Rules:     {config.Rules.Count}");
+                ConsoleOutput.Info($"  Issue rules: {config.IssueRules.Count}");
+                ConsoleOutput.Info($"  PR rules:    {config.PullRequestRules.Count}");
                 if (daemonInfo is { LogInstanceId: { Length: > 0 } daemonLogInstanceId })
                     ConsoleOutput.Info($"  Logs:      {logFileManager.GetDaemonLogDirectoryForDisplay(daemonLogInstanceId)}");
                 ConsoleOutput.Info($"  Machine:   {Environment.MachineName}");

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -59,6 +59,7 @@ public sealed partial class ProcessManager
         var copilotdCommand = _runtimeContext.GetCopilotdCallbackCommand();
         var machineIdentifier = _stateStore.EnsureMachineIdentifier();
         var prompt = BuildPrompt(customPrompt, issue, session, config, copilotdCommand, machineIdentifier);
+        var ruleOptions = GetRuleOptions(config, session);
         var hasExistingResumeContext = HasExistingResumeContext(session);
         var sessionName = session.CopilotSessionName;
         if (!hasExistingResumeContext && string.IsNullOrWhiteSpace(sessionName))
@@ -71,7 +72,7 @@ public sealed partial class ProcessManager
             session,
             prompt,
             sessionName,
-            config.Rules.GetValueOrDefault(session.RuleName),
+            ruleOptions,
             repoPath,
             config.DefaultModel,
             _runtimeContext.GetExtraAllowedDirectories());
@@ -750,13 +751,17 @@ public sealed partial class ProcessManager
 
     private static string BuildPrompt(string globalCustomPrompt, GitHubIssue issue, DispatchSession session, CopilotdConfig config, string copilotdCommand, string machineIdentifier)
     {
-        var prompt = session.RedispatchCount > 0
-            ? session.PullRequestNumber is not null && !session.LastRedispatchWasIssueComment
-                ? BuildPrReviewPrompt(issue, session)
-                : CopilotdConfig.IssueFeedbackPrompt
-            : CopilotdConfig.DefaultPrompt;
+        var prompt = session.SubjectKind == DispatchSubjectKind.PullRequest
+            ? session.RedispatchCount > 0
+                ? BuildPullRequestFeedbackPrompt(session)
+                : BuildPullRequestPrompt(session)
+            : session.RedispatchCount > 0
+                ? session.PullRequestNumber is not null && !session.LastRedispatchWasIssueComment
+                    ? BuildPrReviewPrompt(issue, session)
+                    : CopilotdConfig.IssueFeedbackPrompt
+                : CopilotdConfig.DefaultPrompt;
 
-        var rule = config.Rules.GetValueOrDefault(session.RuleName);
+        var rule = GetRuleOptions(config, session);
 
         // Resolve the effective custom prompt based on rule settings
         var effectiveCustomPrompt = ResolveCustomPrompt(globalCustomPrompt, rule);
@@ -809,11 +814,53 @@ public sealed partial class ProcessManager
             """;
     }
 
+    private static string BuildPullRequestPrompt(DispatchSession session)
+    {
+        var branchInstruction = session.PullRequestBranchStrategy switch
+        {
+            PullRequestBranchStrategy.ReadOnly => "You are in a read-only PR worktree. Do not commit or push changes; review, validate, and comment on the PR instead.",
+            PullRequestBranchStrategy.ChildBranch => "You are on a new copilotd branch created from the PR head. Commit any fixes here and push the branch; explain in the PR how to use it.",
+            _ => "You are on a branch based on the PR source branch. Commit fixes here and push them to update the existing PR.",
+        };
+
+        return $$"""
+            You are working on pull request #$(pr.id) in the $(issue.repo) repository.
+            Read the PR title, description, changed files, comments, and review feedback carefully.
+
+            Important:
+            - {{branchInstruction}}
+            - Focus only on changes relevant to this pull request.
+            - If you need clarification, run `$(copilotd.command) session comment $(issue.repo)#$(pr.id) --message "Your question or findings here"`.
+            - When the work is complete, run `$(copilotd.command) session complete $(issue.repo)#$(pr.id)`.
+            """;
+    }
+
+    private static string BuildPullRequestFeedbackPrompt(DispatchSession session)
+    {
+        var branchInstruction = session.PullRequestBranchStrategy switch
+        {
+            PullRequestBranchStrategy.ReadOnly => "Continue reviewing or validating only; do not commit or push changes.",
+            PullRequestBranchStrategy.ChildBranch => "Continue on the copilotd branch created from the PR head; commit and push any follow-up fixes there.",
+            _ => "Continue on the branch used to update the existing PR; commit and push any follow-up fixes to the PR source branch.",
+        };
+
+        return $$"""
+            You are resuming work on pull request #$(pr.id) in the $(issue.repo) repository because new PR feedback or commits were detected.
+            Read the new PR comments, review feedback, and current diff carefully.
+
+            Important:
+            - {{branchInstruction}}
+            - Focus on the new PR feedback or new commits since the previous dispatch.
+            - If you need more clarification, run `$(copilotd.command) session comment $(issue.repo)#$(pr.id) --message "Your question or findings here"`.
+            - When the work is complete, run `$(copilotd.command) session complete $(issue.repo)#$(pr.id)`.
+            """;
+    }
+
     /// <summary>
     /// Resolves the effective custom prompt by combining the global custom prompt
     /// with the rule's custom prompt based on the rule's <see cref="PromptMode"/>.
     /// </summary>
-    private static string ResolveCustomPrompt(string globalCustomPrompt, DispatchRule? rule)
+    private static string ResolveCustomPrompt(string globalCustomPrompt, DispatchRuleOptions? rule)
     {
         var ruleCustomPrompt = rule?.CustomPrompt;
 
@@ -896,7 +943,15 @@ public sealed partial class ProcessManager
             .Replace("$(issue.id)", issue.Number.ToString(), StringComparison.Ordinal)
             .Replace("$(issue.type)", issue.Type ?? "issue", StringComparison.Ordinal)
             .Replace("$(issue.milestone)", issue.Milestone ?? "none", StringComparison.Ordinal)
-            .Replace("$(pr.id)", session.PullRequestNumber?.ToString() ?? "", StringComparison.Ordinal)
+            .Replace("$(subject.id)", session.SubjectNumber.ToString(), StringComparison.Ordinal)
+            .Replace("$(subject.kind)", session.SubjectKind.ToString().ToLowerInvariant(), StringComparison.Ordinal)
+            .Replace("$(subject.title)", session.SubjectTitle ?? "", StringComparison.Ordinal)
+            .Replace("$(pr.id)", (session.SubjectKind == DispatchSubjectKind.PullRequest ? session.SubjectNumber : session.PullRequestNumber)?.ToString() ?? "", StringComparison.Ordinal)
+            .Replace("$(pr.title)", session.SubjectKind == DispatchSubjectKind.PullRequest ? session.SubjectTitle ?? "" : "", StringComparison.Ordinal)
+            .Replace("$(pr.base)", session.PullRequestBaseBranch ?? "", StringComparison.Ordinal)
+            .Replace("$(pr.head)", session.PullRequestHeadBranch ?? "", StringComparison.Ordinal)
+            .Replace("$(pr.head_repo)", session.PullRequestHeadRepo ?? "", StringComparison.Ordinal)
+            .Replace("$(pr.head_sha)", session.PullRequestHeadSha ?? "", StringComparison.Ordinal)
             .Replace("$(org)", org, StringComparison.Ordinal)
             .Replace("$(repo)", repo, StringComparison.Ordinal)
             .Replace("$(issue_id)", issue.Number.ToString(), StringComparison.Ordinal)
@@ -906,6 +961,11 @@ public sealed partial class ProcessManager
             .Replace("$(machine_name)", Environment.MachineName, StringComparison.Ordinal)
             .Replace("$(gh_user)", ghUser ?? "", StringComparison.Ordinal);
     }
+
+    private static DispatchRuleOptions? GetRuleOptions(CopilotdConfig config, DispatchSession session)
+        => session.SubjectKind == DispatchSubjectKind.PullRequest
+            ? config.PullRequestRules.GetValueOrDefault(session.RuleName)
+            : config.Rules.GetValueOrDefault(session.RuleName);
 
     private static (string Org, string Repo) SplitRepoSlug(string repoSlug)
     {
@@ -919,7 +979,7 @@ public sealed partial class ProcessManager
         return (repoSlug[..separatorIndex], repoSlug[(separatorIndex + 1)..]);
     }
 
-    private static string BuildArguments(DispatchSession session, string prompt, string? sessionName, DispatchRule? rule, string repoPath, string? defaultModel, IEnumerable<string> extraAllowedDirectories)
+    private static string BuildArguments(DispatchSession session, string prompt, string? sessionName, DispatchRuleOptions? rule, string repoPath, string? defaultModel, IEnumerable<string> extraAllowedDirectories)
     {
         var args = new List<string>
         {
@@ -1102,6 +1162,10 @@ public sealed partial class ProcessManager
         {
             return RefreshWorktree(session) ? WorktreeResult.Refreshed : WorktreeResult.Failed;
         }
+
+        if (session.SubjectKind == DispatchSubjectKind.PullRequest)
+            return PreparePullRequestWorktree(session, config, state);
+
         var mainRepoPath = _repoResolver.ResolveRepoPath(session.Repo, config, state);
         if (mainRepoPath is null || !Directory.Exists(mainRepoPath))
         {
@@ -1178,6 +1242,97 @@ public sealed partial class ProcessManager
         return WorktreeResult.CreatedNew;
     }
 
+    private WorktreeResult PreparePullRequestWorktree(DispatchSession session, CopilotdConfig config, DaemonState state)
+    {
+        var mainRepoPath = _repoResolver.ResolveRepoPath(session.Repo, config, state);
+        if (mainRepoPath is null || !Directory.Exists(mainRepoPath))
+        {
+            _logger.LogWarning("Main repo directory not found for {Repo}", session.Repo);
+            return WorktreeResult.Failed;
+        }
+
+        var sessionsDir = mainRepoPath + "_sessions";
+        var worktreePath = Path.Combine(sessionsDir, $"pr-{session.SubjectNumber}");
+
+        if (Directory.Exists(worktreePath))
+        {
+            _logger.LogDebug("Removing existing PR worktree at {Path}", worktreePath);
+            RunGit(mainRepoPath, $"worktree remove \"{worktreePath}\" --force");
+        }
+
+        RunGit(mainRepoPath, "worktree prune");
+
+        if (!string.IsNullOrEmpty(session.BranchName))
+        {
+            _logger.LogDebug("Cleaning up stale branch {Branch} from previous PR attempt", session.BranchName);
+            if (RunGit(mainRepoPath, $"branch -D {session.BranchName}"))
+                session.BranchName = null;
+        }
+
+        Directory.CreateDirectory(sessionsDir);
+
+        var strategy = session.PullRequestBranchStrategy ?? PullRequestBranchStrategy.SourceBranch;
+        var suffix = Guid.NewGuid().ToString("N")[..4];
+        var localBranchName = strategy == PullRequestBranchStrategy.ReadOnly
+            ? null
+            : $"copilotd/pr-{session.SubjectNumber}-{suffix}";
+
+        _logger.LogInformation("Creating PR worktree for {Key} at {Path} using {Strategy}", session.SubjectKey, worktreePath, strategy);
+
+        switch (strategy)
+        {
+            case PullRequestBranchStrategy.SourceBranch:
+                if (string.IsNullOrWhiteSpace(session.PullRequestHeadRepo))
+                {
+                    _logger.LogWarning("Cannot use SourceBranch for {Key}: PR head repo is unknown", session.SubjectKey);
+                    return WorktreeResult.Failed;
+                }
+
+                if (!string.Equals(session.Repo, session.PullRequestHeadRepo, StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogWarning("Cannot use SourceBranch for {Key}: PR head repo {HeadRepo} differs from base repo {Repo}",
+                        session.SubjectKey, session.PullRequestHeadRepo, session.Repo);
+                    return WorktreeResult.Failed;
+                }
+
+                if (string.IsNullOrWhiteSpace(session.PullRequestHeadBranch))
+                {
+                    _logger.LogWarning("Cannot use SourceBranch for {Key}: PR head branch is unknown", session.SubjectKey);
+                    return WorktreeResult.Failed;
+                }
+
+                if (!RunGit(mainRepoPath, $"fetch origin {session.PullRequestHeadBranch}"))
+                    return WorktreeResult.Failed;
+
+                session.BranchName = localBranchName;
+                if (!RunGit(mainRepoPath, $"worktree add \"{worktreePath}\" -b {localBranchName} origin/{session.PullRequestHeadBranch}"))
+                    return WorktreeResult.Failed;
+                break;
+
+            case PullRequestBranchStrategy.ChildBranch:
+                if (!RunGit(mainRepoPath, $"fetch origin pull/{session.SubjectNumber}/head"))
+                    return WorktreeResult.Failed;
+
+                session.BranchName = localBranchName;
+                if (!RunGit(mainRepoPath, $"worktree add \"{worktreePath}\" -b {localBranchName} FETCH_HEAD"))
+                    return WorktreeResult.Failed;
+                break;
+
+            case PullRequestBranchStrategy.ReadOnly:
+                if (!RunGit(mainRepoPath, $"fetch origin pull/{session.SubjectNumber}/head"))
+                    return WorktreeResult.Failed;
+
+                session.BranchName = null;
+                if (!RunGit(mainRepoPath, $"worktree add \"{worktreePath}\" --detach FETCH_HEAD"))
+                    return WorktreeResult.Failed;
+                break;
+        }
+
+        session.WorktreePath = worktreePath;
+        _logger.LogInformation("PR worktree ready for {Key} at {Path}", session.SubjectKey, worktreePath);
+        return WorktreeResult.CreatedNew;
+    }
+
     /// <summary>
     /// Refreshes an existing worktree by pulling the latest changes from origin.
     /// Used when re-dispatching a session for PR review feedback.
@@ -1234,7 +1389,13 @@ public sealed partial class ProcessManager
         // Only clear BranchName on success so a future cleanup can retry.
         if (mainRepoPath is not null)
         {
-            var branchName = session.BranchName ?? $"copilotd/issue-{session.IssueNumber}";
+            var branchName = session.BranchName;
+            if (branchName is null && session.SubjectKind == DispatchSubjectKind.Issue)
+                branchName = $"copilotd/issue-{session.IssueNumber}";
+
+            if (branchName is null)
+                return;
+
             if (RunGit(mainRepoPath, $"branch -D {branchName}"))
             {
                 session.BranchName = null;
@@ -1396,6 +1557,13 @@ public sealed partial class ProcessManager
     /// </summary>
     public bool PushBranch(DispatchSession session, CopilotdConfig config, DaemonState state)
     {
+        if (session.SubjectKind == DispatchSubjectKind.PullRequest
+            && session.PullRequestBranchStrategy == PullRequestBranchStrategy.ReadOnly)
+        {
+            _logger.LogInformation("Skipping push for read-only PR session {Key}", session.SubjectKey);
+            return true;
+        }
+
         if (string.IsNullOrEmpty(session.BranchName))
         {
             _logger.LogWarning("Cannot push branch for {Key}: no branch name set", session.IssueKey);
@@ -1413,6 +1581,14 @@ public sealed partial class ProcessManager
                 _logger.LogWarning("Cannot push branch for {Key}: no working directory found", session.IssueKey);
                 return false;
             }
+        }
+
+        if (session.SubjectKind == DispatchSubjectKind.PullRequest
+            && session.PullRequestBranchStrategy == PullRequestBranchStrategy.SourceBranch
+            && !string.IsNullOrWhiteSpace(session.PullRequestHeadBranch))
+        {
+            _logger.LogInformation("Pushing PR session {Key} HEAD to origin/{Branch}", session.SubjectKey, session.PullRequestHeadBranch);
+            return RunGit(workDir, $"push origin HEAD:{session.PullRequestHeadBranch}");
         }
 
         _logger.LogInformation("Pushing branch {Branch} to origin for {Key}", session.BranchName, session.IssueKey);

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -761,19 +761,19 @@ public sealed partial class ProcessManager
                     : CopilotdConfig.IssueFeedbackPrompt
                 : CopilotdConfig.DefaultPrompt;
 
-        var rule = GetRuleOptions(config, session);
+        var ruleOptions = GetRuleOptions(config, session);
 
         // Resolve the effective custom prompt based on rule settings
-        var effectiveCustomPrompt = ResolveCustomPrompt(globalCustomPrompt, rule);
+        var effectiveCustomPrompt = ResolveCustomPrompt(globalCustomPrompt, ruleOptions);
 
         if (!string.IsNullOrWhiteSpace(effectiveCustomPrompt))
         {
             prompt += "\n\nThe user has supplied the following additional context:\n\n" + effectiveCustomPrompt;
         }
 
-        if (!string.IsNullOrWhiteSpace(rule?.ExtraPrompt))
+        if (!string.IsNullOrWhiteSpace(ruleOptions?.ExtraPrompt))
         {
-            prompt += "\n\n" + rule.ExtraPrompt;
+            prompt += "\n\n" + ruleOptions.ExtraPrompt;
         }
 
         // Append security context when re-dispatching in response to comments
@@ -965,7 +965,7 @@ public sealed partial class ProcessManager
     private static DispatchRuleOptions? GetRuleOptions(CopilotdConfig config, DispatchSession session)
         => session.SubjectKind == DispatchSubjectKind.PullRequest
             ? config.PullRequestRules.GetValueOrDefault(session.RuleName)
-            : config.Rules.GetValueOrDefault(session.RuleName);
+            : config.IssueRules.GetValueOrDefault(session.RuleName);
 
     private static (string Org, string Repo) SplitRepoSlug(string repoSlug)
     {

--- a/src/copilotd/Models/CopilotdConfig.cs
+++ b/src/copilotd/Models/CopilotdConfig.cs
@@ -86,9 +86,11 @@ public sealed class CopilotdConfig
     public bool EnableReactions { get; set; } = true;
 
     /// <summary>
-    /// Named issue dispatch rules. Key is the rule name.
+    /// Named issue dispatch rules. Key is the rule name. Stored as "rules" for
+    /// compatibility with existing config files.
     /// </summary>
-    public Dictionary<string, IssueDispatchRule> Rules { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+    [JsonPropertyName("rules")]
+    public Dictionary<string, IssueDispatchRule> IssueRules { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Named pull request dispatch rules. Key is the rule name. Empty by default;

--- a/src/copilotd/Models/CopilotdConfig.cs
+++ b/src/copilotd/Models/CopilotdConfig.cs
@@ -79,16 +79,22 @@ public sealed class CopilotdConfig
     public bool EnableControlSession { get; set; } = true;
 
     /// <summary>
-    /// Whether to post emoji reactions on issues to indicate session lifecycle status
+    /// Whether to post emoji reactions on issues/PRs to indicate session lifecycle status
     /// (👀 queued, 🚀 working, 👍 completed, 👎 failed). Default is true.
-    /// Can be overridden per-rule via <see cref="DispatchRule.EnableReactions"/>.
+    /// Can be overridden per-rule via <see cref="IssueDispatchRule.EnableReactions"/>.
     /// </summary>
     public bool EnableReactions { get; set; } = true;
 
     /// <summary>
-    /// Named dispatch rules. Key is the rule name.
+    /// Named issue dispatch rules. Key is the rule name.
     /// </summary>
-    public Dictionary<string, DispatchRule> Rules { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+    public Dictionary<string, IssueDispatchRule> Rules { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Named pull request dispatch rules. Key is the rule name. Empty by default;
+    /// PR dispatch is always opt-in.
+    /// </summary>
+    public Dictionary<string, PullRequestDispatchRule> PullRequestRules { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 
     public const string DefaultRuleName = "Default";
 
@@ -184,12 +190,22 @@ public sealed class CopilotdConfig
 }
 
 /// <summary>
-/// A named dispatch rule with match conditions and launch options.
+/// A named issue dispatch rule with match conditions and launch options.
 /// </summary>
-public sealed class DispatchRule
+public sealed class IssueDispatchRule : DispatchRuleOptions
 {
-    /// <summary>Assigned user to match (null = any).</summary>
-    public string? User { get; set; }
+    /// <summary>Assigned user to match (null = any). Stored as "user" for config compatibility.</summary>
+    [JsonPropertyName("user")]
+    public string? Assignee { get; set; }
+
+    /// <summary>Compatibility alias for older code paths that referred to the issue assignee as User.</summary>
+    [JsonIgnore]
+    [Obsolete("Use Assignee for issue dispatch rules.")]
+    public string? User
+    {
+        get => Assignee;
+        set => Assignee = value;
+    }
 
     /// <summary>Labels that must all be present on the issue.</summary>
     public List<string> Labels { get; set; } = [];
@@ -199,9 +215,6 @@ public sealed class DispatchRule
 
     /// <summary>Issue type filter, e.g. "bug", "feature" (null = any).</summary>
     public string? Type { get; set; }
-
-    /// <summary>Repositories this rule applies to (org/repo format).</summary>
-    public List<string> Repos { get; set; } = [];
 
     // --- Author filtering ---
 
@@ -218,57 +231,6 @@ public sealed class DispatchRule
     /// </summary>
     public List<string> Authors { get; set; } = [];
 
-    // --- Launch options ---
-
-    /// <summary>Whether to pass --yolo to copilot, which implies --allow-all-tools and --allow-all-urls.</summary>
-    public bool Yolo { get; set; }
-
-    /// <summary>Whether to pass --allow-all-tools to copilot. Defaults to true. Implied by Yolo.</summary>
-    public bool AllowAllTools { get; set; } = true;
-
-    /// <summary>Whether to pass --allow-all-urls to copilot. Defaults to false. Implied by Yolo.</summary>
-    public bool AllowAllUrls { get; set; }
-
-    /// <summary>
-    /// Model to use for sessions triggered by this rule. Overrides the global
-    /// <see cref="CopilotdConfig.DefaultModel"/> when set.
-    /// </summary>
-    public string? Model { get; set; }
-
-    /// <summary>
-    /// Controls which comment authors can trigger session re-dispatch.
-    /// <see cref="CommentTrustLevel.Collaborators"/>: only repo collaborators with write access (default).
-    /// <see cref="CommentTrustLevel.All"/>: any commenter can trigger re-dispatch.
-    /// <see cref="CommentTrustLevel.IssueAuthor"/>: only the original issue author.
-    /// <see cref="CommentTrustLevel.Assignees"/>: only current issue assignees.
-    /// <see cref="CommentTrustLevel.IssueAuthorAndCollaborators"/>: issue author or write-access collaborators.
-    /// <see cref="CommentTrustLevel.MatchDispatchRule"/>: commenter must pass the rule's author filtering.
-    /// </summary>
-    public CommentTrustLevel TrustLevel { get; set; } = CommentTrustLevel.Collaborators;
-
-    /// <summary>Extra prompt text appended when this rule triggers.</summary>
-    public string? ExtraPrompt { get; set; }
-
-    /// <summary>
-    /// Per-rule custom prompt text. When set, this is used as the custom prompt
-    /// for sessions matching this rule. See <see cref="CustomPromptMode"/> for
-    /// how it interacts with the global custom prompt.
-    /// </summary>
-    public string? CustomPrompt { get; set; }
-
-    /// <summary>
-    /// Controls how <see cref="CustomPrompt"/> interacts with the global custom prompt.
-    /// <see cref="PromptMode.Append"/>: rule prompt is appended after the global custom prompt (default).
-    /// <see cref="PromptMode.Override"/>: rule prompt replaces the global custom prompt entirely.
-    /// </summary>
-    public PromptMode CustomPromptMode { get; set; } = PromptMode.Append;
-
-    /// <summary>
-    /// Per-rule override for emoji reactions on issues. When null (default), falls back
-    /// to the global <see cref="CopilotdConfig.EnableReactions"/> setting.
-    /// </summary>
-    public bool? EnableReactions { get; set; }
-
     /// <summary>
     /// Returns true if the given issue matches all conditions on this rule.
     /// All conditions are logical AND.
@@ -283,7 +245,7 @@ public sealed class DispatchRule
     /// </summary>
     public bool Matches(GitHubIssue issue, Func<string, string, bool>? hasWriteAccess)
     {
-        if (User is not null && !string.Equals(User, issue.Assignee, StringComparison.OrdinalIgnoreCase))
+        if (Assignee is not null && !string.Equals(Assignee, issue.Assignee, StringComparison.OrdinalIgnoreCase))
             return false;
 
         if (Labels.Count > 0 && !Labels.All(l => issue.Labels.Contains(l, StringComparer.OrdinalIgnoreCase)))
@@ -312,6 +274,142 @@ public sealed class DispatchRule
 
         return true;
     }
+}
+
+/// <summary>
+/// A named pull request dispatch rule with PR-specific match conditions and launch options.
+/// </summary>
+public sealed class PullRequestDispatchRule : DispatchRuleOptions
+{
+    /// <summary>Assigned user to match (null = any).</summary>
+    public string? Assignee { get; set; }
+
+    /// <summary>Labels that must all be present on the PR.</summary>
+    public List<string> Labels { get; set; } = [];
+
+    /// <summary>Base branch the PR targets (null = any).</summary>
+    public string? BaseBranch { get; set; }
+
+    /// <summary>Head branch name to match (null = any).</summary>
+    public string? HeadBranch { get; set; }
+
+    /// <summary>Head repository slug to match, e.g. "org/repo" (null = any).</summary>
+    public string? HeadRepo { get; set; }
+
+    /// <summary>Draft-state filter (null = any draft state).</summary>
+    public bool? Draft { get; set; }
+
+    /// <summary>Review decision filter, e.g. APPROVED, REVIEW_REQUIRED, CHANGES_REQUESTED (null = any).</summary>
+    public string? ReviewDecision { get; set; }
+
+    /// <summary>
+    /// Controls how the PR author is checked when matching.
+    /// </summary>
+    public AuthorMode AuthorMode { get; set; } = AuthorMode.Any;
+
+    /// <summary>
+    /// Allowed PR authors when <see cref="AuthorMode"/> is <see cref="AuthorMode.Allowed"/>.
+    /// </summary>
+    public List<string> Authors { get; set; } = [];
+
+    /// <summary>How PR-root sessions prepare a worktree/branch.</summary>
+    public PullRequestBranchStrategy BranchStrategy { get; set; } = PullRequestBranchStrategy.SourceBranch;
+
+    /// <summary>
+    /// Returns true if the given pull request matches all conditions on this rule.
+    /// All conditions are logical AND.
+    /// </summary>
+    public bool Matches(GitHubPullRequest pullRequest, Func<string, string, bool>? hasWriteAccess)
+    {
+        if (Assignee is not null && !pullRequest.Assignees.Contains(Assignee, StringComparer.OrdinalIgnoreCase))
+            return false;
+
+        if (Labels.Count > 0 && !Labels.All(l => pullRequest.Labels.Contains(l, StringComparer.OrdinalIgnoreCase)))
+            return false;
+
+        if (BaseBranch is not null && !string.Equals(BaseBranch, pullRequest.BaseBranch, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        if (HeadBranch is not null && !string.Equals(HeadBranch, pullRequest.HeadBranch, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        if (HeadRepo is not null && !string.Equals(HeadRepo, pullRequest.HeadRepo, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        if (Draft.HasValue && Draft.Value != pullRequest.IsDraft)
+            return false;
+
+        if (ReviewDecision is not null && !string.Equals(ReviewDecision, pullRequest.ReviewDecision, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        if (AuthorMode == AuthorMode.Allowed)
+        {
+            if (pullRequest.Author is null || !Authors.Contains(pullRequest.Author, StringComparer.OrdinalIgnoreCase))
+                return false;
+        }
+        else if (AuthorMode == AuthorMode.WriteAccess)
+        {
+            if (pullRequest.Author is null)
+                return false;
+
+            if (hasWriteAccess is not null && !hasWriteAccess(pullRequest.Repo, pullRequest.Author))
+                return false;
+        }
+
+        return true;
+    }
+}
+
+/// <summary>
+/// Shared launch/prompt/trust options for issue and pull request dispatch rules.
+/// </summary>
+public abstract class DispatchRuleOptions
+{
+    /// <summary>Repositories this rule applies to (org/repo format).</summary>
+    public List<string> Repos { get; set; } = [];
+
+    /// <summary>Whether to pass --yolo to copilot, which implies --allow-all-tools and --allow-all-urls.</summary>
+    public bool Yolo { get; set; }
+
+    /// <summary>Whether to pass --allow-all-tools to copilot. Defaults to true. Implied by Yolo.</summary>
+    public bool AllowAllTools { get; set; } = true;
+
+    /// <summary>Whether to pass --allow-all-urls to copilot. Defaults to false. Implied by Yolo.</summary>
+    public bool AllowAllUrls { get; set; }
+
+    /// <summary>
+    /// Model to use for sessions triggered by this rule. Overrides the global
+    /// <see cref="CopilotdConfig.DefaultModel"/> when set.
+    /// </summary>
+    public string? Model { get; set; }
+
+    /// <summary>
+    /// Controls which comment authors can trigger session re-dispatch.
+    /// </summary>
+    public CommentTrustLevel TrustLevel { get; set; } = CommentTrustLevel.Collaborators;
+
+    /// <summary>Extra prompt text appended when this rule triggers.</summary>
+    public string? ExtraPrompt { get; set; }
+
+    /// <summary>
+    /// Per-rule custom prompt text. When set, this is used as the custom prompt
+    /// for sessions matching this rule. See <see cref="CustomPromptMode"/> for
+    /// how it interacts with the global custom prompt.
+    /// </summary>
+    public string? CustomPrompt { get; set; }
+
+    /// <summary>
+    /// Controls how <see cref="CustomPrompt"/> interacts with the global custom prompt.
+    /// <see cref="PromptMode.Append"/>: rule prompt is appended after the global custom prompt (default).
+    /// <see cref="PromptMode.Override"/>: rule prompt replaces the global custom prompt entirely.
+    /// </summary>
+    public PromptMode CustomPromptMode { get; set; } = PromptMode.Append;
+
+    /// <summary>
+    /// Per-rule override for emoji reactions on issues. When null (default), falls back
+    /// to the global <see cref="CopilotdConfig.EnableReactions"/> setting.
+    /// </summary>
+    public bool? EnableReactions { get; set; }
 }
 
 /// <summary>
@@ -364,9 +462,25 @@ public enum AuthorMode
     /// <summary>Any author matches (default, no filtering).</summary>
     Any,
 
-    /// <summary>Only authors in the rule's <see cref="DispatchRule.Authors"/> list match.</summary>
+    /// <summary>Only authors in the rule's author allow-list match.</summary>
     Allowed,
 
     /// <summary>Only authors with write (or higher) access to the repository match.</summary>
     WriteAccess,
+}
+
+/// <summary>
+/// Controls how a PR-root dispatch session prepares its branch/worktree.
+/// </summary>
+[JsonConverter(typeof(TolerantPullRequestBranchStrategyConverter))]
+public enum PullRequestBranchStrategy
+{
+    /// <summary>Check out and push to the PR source branch when it is writable.</summary>
+    SourceBranch,
+
+    /// <summary>Create a new copilotd branch from the PR head SHA.</summary>
+    ChildBranch,
+
+    /// <summary>Check out the PR head for inspection/commenting only; do not push changes.</summary>
+    ReadOnly,
 }

--- a/src/copilotd/Models/GitHubPullRequest.cs
+++ b/src/copilotd/Models/GitHubPullRequest.cs
@@ -1,0 +1,52 @@
+namespace Copilotd.Models;
+
+/// <summary>
+/// Represents a GitHub pull request as returned by the gh CLI/API.
+/// </summary>
+public sealed class GitHubPullRequest
+{
+    /// <summary>Pull request number.</summary>
+    public int Number { get; set; }
+
+    /// <summary>Pull request title.</summary>
+    public string Title { get; set; } = "";
+
+    /// <summary>Repository in org/repo format.</summary>
+    public string Repo { get; set; } = "";
+
+    /// <summary>Pull request author login.</summary>
+    public string? Author { get; set; }
+
+    /// <summary>Assigned user logins.</summary>
+    public List<string> Assignees { get; set; } = [];
+
+    /// <summary>All label names.</summary>
+    public List<string> Labels { get; set; } = [];
+
+    /// <summary>Base branch targeted by the PR.</summary>
+    public string? BaseBranch { get; set; }
+
+    /// <summary>Source branch name.</summary>
+    public string? HeadBranch { get; set; }
+
+    /// <summary>Source repository in org/repo format.</summary>
+    public string? HeadRepo { get; set; }
+
+    /// <summary>Current PR head commit SHA.</summary>
+    public string? HeadSha { get; set; }
+
+    /// <summary>Whether the PR is a draft.</summary>
+    public bool IsDraft { get; set; }
+
+    /// <summary>Current review decision, if available.</summary>
+    public string? ReviewDecision { get; set; }
+
+    /// <summary>PR state (OPEN, CLOSED, MERGED).</summary>
+    public string State { get; set; } = "OPEN";
+
+    /// <summary>Whether the PR head is in the same repo as the base repo.</summary>
+    public bool IsSameRepository => string.Equals(Repo, HeadRepo, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Composite key for deduplication: "org/repo#number".</summary>
+    public string Key => $"{Repo}#{Number}";
+}

--- a/src/copilotd/Models/JsonContext.cs
+++ b/src/copilotd/Models/JsonContext.cs
@@ -256,20 +256,94 @@ public sealed class TolerantControlSessionStatusConverter : JsonConverter<Contro
 }
 
 /// <summary>
+/// AOT-compatible JSON converter for <see cref="DispatchSubjectKind"/> that gracefully handles
+/// unknown enum values by falling back to <see cref="DispatchSubjectKind.Issue"/>.
+/// </summary>
+public sealed class TolerantDispatchSubjectKindConverter : JsonConverter<DispatchSubjectKind>
+{
+    public override DispatchSubjectKind Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            var value = reader.GetString();
+            if (Enum.TryParse<DispatchSubjectKind>(value, ignoreCase: true, out var kind))
+                return kind;
+
+            return DispatchSubjectKind.Issue;
+        }
+
+        if (reader.TokenType == JsonTokenType.Number)
+        {
+            var intValue = reader.GetInt32();
+            if (Enum.IsDefined(typeof(DispatchSubjectKind), intValue))
+                return (DispatchSubjectKind)intValue;
+
+            return DispatchSubjectKind.Issue;
+        }
+
+        return DispatchSubjectKind.Issue;
+    }
+
+    public override void Write(Utf8JsonWriter writer, DispatchSubjectKind value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToString());
+    }
+}
+
+/// <summary>
+/// AOT-compatible JSON converter for <see cref="PullRequestBranchStrategy"/> that gracefully handles
+/// unknown enum values by falling back to <see cref="PullRequestBranchStrategy.SourceBranch"/>.
+/// </summary>
+public sealed class TolerantPullRequestBranchStrategyConverter : JsonConverter<PullRequestBranchStrategy>
+{
+    public override PullRequestBranchStrategy Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            var value = reader.GetString();
+            if (Enum.TryParse<PullRequestBranchStrategy>(value, ignoreCase: true, out var strategy))
+                return strategy;
+
+            return PullRequestBranchStrategy.SourceBranch;
+        }
+
+        if (reader.TokenType == JsonTokenType.Number)
+        {
+            var intValue = reader.GetInt32();
+            if (Enum.IsDefined(typeof(PullRequestBranchStrategy), intValue))
+                return (PullRequestBranchStrategy)intValue;
+
+            return PullRequestBranchStrategy.SourceBranch;
+        }
+
+        return PullRequestBranchStrategy.SourceBranch;
+    }
+
+    public override void Write(Utf8JsonWriter writer, PullRequestBranchStrategy value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToString());
+    }
+}
+
+/// <summary>
 /// AOT-safe JSON serialization metadata for all persisted models.
 /// </summary>
 [JsonSourceGenerationOptions(
     WriteIndented = true,
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-    Converters = [typeof(TolerantSessionStatusConverter), typeof(TolerantReactionTargetTypeConverter), typeof(TolerantUpdateStatusConverter), typeof(TolerantPromptModeConverter), typeof(TolerantCommentTrustLevelConverter), typeof(TolerantAuthorModeConverter), typeof(TolerantControlSessionStatusConverter)])]
+    Converters = [typeof(TolerantSessionStatusConverter), typeof(TolerantReactionTargetTypeConverter), typeof(TolerantUpdateStatusConverter), typeof(TolerantPromptModeConverter), typeof(TolerantCommentTrustLevelConverter), typeof(TolerantAuthorModeConverter), typeof(TolerantControlSessionStatusConverter), typeof(TolerantDispatchSubjectKindConverter), typeof(TolerantPullRequestBranchStrategyConverter)])]
 [JsonSerializable(typeof(CopilotdConfig))]
 [JsonSerializable(typeof(DaemonState))]
-[JsonSerializable(typeof(DispatchRule))]
+[JsonSerializable(typeof(DispatchRuleOptions))]
+[JsonSerializable(typeof(IssueDispatchRule))]
+[JsonSerializable(typeof(PullRequestDispatchRule))]
 [JsonSerializable(typeof(DispatchSession))]
 [JsonSerializable(typeof(ControlSessionInfo))]
 [JsonSerializable(typeof(GitHubIssue))]
 [JsonSerializable(typeof(List<GitHubIssue>))]
+[JsonSerializable(typeof(GitHubPullRequest))]
+[JsonSerializable(typeof(List<GitHubPullRequest>))]
 [JsonSerializable(typeof(List<GhRepo>))]
 [JsonSerializable(typeof(GhAuthStatus))]
 [JsonSerializable(typeof(UpdateState))]

--- a/src/copilotd/Models/SessionState.cs
+++ b/src/copilotd/Models/SessionState.cs
@@ -73,6 +73,19 @@ public enum SessionStatus
 }
 
 /// <summary>
+/// The GitHub subject kind that caused a session to be dispatched.
+/// </summary>
+[JsonConverter(typeof(TolerantDispatchSubjectKindConverter))]
+public enum DispatchSubjectKind
+{
+    /// <summary>The root dispatch subject is an issue.</summary>
+    Issue,
+
+    /// <summary>The root dispatch subject is a pull request.</summary>
+    PullRequest,
+}
+
+/// <summary>
 /// The GitHub object currently hosting a session's lifecycle reaction.
 /// </summary>
 [JsonConverter(typeof(TolerantReactionTargetTypeConverter))]
@@ -101,24 +114,63 @@ public readonly record struct ReactionAnchor(ReactionTargetType TargetType, long
 /// </summary>
 public sealed class DispatchSession
 {
-    /// <summary>Issue key: "org/repo#number".</summary>
+    /// <summary>The kind of GitHub subject that caused this session to be dispatched.</summary>
+    public DispatchSubjectKind SubjectKind { get; set; } = DispatchSubjectKind.Issue;
+
+    /// <summary>
+    /// Subject key in "org/repo#number" format. Stored under the legacy issueKey
+    /// JSON name for compatibility with existing state files.
+    /// </summary>
+    [JsonPropertyName("issueKey")]
     public string IssueKey { get; set; } = "";
+
+    /// <summary>Subject key in "org/repo#number" format.</summary>
+    [JsonIgnore]
+    public string SubjectKey
+    {
+        get => IssueKey;
+        set => IssueKey = value;
+    }
 
     /// <summary>Repository in org/repo format.</summary>
     public string Repo { get; set; } = "";
 
-    /// <summary>Issue number.</summary>
+    /// <summary>
+    /// Subject number. Stored under the legacy issueNumber JSON name for compatibility
+    /// with existing state files.
+    /// </summary>
+    [JsonPropertyName("issueNumber")]
     public int IssueNumber { get; set; }
+
+    /// <summary>Root issue or PR number.</summary>
+    [JsonIgnore]
+    public int SubjectNumber
+    {
+        get => IssueNumber;
+        set => IssueNumber = value;
+    }
 
     /// <summary>Name of the rule that triggered this dispatch.</summary>
     public string RuleName { get; set; } = "";
 
     /// <summary>
-    /// The GitHub login of the issue author at the time of dispatch.
+    /// The GitHub login of the root subject author at the time of dispatch.
     /// Used by <see cref="CommentTrustLevel.IssueAuthor"/> and
     /// <see cref="CommentTrustLevel.IssueAuthorAndCollaborators"/> trust checks.
     /// </summary>
+    [JsonPropertyName("issueAuthor")]
     public string? IssueAuthor { get; set; }
+
+    /// <summary>GitHub login of the root subject author at dispatch time.</summary>
+    [JsonIgnore]
+    public string? SubjectAuthor
+    {
+        get => IssueAuthor;
+        set => IssueAuthor = value;
+    }
+
+    /// <summary>Title of the root subject at dispatch time, when available.</summary>
+    public string? SubjectTitle { get; set; }
 
     /// <summary>
     /// Stable local identifier for this tracked session. Existing persisted sessions also use this
@@ -183,10 +235,36 @@ public sealed class DispatchSession
     public DateTimeOffset? WaitingSince { get; set; }
 
     /// <summary>
-    /// The pull request number associated with this session, if one was created.
+    /// The pull request number associated with this issue-root session, if one was created.
     /// Set via 'copilotd session pr' and used to monitor for review comments.
     /// </summary>
+    [JsonPropertyName("pullRequestNumber")]
     public int? PullRequestNumber { get; set; }
+
+    /// <summary>
+    /// Pull request number monitored by an issue-root session for review feedback.
+    /// </summary>
+    [JsonIgnore]
+    public int? ReviewPullRequestNumber
+    {
+        get => PullRequestNumber;
+        set => PullRequestNumber = value;
+    }
+
+    /// <summary>PR base branch for PR-root sessions.</summary>
+    public string? PullRequestBaseBranch { get; set; }
+
+    /// <summary>PR head branch for PR-root sessions.</summary>
+    public string? PullRequestHeadBranch { get; set; }
+
+    /// <summary>PR head repository for PR-root sessions.</summary>
+    public string? PullRequestHeadRepo { get; set; }
+
+    /// <summary>PR head SHA that was last dispatched for a PR-root session.</summary>
+    public string? PullRequestHeadSha { get; set; }
+
+    /// <summary>Branch strategy used by PR-root sessions.</summary>
+    public PullRequestBranchStrategy? PullRequestBranchStrategy { get; set; }
 
     /// <summary>
     /// Number of times this session has been re-dispatched via comment/review feedback loops.
@@ -216,6 +294,7 @@ public sealed class DispatchSession
     /// The GitHub reaction ID currently posted by copilotd for lifecycle tracking.
     /// Kept under its legacy name for persisted-state compatibility.
     /// </summary>
+    [JsonPropertyName("issueReactionId")]
     public long? IssueReactionId { get; set; }
 
     /// <summary>

--- a/src/copilotd/Services/GhCliService.cs
+++ b/src/copilotd/Services/GhCliService.cs
@@ -300,7 +300,7 @@ public sealed class GhCliService
     /// <summary>
     /// Queries open issues for a repo matching the given rule conditions.
     /// </summary>
-    public List<GitHubIssue> QueryIssues(string repo, DispatchRule rule)
+    public List<GitHubIssue> QueryIssues(string repo, IssueDispatchRule rule)
     {
         var jsonFields = _supportsTypeField
             ? "number,title,author,assignees,labels,milestone,type"
@@ -308,8 +308,8 @@ public sealed class GhCliService
 
         var args = $"issue list --repo {repo} --state open --json {jsonFields} --limit 100";
 
-        if (rule.User is not null)
-            args += $" --assignee {rule.User}";
+        if (rule.Assignee is not null)
+            args += $" --assignee {rule.Assignee}";
 
         foreach (var label in rule.Labels)
             args += $" --label \"{label}\"";
@@ -326,8 +326,8 @@ public sealed class GhCliService
             _supportsTypeField = false;
             args = $"issue list --repo {repo} --state open --json number,title,author,assignees,labels,milestone --limit 100";
 
-            if (rule.User is not null)
-                args += $" --assignee {rule.User}";
+            if (rule.Assignee is not null)
+                args += $" --assignee {rule.Assignee}";
 
             foreach (var label in rule.Labels)
                 args += $" --label \"{label}\"";
@@ -408,6 +408,130 @@ public sealed class GhCliService
         }
 
         return issues;
+    }
+
+    /// <summary>
+    /// Queries open pull requests for a repo matching the given rule conditions.
+    /// </summary>
+    public List<GitHubPullRequest> QueryPullRequests(string repo, PullRequestDispatchRule rule)
+    {
+        const string jsonFields = "number,title,author,assignees,labels,baseRefName,headRefName,headRepository,headRepositoryOwner,headRefOid,isDraft,reviewDecision,state";
+        var args = $"pr list --repo {repo} --state open --json {jsonFields} --limit 100";
+
+        if (rule.Assignee is not null)
+            args += $" --assignee {rule.Assignee}";
+
+        foreach (var label in rule.Labels)
+            args += $" --label \"{label}\"";
+
+        if (rule.BaseBranch is not null)
+            args += $" --base \"{rule.BaseBranch}\"";
+
+        if (rule.AuthorMode == AuthorMode.Allowed && rule.Authors.Count == 1)
+            args += $" --author \"{rule.Authors[0]}\"";
+
+        var (exitCode, output) = RunGh(args);
+        if (exitCode != 0)
+        {
+            _logger.LogWarning("Failed to query pull requests for {Repo}: {Output}", repo, output);
+            return [];
+        }
+
+        try
+        {
+            return ParsePullRequestsJson(output, repo);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse pull request JSON for {Repo}", repo);
+            return [];
+        }
+    }
+
+    private static List<GitHubPullRequest> ParsePullRequestsJson(string json, string repo)
+    {
+        using var doc = JsonDocument.Parse(json);
+        var pullRequests = new List<GitHubPullRequest>();
+
+        foreach (var element in doc.RootElement.EnumerateArray())
+        {
+            var pullRequest = new GitHubPullRequest
+            {
+                Number = element.GetProperty("number").GetInt32(),
+                Title = element.TryGetProperty("title", out var title) ? title.GetString() ?? "" : "",
+                Repo = repo,
+                BaseBranch = element.TryGetProperty("baseRefName", out var baseRefName) ? baseRefName.GetString() : null,
+                HeadBranch = element.TryGetProperty("headRefName", out var headRefName) ? headRefName.GetString() : null,
+                HeadSha = element.TryGetProperty("headRefOid", out var headRefOid) ? headRefOid.GetString() : null,
+                IsDraft = element.TryGetProperty("isDraft", out var isDraft) && isDraft.ValueKind == JsonValueKind.True,
+                ReviewDecision = element.TryGetProperty("reviewDecision", out var reviewDecision) ? reviewDecision.GetString() : null,
+                State = element.TryGetProperty("state", out var state) ? state.GetString() ?? "OPEN" : "OPEN",
+                Labels = [],
+                Assignees = [],
+            };
+
+            if (element.TryGetProperty("author", out var authorEl) && authorEl.ValueKind == JsonValueKind.Object)
+            {
+                pullRequest.Author = authorEl.TryGetProperty("login", out var authorLogin) ? authorLogin.GetString() : null;
+            }
+
+            if (element.TryGetProperty("assignees", out var assignees))
+            {
+                foreach (var assignee in assignees.EnumerateArray())
+                {
+                    var login = assignee.TryGetProperty("login", out var loginEl) ? loginEl.GetString() : null;
+                    if (login is not null)
+                        pullRequest.Assignees.Add(login);
+                }
+            }
+
+            if (element.TryGetProperty("labels", out var labels))
+            {
+                foreach (var label in labels.EnumerateArray())
+                {
+                    var name = label.TryGetProperty("name", out var nameEl) ? nameEl.GetString() : null;
+                    if (name is not null)
+                        pullRequest.Labels.Add(name);
+                }
+            }
+
+            pullRequest.HeadRepo = GetHeadRepositorySlug(element);
+            pullRequests.Add(pullRequest);
+        }
+
+        return pullRequests;
+    }
+
+    private static string? GetHeadRepositorySlug(JsonElement pullRequest)
+    {
+        if (pullRequest.TryGetProperty("headRepository", out var headRepo)
+            && headRepo.ValueKind == JsonValueKind.Object)
+        {
+            if (headRepo.TryGetProperty("nameWithOwner", out var nameWithOwner))
+                return nameWithOwner.GetString();
+
+            var name = headRepo.TryGetProperty("name", out var nameEl) ? nameEl.GetString() : null;
+            var owner = headRepo.TryGetProperty("owner", out var ownerEl) && ownerEl.ValueKind == JsonValueKind.Object
+                ? ownerEl.TryGetProperty("login", out var loginEl) ? loginEl.GetString() : null
+                : null;
+            if (owner is not null && name is not null)
+                return $"{owner}/{name}";
+        }
+
+        if (pullRequest.TryGetProperty("headRepositoryOwner", out var headRepoOwner)
+            && headRepoOwner.ValueKind == JsonValueKind.Object
+            && headRepoOwner.TryGetProperty("login", out var ownerLogin)
+            && pullRequest.TryGetProperty("headRepository", out var repoEl)
+            && repoEl.ValueKind == JsonValueKind.Object
+            && repoEl.TryGetProperty("name", out var repoName))
+        {
+            var owner = ownerLogin.GetString();
+            var name = repoName.GetString();
+            if (owner is not null && name is not null)
+                return $"{owner}/{name}";
+        }
+
+        return null;
     }
 
     /// <summary>
@@ -543,6 +667,97 @@ public sealed class GhCliService
         }
     }
 
+    private NewCommentInfo? GetNewPrReviewThreadCommentSince(string repo, int prNumber, DateTimeOffset since)
+    {
+        var repoParts = repo.Split('/', 2);
+        if (repoParts.Length != 2)
+            return null;
+
+        var request = new JsonObject
+        {
+            ["query"] = """
+                query($owner: String!, $name: String!, $number: Int!) {
+                  repository(owner: $owner, name: $name) {
+                    pullRequest(number: $number) {
+                      reviewThreads(first: 100) {
+                        nodes {
+                          comments(first: 100) {
+                            nodes {
+                              databaseId
+                              body
+                              createdAt
+                              author {
+                                login
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                """,
+            ["variables"] = new JsonObject
+            {
+                ["owner"] = repoParts[0],
+                ["name"] = repoParts[1],
+                ["number"] = prNumber,
+            },
+        };
+
+        var (exitCode, output) = RunGhWithStdin("api graphql --input -", request.ToJsonString());
+        if (exitCode != 0)
+        {
+            _logger.LogWarning("Failed to query PR review thread comments on {Repo}!{Pr}: {Output}", repo, prNumber, output);
+            return null;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(output);
+            if (doc.RootElement.TryGetProperty("errors", out var errors))
+            {
+                _logger.LogWarning("GraphQL errors querying PR review thread comments on {Repo}!{Pr}: {Errors}", repo, prNumber, errors.ToString());
+                return null;
+            }
+
+            if (!doc.RootElement.TryGetProperty("data", out var data)
+                || !data.TryGetProperty("repository", out var repository)
+                || !repository.TryGetProperty("pullRequest", out var pullRequest)
+                || !pullRequest.TryGetProperty("reviewThreads", out var reviewThreads)
+                || !reviewThreads.TryGetProperty("nodes", out var threadNodes))
+            {
+                return null;
+            }
+
+            foreach (var thread in threadNodes.EnumerateArray())
+            {
+                if (!thread.TryGetProperty("comments", out var comments)
+                    || !comments.TryGetProperty("nodes", out var commentNodes))
+                {
+                    continue;
+                }
+
+                foreach (var comment in commentNodes.EnumerateArray())
+                {
+                    var info = ExtractNewNonBotComment(comment, since, "createdAt");
+                    if (info is null)
+                        continue;
+
+                    _logger.LogDebug("Found new PR review thread comment on {Repo}!{Pr} from {Author}", repo, prNumber, info.Author);
+                    return info;
+                }
+            }
+
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse PR review thread comments JSON for {Repo}!{Pr}", repo, prNumber);
+            return null;
+        }
+    }
+
     /// <summary>
     /// Checks whether a user has write (or higher) access to a repository.
     /// Results are cached for 15 minutes to avoid excessive API calls.
@@ -630,9 +845,8 @@ public sealed class GhCliService
 
     /// <summary>
     /// Returns info about the first new non-bot review comment or PR comment since the given timestamp,
-    /// or null if no new comments exist. Checks both regular PR comments and formal review submissions.
-    /// Note: Does not detect individual review-thread replies (only top-level comments and formal
-    /// review submissions). Detecting thread replies would require GraphQL queries against reviewThreads.
+    /// or null if no new comments exist. Checks regular PR comments, formal review submissions,
+    /// and individual review-thread replies.
     /// </summary>
     public NewCommentInfo? GetNewPrReviewCommentSince(string repo, int prNumber, DateTimeOffset since)
     {
@@ -641,6 +855,10 @@ public sealed class GhCliService
         if (exitCode != 0)
         {
             _logger.LogWarning("Failed to query PR comments on {Repo}#{Pr}: {Output}", repo, prNumber, output);
+            var threadComment = GetNewPrReviewThreadCommentSince(repo, prNumber, since);
+            if (threadComment is not null)
+                return threadComment;
+
             return null;
         }
 

--- a/src/copilotd/Services/GhCliService.cs
+++ b/src/copilotd/Services/GhCliService.cs
@@ -300,7 +300,7 @@ public sealed class GhCliService
     /// <summary>
     /// Queries open issues for a repo matching the given rule conditions.
     /// </summary>
-    public List<GitHubIssue> QueryIssues(string repo, IssueDispatchRule rule)
+    public List<GitHubIssue> QueryIssues(string repo, IssueDispatchRule issueRule)
     {
         var jsonFields = _supportsTypeField
             ? "number,title,author,assignees,labels,milestone,type"
@@ -308,14 +308,14 @@ public sealed class GhCliService
 
         var args = $"issue list --repo {repo} --state open --json {jsonFields} --limit 100";
 
-        if (rule.Assignee is not null)
-            args += $" --assignee {rule.Assignee}";
+        if (issueRule.Assignee is not null)
+            args += $" --assignee {issueRule.Assignee}";
 
-        foreach (var label in rule.Labels)
+        foreach (var label in issueRule.Labels)
             args += $" --label \"{label}\"";
 
-        if (rule.Milestone is not null)
-            args += $" --milestone \"{rule.Milestone}\"";
+        if (issueRule.Milestone is not null)
+            args += $" --milestone \"{issueRule.Milestone}\"";
 
         var (exitCode, output) = RunGh(args);
 
@@ -326,14 +326,14 @@ public sealed class GhCliService
             _supportsTypeField = false;
             args = $"issue list --repo {repo} --state open --json number,title,author,assignees,labels,milestone --limit 100";
 
-            if (rule.Assignee is not null)
-                args += $" --assignee {rule.Assignee}";
+            if (issueRule.Assignee is not null)
+                args += $" --assignee {issueRule.Assignee}";
 
-            foreach (var label in rule.Labels)
+            foreach (var label in issueRule.Labels)
                 args += $" --label \"{label}\"";
 
-            if (rule.Milestone is not null)
-                args += $" --milestone \"{rule.Milestone}\"";
+            if (issueRule.Milestone is not null)
+                args += $" --milestone \"{issueRule.Milestone}\"";
 
             (exitCode, output) = RunGh(args);
         }
@@ -413,22 +413,22 @@ public sealed class GhCliService
     /// <summary>
     /// Queries open pull requests for a repo matching the given rule conditions.
     /// </summary>
-    public List<GitHubPullRequest> QueryPullRequests(string repo, PullRequestDispatchRule rule)
+    public List<GitHubPullRequest> QueryPullRequests(string repo, PullRequestDispatchRule pullRequestRule)
     {
         const string jsonFields = "number,title,author,assignees,labels,baseRefName,headRefName,headRepository,headRepositoryOwner,headRefOid,isDraft,reviewDecision,state";
         var args = $"pr list --repo {repo} --state open --json {jsonFields} --limit 100";
 
-        if (rule.Assignee is not null)
-            args += $" --assignee {rule.Assignee}";
+        if (pullRequestRule.Assignee is not null)
+            args += $" --assignee {pullRequestRule.Assignee}";
 
-        foreach (var label in rule.Labels)
+        foreach (var label in pullRequestRule.Labels)
             args += $" --label \"{label}\"";
 
-        if (rule.BaseBranch is not null)
-            args += $" --base \"{rule.BaseBranch}\"";
+        if (pullRequestRule.BaseBranch is not null)
+            args += $" --base \"{pullRequestRule.BaseBranch}\"";
 
-        if (rule.AuthorMode == AuthorMode.Allowed && rule.Authors.Count == 1)
-            args += $" --author \"{rule.Authors[0]}\"";
+        if (pullRequestRule.AuthorMode == AuthorMode.Allowed && pullRequestRule.Authors.Count == 1)
+            args += $" --author \"{pullRequestRule.Authors[0]}\"";
 
         var (exitCode, output) = RunGh(args);
         if (exitCode != 0)

--- a/src/copilotd/Services/ReconciliationEngine.cs
+++ b/src/copilotd/Services/ReconciliationEngine.cs
@@ -5,13 +5,13 @@ using Microsoft.Extensions.Logging;
 namespace Copilotd.Services;
 
 /// <summary>
-/// The reconciliation engine. Compares desired dispatches (from rules + issues)
+/// The reconciliation engine. Compares desired dispatches (from rules + issues/PRs)
 /// against observed state (persisted sessions + live processes) and takes
 /// corrective action to converge.
 ///
 /// Truth sources (in order of precedence for conflicts):
 /// 1. Live process status (ground truth for "is it actually running?")
-/// 2. Current GitHub issue matches (ground truth for "should it be running?")
+/// 2. Current GitHub issue/PR matches (ground truth for "should it be running?")
 /// 3. Persisted state (bookkeeping, used as starting point)
 /// </summary>
 public sealed class ReconciliationEngine
@@ -57,12 +57,12 @@ public sealed class ReconciliationEngine
         // Step 1: Verify all tracked non-terminal sessions against live processes
         VerifyTrackedSessions(state);
 
-        // Step 2: Gather all matching issues and pull requests from configured rules
-        var (desiredDispatches, queriedRepos) = ComputeDesiredDispatches(config);
+        // Step 2: Gather all matching issues and pull requests from configured issue/PR rules
+        var (desiredIssueDispatches, queriedIssueRepos) = ComputeDesiredIssueDispatches(config);
         var (desiredPullRequestDispatches, queriedPullRequestRepos) = ComputeDesiredPullRequestDispatches(config);
 
         // Step 3: Reconcile desired vs observed
-        ReconcileDesiredVsObserved(config, state, desiredDispatches, queriedRepos, desiredPullRequestDispatches, queriedPullRequestRepos);
+        ReconcileDesiredVsObserved(config, state, desiredIssueDispatches, queriedIssueRepos, desiredPullRequestDispatches, queriedPullRequestRepos);
 
         // Step 4: Dispatch pending sessions (respects MaxInstances)
         DispatchPendingSessions(config, state);
@@ -180,51 +180,51 @@ public sealed class ReconciliationEngine
     }
 
     /// <summary>
-    /// Step 2: Query GitHub for all issues that currently match configured rules.
-    /// Returns the desired dispatches and the set of repos that were successfully queried.
+    /// Step 2: Query GitHub for all issues that currently match configured issue rules.
+    /// Returns the desired issue dispatches and the set of repos that were successfully queried.
     /// Only repos in the queried set should be used for termination decisions — if a repo
     /// query fails, existing sessions for that repo are preserved.
     /// </summary>
     private (Dictionary<string, (GitHubIssue Issue, string RuleName)> Desired, HashSet<string> QueriedRepos)
-        ComputeDesiredDispatches(CopilotdConfig config)
+        ComputeDesiredIssueDispatches(CopilotdConfig config)
     {
-        var desired = new Dictionary<string, (GitHubIssue, string)>(StringComparer.OrdinalIgnoreCase);
-        var queriedRepos = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var desiredIssues = new Dictionary<string, (GitHubIssue, string)>(StringComparer.OrdinalIgnoreCase);
+        var queriedIssueRepos = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        foreach (var (ruleName, rule) in config.Rules)
+        foreach (var (issueRuleName, issueRule) in config.IssueRules)
         {
-            foreach (var repo in rule.Repos)
+            foreach (var repo in issueRule.Repos)
             {
                 try
                 {
-                    var issues = _ghCli.QueryIssues(repo, rule);
-                    queriedRepos.Add(repo);
+                    var issues = _ghCli.QueryIssues(repo, issueRule);
+                    queriedIssueRepos.Add(repo);
 
                     foreach (var issue in issues)
                     {
-                        // Double-check rule match (gh filters are best-effort)
+                        // Double-check issue rule match (gh filters are best-effort)
                         // Pass HasWriteAccess for AuthorMode.WriteAccess checks
-                        if (!rule.Matches(issue, _ghCli.HasWriteAccess))
+                        if (!issueRule.Matches(issue, _ghCli.HasWriteAccess))
                             continue;
 
-                        if (!desired.ContainsKey(issue.Key))
+                        if (!desiredIssues.ContainsKey(issue.Key))
                         {
-                            desired[issue.Key] = (issue, ruleName);
-                            _logger.LogDebug("Desired dispatch: {Key} via rule '{Rule}'", issue.Key, ruleName);
+                            desiredIssues[issue.Key] = (issue, issueRuleName);
+                            _logger.LogDebug("Desired issue dispatch: {Key} via issue rule '{Rule}'", issue.Key, issueRuleName);
                         }
                     }
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogWarning(ex, "Error querying issues for {Repo} with rule '{Rule}', preserving existing sessions", repo, ruleName);
+                    _logger.LogWarning(ex, "Error querying issues for {Repo} with issue rule '{Rule}', preserving existing sessions", repo, issueRuleName);
                 }
             }
         }
 
-        _logger.LogInformation("Found {Count} issues matching configured rules ({Queried}/{Total} repos queried successfully)",
-            desired.Count, queriedRepos.Count,
-            config.Rules.Values.SelectMany(r => r.Repos).Distinct(StringComparer.OrdinalIgnoreCase).Count());
-        return (desired, queriedRepos);
+        _logger.LogInformation("Found {Count} issues matching configured issue rules ({Queried}/{Total} repos queried successfully)",
+            desiredIssues.Count, queriedIssueRepos.Count,
+            config.IssueRules.Values.SelectMany(r => r.Repos).Distinct(StringComparer.OrdinalIgnoreCase).Count());
+        return (desiredIssues, queriedIssueRepos);
     }
 
     /// <summary>
@@ -233,55 +233,55 @@ public sealed class ReconciliationEngine
     private (Dictionary<string, (GitHubPullRequest PullRequest, string RuleName)> Desired, HashSet<string> QueriedRepos)
         ComputeDesiredPullRequestDispatches(CopilotdConfig config)
     {
-        var desired = new Dictionary<string, (GitHubPullRequest, string)>(StringComparer.OrdinalIgnoreCase);
-        var queriedRepos = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var desiredPullRequests = new Dictionary<string, (GitHubPullRequest, string)>(StringComparer.OrdinalIgnoreCase);
+        var queriedPullRequestRepos = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        foreach (var (ruleName, rule) in config.PullRequestRules)
+        foreach (var (pullRequestRuleName, pullRequestRule) in config.PullRequestRules)
         {
-            foreach (var repo in rule.Repos)
+            foreach (var repo in pullRequestRule.Repos)
             {
                 try
                 {
-                    var pullRequests = _ghCli.QueryPullRequests(repo, rule);
-                    queriedRepos.Add(repo);
+                    var pullRequests = _ghCli.QueryPullRequests(repo, pullRequestRule);
+                    queriedPullRequestRepos.Add(repo);
 
                     foreach (var pullRequest in pullRequests)
                     {
-                        if (!rule.Matches(pullRequest, _ghCli.HasWriteAccess))
+                        if (!pullRequestRule.Matches(pullRequest, _ghCli.HasWriteAccess))
                             continue;
 
-                        if (!desired.ContainsKey(pullRequest.Key))
+                        if (!desiredPullRequests.ContainsKey(pullRequest.Key))
                         {
-                            desired[pullRequest.Key] = (pullRequest, ruleName);
-                            _logger.LogDebug("Desired PR dispatch: {Key} via rule '{Rule}'", pullRequest.Key, ruleName);
+                            desiredPullRequests[pullRequest.Key] = (pullRequest, pullRequestRuleName);
+                            _logger.LogDebug("Desired PR dispatch: {Key} via PR rule '{Rule}'", pullRequest.Key, pullRequestRuleName);
                         }
                     }
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogWarning(ex, "Error querying pull requests for {Repo} with rule '{Rule}', preserving existing sessions", repo, ruleName);
+                    _logger.LogWarning(ex, "Error querying pull requests for {Repo} with PR rule '{Rule}', preserving existing sessions", repo, pullRequestRuleName);
                 }
             }
         }
 
         _logger.LogInformation("Found {Count} pull requests matching configured PR rules ({Queried}/{Total} repos queried successfully)",
-            desired.Count, queriedRepos.Count,
+            desiredPullRequests.Count, queriedPullRequestRepos.Count,
             config.PullRequestRules.Values.SelectMany(r => r.Repos).Distinct(StringComparer.OrdinalIgnoreCase).Count());
-        return (desired, queriedRepos);
+        return (desiredPullRequests, queriedPullRequestRepos);
     }
 
     /// <summary>
     /// Step 3: Compare desired dispatches against tracked sessions.
     /// - Issues without active sessions → create pending
-    /// - Tracked sessions whose issues no longer match (and repo was queried) → mark completed
+    /// - Tracked sessions whose subjects no longer match (and repo was queried) → mark completed
     /// - Orphaned sessions for still-matching issues → re-dispatch if retries remain
     /// - Completed sessions for still-matching issues → re-dispatch with new session ID
     /// </summary>
     private void ReconcileDesiredVsObserved(
         CopilotdConfig config,
         DaemonState state,
-        Dictionary<string, (GitHubIssue Issue, string RuleName)> desired,
-        HashSet<string> queriedRepos,
+        Dictionary<string, (GitHubIssue Issue, string RuleName)> desiredIssues,
+        HashSet<string> queriedIssueRepos,
         Dictionary<string, (GitHubPullRequest PullRequest, string RuleName)> desiredPullRequests,
         HashSet<string> queriedPullRequestRepos)
     {
@@ -291,18 +291,18 @@ public sealed class ReconciliationEngine
         {
             var desiredContainsSession = session.SubjectKind == DispatchSubjectKind.PullRequest
                 ? desiredPullRequests.ContainsKey(key)
-                : desired.ContainsKey(key);
+                : desiredIssues.ContainsKey(key);
             var repoWasQueried = session.SubjectKind == DispatchSubjectKind.PullRequest
                 ? queriedPullRequestRepos.Contains(session.Repo)
-                : queriedRepos.Contains(session.Repo);
+                : queriedIssueRepos.Contains(session.Repo);
             var subjectLabel = session.SubjectKind == DispatchSubjectKind.PullRequest ? "Pull request" : "Issue";
 
-            // Clear CompletedBySession flag when the subject no longer matches rules,
+            // Clear CompletedBySession flag when the subject no longer matches issue/PR rules,
             // so that if the subject re-matches later it will be re-dispatched
             if (session.Status == SessionStatus.Completed && session.CompletedBySession
                 && !desiredContainsSession && repoWasQueried)
             {
-                _logger.LogInformation("{Subject} {Key} no longer matches rules, clearing CompletedBySession flag", subjectLabel, key);
+                _logger.LogInformation("{Subject} {Key} no longer matches issue/PR rules, clearing CompletedBySession flag", subjectLabel, key);
                 session.CompletedBySession = false;
                 session.UpdatedAt = DateTimeOffset.UtcNow;
             }
@@ -327,7 +327,7 @@ public sealed class ReconciliationEngine
                 // WaitingForFeedback sessions have no process to terminate
                 if (session.Status is SessionStatus.WaitingForFeedback)
                 {
-                    _logger.LogInformation("{Subject} {Key} no longer matches rules, completing waiting session", subjectLabel, key);
+                    _logger.LogInformation("{Subject} {Key} no longer matches issue/PR rules, completing waiting session", subjectLabel, key);
                     session.Status = SessionStatus.Completed;
                     session.FailureDetail = null;
                     session.WaitingSince = null;
@@ -340,7 +340,7 @@ public sealed class ReconciliationEngine
                 // WaitingForReview sessions have no process to terminate
                 if (session.Status is SessionStatus.WaitingForReview)
                 {
-                    _logger.LogInformation("{Subject} {Key} no longer matches rules, completing PR review session", subjectLabel, key);
+                    _logger.LogInformation("{Subject} {Key} no longer matches issue/PR rules, completing PR review session", subjectLabel, key);
                     session.Status = SessionStatus.Completed;
                     session.FailureDetail = null;
                     session.WaitingSince = null;
@@ -350,7 +350,7 @@ public sealed class ReconciliationEngine
                     continue;
                 }
 
-                _logger.LogInformation("{Subject} {Key} no longer matches rules, terminating session", subjectLabel, key);
+                _logger.LogInformation("{Subject} {Key} no longer matches issue/PR rules, terminating session", subjectLabel, key);
                 toTerminate.Add(session);
             }
         }
@@ -374,7 +374,7 @@ public sealed class ReconciliationEngine
         }
 
         // Handle desired issues that need new or re-dispatched sessions
-        foreach (var (issueKey, (issue, ruleName)) in desired)
+        foreach (var (issueKey, (issue, issueRuleName)) in desiredIssues)
         {
             if (state.Sessions.TryGetValue(issueKey, out var existing))
             {
@@ -655,7 +655,7 @@ public sealed class ReconciliationEngine
                     SubjectKind = DispatchSubjectKind.Issue,
                     Repo = issue.Repo,
                     IssueNumber = issue.Number,
-                    RuleName = ruleName,
+                    RuleName = issueRuleName,
                     IssueAuthor = issue.Author,
                     SubjectTitle = issue.Title,
                     CopilotSessionId = Guid.NewGuid().ToString(),
@@ -666,20 +666,20 @@ public sealed class ReconciliationEngine
                 };
                 state.Sessions[issueKey] = newSession;
 
-                _logger.LogInformation("New issue {Key} matched by rule '{Rule}', creating pending dispatch", issueKey, ruleName);
+                _logger.LogInformation("New issue {Key} matched by issue rule '{Rule}', creating pending dispatch", issueKey, issueRuleName);
                 TransitionReactionToIssue(newSession, config, GhCliService.ReactionEyes);
             }
         }
 
         // Handle desired pull requests that need new or re-dispatched sessions
-        foreach (var (prKey, (pullRequest, ruleName)) in desiredPullRequests)
+        foreach (var (prKey, (pullRequest, pullRequestRuleName)) in desiredPullRequests)
         {
             if (state.Sessions.TryGetValue(prKey, out var existing))
             {
                 if (existing.SubjectKind != DispatchSubjectKind.PullRequest)
                     continue;
 
-                UpdatePullRequestSessionMetadata(existing, pullRequest, ruleName, config);
+                UpdatePullRequestSessionMetadata(existing, pullRequest, pullRequestRuleName, config);
 
                 switch (existing.Status)
                 {
@@ -752,14 +752,14 @@ public sealed class ReconciliationEngine
                     SubjectKind = DispatchSubjectKind.PullRequest,
                     Repo = pullRequest.Repo,
                     IssueNumber = pullRequest.Number,
-                    RuleName = ruleName,
+                    RuleName = pullRequestRuleName,
                     IssueAuthor = pullRequest.Author,
                     SubjectTitle = pullRequest.Title,
                     PullRequestBaseBranch = pullRequest.BaseBranch,
                     PullRequestHeadBranch = pullRequest.HeadBranch,
                     PullRequestHeadRepo = pullRequest.HeadRepo,
                     PullRequestHeadSha = pullRequest.HeadSha,
-                    PullRequestBranchStrategy = config.PullRequestRules.GetValueOrDefault(ruleName)?.BranchStrategy,
+                    PullRequestBranchStrategy = config.PullRequestRules.GetValueOrDefault(pullRequestRuleName)?.BranchStrategy,
                     CopilotSessionId = Guid.NewGuid().ToString(),
                     HasStarted = false,
                     Status = SessionStatus.Pending,
@@ -768,7 +768,7 @@ public sealed class ReconciliationEngine
                 };
                 state.Sessions[prKey] = newSession;
 
-                _logger.LogInformation("New pull request {Key} matched by rule '{Rule}', creating pending dispatch", prKey, ruleName);
+                _logger.LogInformation("New pull request {Key} matched by PR rule '{Rule}', creating pending dispatch", prKey, pullRequestRuleName);
                 TransitionReactionToIssue(newSession, config, GhCliService.ReactionEyes);
             }
         }
@@ -1000,7 +1000,7 @@ public sealed class ReconciliationEngine
         out CommentTrustLevel effectiveTrustLevel)
     {
         var issueRule = session.SubjectKind == DispatchSubjectKind.Issue
-            ? config.Rules.GetValueOrDefault(session.RuleName)
+            ? config.IssueRules.GetValueOrDefault(session.RuleName)
             : null;
         var pullRequestRule = session.SubjectKind == DispatchSubjectKind.PullRequest
             ? config.PullRequestRules.GetValueOrDefault(session.RuleName)
@@ -1101,10 +1101,14 @@ public sealed class ReconciliationEngine
     /// <summary>
     /// Checks whether reactions are enabled for a session based on rule + global config.
     /// </summary>
-    private static bool AreReactionsEnabled(CopilotdConfig config, string ruleName)
+    private static bool AreReactionsEnabled(CopilotdConfig config, DispatchSession session)
     {
-        if (config.Rules.TryGetValue(ruleName, out var rule) && rule.EnableReactions.HasValue)
-            return rule.EnableReactions.Value;
+        var ruleOptions = session.SubjectKind == DispatchSubjectKind.PullRequest
+            ? (DispatchRuleOptions?)config.PullRequestRules.GetValueOrDefault(session.RuleName)
+            : config.IssueRules.GetValueOrDefault(session.RuleName);
+        if (ruleOptions?.EnableReactions is { } enableReactions)
+            return enableReactions;
+
         return config.EnableReactions;
     }
 
@@ -1132,7 +1136,7 @@ public sealed class ReconciliationEngine
     /// </summary>
     private void TransitionReaction(DispatchSession session, CopilotdConfig config, ReactionAnchor anchor, string? newContent)
     {
-        if (!AreReactionsEnabled(config, session.RuleName))
+        if (!AreReactionsEnabled(config, session))
             return;
 
         if (session.IssueReactionId.HasValue)

--- a/src/copilotd/Services/ReconciliationEngine.cs
+++ b/src/copilotd/Services/ReconciliationEngine.cs
@@ -57,11 +57,12 @@ public sealed class ReconciliationEngine
         // Step 1: Verify all tracked non-terminal sessions against live processes
         VerifyTrackedSessions(state);
 
-        // Step 2: Gather all matching issues from configured rules
+        // Step 2: Gather all matching issues and pull requests from configured rules
         var (desiredDispatches, queriedRepos) = ComputeDesiredDispatches(config);
+        var (desiredPullRequestDispatches, queriedPullRequestRepos) = ComputeDesiredPullRequestDispatches(config);
 
         // Step 3: Reconcile desired vs observed
-        ReconcileDesiredVsObserved(config, state, desiredDispatches, queriedRepos);
+        ReconcileDesiredVsObserved(config, state, desiredDispatches, queriedRepos, desiredPullRequestDispatches, queriedPullRequestRepos);
 
         // Step 4: Dispatch pending sessions (respects MaxInstances)
         DispatchPendingSessions(config, state);
@@ -227,6 +228,49 @@ public sealed class ReconciliationEngine
     }
 
     /// <summary>
+    /// Step 2b: Query GitHub for all pull requests that currently match configured PR rules.
+    /// </summary>
+    private (Dictionary<string, (GitHubPullRequest PullRequest, string RuleName)> Desired, HashSet<string> QueriedRepos)
+        ComputeDesiredPullRequestDispatches(CopilotdConfig config)
+    {
+        var desired = new Dictionary<string, (GitHubPullRequest, string)>(StringComparer.OrdinalIgnoreCase);
+        var queriedRepos = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (ruleName, rule) in config.PullRequestRules)
+        {
+            foreach (var repo in rule.Repos)
+            {
+                try
+                {
+                    var pullRequests = _ghCli.QueryPullRequests(repo, rule);
+                    queriedRepos.Add(repo);
+
+                    foreach (var pullRequest in pullRequests)
+                    {
+                        if (!rule.Matches(pullRequest, _ghCli.HasWriteAccess))
+                            continue;
+
+                        if (!desired.ContainsKey(pullRequest.Key))
+                        {
+                            desired[pullRequest.Key] = (pullRequest, ruleName);
+                            _logger.LogDebug("Desired PR dispatch: {Key} via rule '{Rule}'", pullRequest.Key, ruleName);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Error querying pull requests for {Repo} with rule '{Rule}', preserving existing sessions", repo, ruleName);
+                }
+            }
+        }
+
+        _logger.LogInformation("Found {Count} pull requests matching configured PR rules ({Queried}/{Total} repos queried successfully)",
+            desired.Count, queriedRepos.Count,
+            config.PullRequestRules.Values.SelectMany(r => r.Repos).Distinct(StringComparer.OrdinalIgnoreCase).Count());
+        return (desired, queriedRepos);
+    }
+
+    /// <summary>
     /// Step 3: Compare desired dispatches against tracked sessions.
     /// - Issues without active sessions → create pending
     /// - Tracked sessions whose issues no longer match (and repo was queried) → mark completed
@@ -237,18 +281,28 @@ public sealed class ReconciliationEngine
         CopilotdConfig config,
         DaemonState state,
         Dictionary<string, (GitHubIssue Issue, string RuleName)> desired,
-        HashSet<string> queriedRepos)
+        HashSet<string> queriedRepos,
+        Dictionary<string, (GitHubPullRequest PullRequest, string RuleName)> desiredPullRequests,
+        HashSet<string> queriedPullRequestRepos)
     {
-        // Handle sessions for issues that no longer match — only for successfully queried repos
+        // Handle sessions for subjects that no longer match — only for successfully queried repos
         var toTerminate = new List<DispatchSession>();
         foreach (var (key, session) in state.Sessions)
         {
-            // Clear CompletedBySession flag when the issue no longer matches rules,
-            // so that if the issue re-matches later it will be re-dispatched
+            var desiredContainsSession = session.SubjectKind == DispatchSubjectKind.PullRequest
+                ? desiredPullRequests.ContainsKey(key)
+                : desired.ContainsKey(key);
+            var repoWasQueried = session.SubjectKind == DispatchSubjectKind.PullRequest
+                ? queriedPullRequestRepos.Contains(session.Repo)
+                : queriedRepos.Contains(session.Repo);
+            var subjectLabel = session.SubjectKind == DispatchSubjectKind.PullRequest ? "Pull request" : "Issue";
+
+            // Clear CompletedBySession flag when the subject no longer matches rules,
+            // so that if the subject re-matches later it will be re-dispatched
             if (session.Status == SessionStatus.Completed && session.CompletedBySession
-                && !desired.ContainsKey(key) && queriedRepos.Contains(session.Repo))
+                && !desiredContainsSession && repoWasQueried)
             {
-                _logger.LogInformation("Issue {Key} no longer matches rules, clearing CompletedBySession flag", key);
+                _logger.LogInformation("{Subject} {Key} no longer matches rules, clearing CompletedBySession flag", subjectLabel, key);
                 session.CompletedBySession = false;
                 session.UpdatedAt = DateTimeOffset.UtcNow;
             }
@@ -260,11 +314,11 @@ public sealed class ReconciliationEngine
             if (session.Status is SessionStatus.Joined)
                 continue;
 
-            if (!desired.ContainsKey(key))
+            if (!desiredContainsSession)
             {
                 // Only act if the session's repo was successfully queried.
-                // If the repo query failed, we don't know if the issue still matches.
-                if (!queriedRepos.Contains(session.Repo))
+                // If the repo query failed, we don't know if the subject still matches.
+                if (!repoWasQueried)
                 {
                     _logger.LogDebug("Repo {Repo} query failed, preserving session {Key}", session.Repo, key);
                     continue;
@@ -273,7 +327,7 @@ public sealed class ReconciliationEngine
                 // WaitingForFeedback sessions have no process to terminate
                 if (session.Status is SessionStatus.WaitingForFeedback)
                 {
-                    _logger.LogInformation("Issue {Key} no longer matches rules, completing waiting session", key);
+                    _logger.LogInformation("{Subject} {Key} no longer matches rules, completing waiting session", subjectLabel, key);
                     session.Status = SessionStatus.Completed;
                     session.FailureDetail = null;
                     session.WaitingSince = null;
@@ -286,7 +340,7 @@ public sealed class ReconciliationEngine
                 // WaitingForReview sessions have no process to terminate
                 if (session.Status is SessionStatus.WaitingForReview)
                 {
-                    _logger.LogInformation("Issue {Key} no longer matches rules, completing PR review session", key);
+                    _logger.LogInformation("{Subject} {Key} no longer matches rules, completing PR review session", subjectLabel, key);
                     session.Status = SessionStatus.Completed;
                     session.FailureDetail = null;
                     session.WaitingSince = null;
@@ -296,7 +350,7 @@ public sealed class ReconciliationEngine
                     continue;
                 }
 
-                _logger.LogInformation("Issue {Key} no longer matches rules, terminating session", key);
+                _logger.LogInformation("{Subject} {Key} no longer matches rules, terminating session", subjectLabel, key);
                 toTerminate.Add(session);
             }
         }
@@ -324,6 +378,9 @@ public sealed class ReconciliationEngine
         {
             if (state.Sessions.TryGetValue(issueKey, out var existing))
             {
+                if (existing.SubjectKind != DispatchSubjectKind.Issue)
+                    continue;
+
                 // Backfill IssueAuthor for sessions created before this field existed
                 if (existing.IssueAuthor is null && issue.Author is not null)
                 {
@@ -595,10 +652,12 @@ public sealed class ReconciliationEngine
                 var newSession = new DispatchSession
                 {
                     IssueKey = issueKey,
+                    SubjectKind = DispatchSubjectKind.Issue,
                     Repo = issue.Repo,
                     IssueNumber = issue.Number,
                     RuleName = ruleName,
                     IssueAuthor = issue.Author,
+                    SubjectTitle = issue.Title,
                     CopilotSessionId = Guid.NewGuid().ToString(),
                     HasStarted = false,
                     Status = SessionStatus.Pending,
@@ -611,6 +670,205 @@ public sealed class ReconciliationEngine
                 TransitionReactionToIssue(newSession, config, GhCliService.ReactionEyes);
             }
         }
+
+        // Handle desired pull requests that need new or re-dispatched sessions
+        foreach (var (prKey, (pullRequest, ruleName)) in desiredPullRequests)
+        {
+            if (state.Sessions.TryGetValue(prKey, out var existing))
+            {
+                if (existing.SubjectKind != DispatchSubjectKind.PullRequest)
+                    continue;
+
+                UpdatePullRequestSessionMetadata(existing, pullRequest, ruleName, config);
+
+                switch (existing.Status)
+                {
+                    case SessionStatus.Running:
+                    case SessionStatus.Dispatching:
+                    case SessionStatus.Pending:
+                    case SessionStatus.Joined:
+                        continue;
+
+                    case SessionStatus.WaitingForFeedback:
+                        if (existing.WaitingSince is not null)
+                        {
+                            var feedbackInfo = _ghCli.GetNewPrReviewCommentSince(existing.Repo, existing.SubjectNumber, existing.WaitingSince.Value);
+                            if (feedbackInfo is not null)
+                            {
+                                if (!TryQueueFeedbackRedispatch(existing, prKey, feedbackInfo, config, isIssueComment: false))
+                                    continue;
+                            }
+                            else
+                            {
+                                _logger.LogDebug("PR-root session {Key} still waiting for feedback", prKey);
+                            }
+                        }
+                        continue;
+
+                    case SessionStatus.Orphaned when existing.CanRetry:
+                        _logger.LogInformation("Re-dispatching orphaned PR-root session {Key} (retry {N}/{Max})",
+                            prKey, existing.RetryCount + 1, DispatchSession.MaxRetries);
+                        _processManager.CleanupWorktree(existing, config, state);
+                        ResetForFreshDispatch(existing, preserveReviewPullRequest: true);
+                        existing.RetryCount++;
+                        existing.LastFailureAt = DateTimeOffset.UtcNow;
+                        TransitionReactionOnCurrentAnchor(existing, config, GhCliService.ReactionEyes);
+                        continue;
+
+                    case SessionStatus.Orphaned:
+                    case SessionStatus.Failed:
+                        if (!existing.CanRetry)
+                        {
+                            _logger.LogWarning("PR-root session {Key} exceeded max retries, marking failed", prKey);
+                            existing.Status = SessionStatus.Failed;
+                            existing.FailureDetail ??= $"The session exceeded the maximum retry count ({DispatchSession.MaxRetries}). " +
+                                $"Resolve the underlying issue, then run 'copilotd session reset {prKey}'.";
+                            existing.UpdatedAt = DateTimeOffset.UtcNow;
+                            TransitionReactionOnCurrentAnchor(existing, config, GhCliService.ReactionThumbsDown);
+                        }
+                        continue;
+
+                    case SessionStatus.Completed:
+                        if (existing.CompletedBySession
+                            && string.Equals(existing.PullRequestHeadSha, pullRequest.HeadSha, StringComparison.OrdinalIgnoreCase))
+                        {
+                            _logger.LogDebug("PR-root session {Key} was explicitly completed and head SHA did not change, skipping re-dispatch", prKey);
+                            continue;
+                        }
+
+                        _logger.LogInformation("PR {Key} matched after completion or new head SHA, re-dispatching", prKey);
+                        _processManager.CleanupWorktree(existing, config, state);
+                        ResetForFreshDispatch(existing, preserveReviewPullRequest: true);
+                        existing.PullRequestHeadSha = pullRequest.HeadSha;
+                        TransitionReactionToIssue(existing, config, GhCliService.ReactionEyes);
+                        continue;
+                }
+            }
+            else
+            {
+                var newSession = new DispatchSession
+                {
+                    IssueKey = prKey,
+                    SubjectKind = DispatchSubjectKind.PullRequest,
+                    Repo = pullRequest.Repo,
+                    IssueNumber = pullRequest.Number,
+                    RuleName = ruleName,
+                    IssueAuthor = pullRequest.Author,
+                    SubjectTitle = pullRequest.Title,
+                    PullRequestBaseBranch = pullRequest.BaseBranch,
+                    PullRequestHeadBranch = pullRequest.HeadBranch,
+                    PullRequestHeadRepo = pullRequest.HeadRepo,
+                    PullRequestHeadSha = pullRequest.HeadSha,
+                    PullRequestBranchStrategy = config.PullRequestRules.GetValueOrDefault(ruleName)?.BranchStrategy,
+                    CopilotSessionId = Guid.NewGuid().ToString(),
+                    HasStarted = false,
+                    Status = SessionStatus.Pending,
+                    CreatedAt = DateTimeOffset.UtcNow,
+                    UpdatedAt = DateTimeOffset.UtcNow,
+                };
+                state.Sessions[prKey] = newSession;
+
+                _logger.LogInformation("New pull request {Key} matched by rule '{Rule}', creating pending dispatch", prKey, ruleName);
+                TransitionReactionToIssue(newSession, config, GhCliService.ReactionEyes);
+            }
+        }
+    }
+
+    private void UpdatePullRequestSessionMetadata(
+        DispatchSession session,
+        GitHubPullRequest pullRequest,
+        string ruleName,
+        CopilotdConfig config)
+    {
+        session.RuleName = ruleName;
+        session.SubjectKind = DispatchSubjectKind.PullRequest;
+        session.IssueKey = pullRequest.Key;
+        session.Repo = pullRequest.Repo;
+        session.IssueNumber = pullRequest.Number;
+        session.IssueAuthor = pullRequest.Author;
+        session.SubjectTitle = pullRequest.Title;
+        session.PullRequestBaseBranch = pullRequest.BaseBranch;
+        session.PullRequestHeadBranch = pullRequest.HeadBranch;
+        session.PullRequestHeadRepo = pullRequest.HeadRepo;
+        session.PullRequestBranchStrategy = config.PullRequestRules.GetValueOrDefault(ruleName)?.BranchStrategy;
+
+        if (!string.IsNullOrWhiteSpace(pullRequest.HeadSha)
+            && (session.Status != SessionStatus.Completed || !session.CompletedBySession))
+        {
+            session.PullRequestHeadSha = pullRequest.HeadSha;
+        }
+
+        session.UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    private bool TryQueueFeedbackRedispatch(
+        DispatchSession session,
+        string sessionKey,
+        GhCliService.NewCommentInfo commentInfo,
+        CopilotdConfig config,
+        bool isIssueComment)
+    {
+        if (session.RedispatchCount >= config.MaxRedispatches)
+        {
+            _logger.LogWarning("Session {Key} has reached the maximum re-dispatch limit ({Max}). " +
+                "Use 'copilotd session reset' to re-enable. Ignoring feedback from {Author}",
+                sessionKey, config.MaxRedispatches, commentInfo.Author);
+            return false;
+        }
+
+        var trusted = IsCommentTrusted(session, commentInfo.Author, config, out var trustLevel);
+        if (trusted is null)
+        {
+            _logger.LogWarning("Could not evaluate trust for {Author} on {Key} (trust_level={TrustLevel}), will retry next cycle",
+                commentInfo.Author, sessionKey, trustLevel);
+            return false;
+        }
+
+        if (trusted == false)
+        {
+            _logger.LogInformation("Ignoring feedback from untrusted author {Author} on {Key} (trust_level={TrustLevel})",
+                commentInfo.Author, sessionKey, trustLevel);
+            session.WaitingSince = commentInfo.CreatedAt;
+            session.UpdatedAt = DateTimeOffset.UtcNow;
+            return false;
+        }
+
+        _logger.LogInformation("New feedback from {Author} detected on {Key}, re-dispatching session (redispatch {N}/{Max})",
+            commentInfo.Author, sessionKey, session.RedispatchCount + 1, config.MaxRedispatches);
+        session.Status = SessionStatus.Pending;
+        session.FailureDetail = null;
+        session.RedispatchCount++;
+        session.LastRedispatchWasIssueComment = isIssueComment;
+        session.WaitingSince = null;
+        session.ProcessId = null;
+        session.ProcessStartTime = null;
+        session.UpdatedAt = DateTimeOffset.UtcNow;
+
+        if (isIssueComment && commentInfo.IssueCommentId.HasValue)
+            TransitionReactionToIssueComment(session, config, commentInfo.IssueCommentId.Value, GhCliService.ReactionEyes);
+        else
+            TransitionReactionOnCurrentAnchor(session, config, GhCliService.ReactionEyes);
+
+        return true;
+    }
+
+    private static void ResetForFreshDispatch(DispatchSession session, bool preserveReviewPullRequest)
+    {
+        session.Status = SessionStatus.Pending;
+        session.FailureDetail = null;
+        session.CompletedBySession = false;
+        if (!preserveReviewPullRequest)
+            session.PullRequestNumber = null;
+        session.RedispatchCount = 0;
+        session.LastRedispatchWasIssueComment = false;
+        session.CopilotSessionId = Guid.NewGuid().ToString();
+        session.CopilotSessionName = null;
+        session.HasStarted = false;
+        session.ProcessId = null;
+        session.ProcessStartTime = null;
+        session.LastVerifiedAt = null;
+        session.WaitingSince = null;
+        session.UpdatedAt = DateTimeOffset.UtcNow;
     }
 
     /// <summary>
@@ -679,19 +937,20 @@ public sealed class ReconciliationEngine
                 continue;
             }
 
-            // For newly created worktrees, create the linked branch on GitHub first
+            // For newly created issue worktrees, create the linked branch on GitHub first
             // (that mutation creates the remote branch), then push locally to set
-            // upstream tracking. Both operations are best-effort.
+            // upstream tracking. PR worktrees are pushed according to their branch strategy.
             if (worktreeResult == WorktreeResult.CreatedNew && !string.IsNullOrEmpty(session.BranchName))
             {
-                var sha = _processManager.GetHeadSha(session);
-                if (sha is not null)
+                if (session.SubjectKind == DispatchSubjectKind.Issue)
                 {
-                    _ghCli.CreateLinkedBranchForIssue(session.Repo, session.IssueNumber, session.BranchName, sha);
+                    var sha = _processManager.GetHeadSha(session);
+                    if (sha is not null)
+                    {
+                        _ghCli.CreateLinkedBranchForIssue(session.Repo, session.IssueNumber, session.BranchName, sha);
+                    }
                 }
 
-                // Push the branch to the remote and set up tracking. If the linked branch
-                // was created successfully above, this becomes a no-op push plus upstream setup.
                 _processManager.PushBranch(session, config, state);
             }
 
@@ -740,8 +999,14 @@ public sealed class ReconciliationEngine
         CopilotdConfig config,
         out CommentTrustLevel effectiveTrustLevel)
     {
-        var rule = config.Rules.GetValueOrDefault(session.RuleName);
-        effectiveTrustLevel = rule?.TrustLevel ?? CommentTrustLevel.Collaborators;
+        var issueRule = session.SubjectKind == DispatchSubjectKind.Issue
+            ? config.Rules.GetValueOrDefault(session.RuleName)
+            : null;
+        var pullRequestRule = session.SubjectKind == DispatchSubjectKind.PullRequest
+            ? config.PullRequestRules.GetValueOrDefault(session.RuleName)
+            : null;
+        var ruleOptions = (DispatchRuleOptions?)issueRule ?? pullRequestRule;
+        effectiveTrustLevel = ruleOptions?.TrustLevel ?? CommentTrustLevel.Collaborators;
 
         switch (effectiveTrustLevel)
         {
@@ -752,30 +1017,39 @@ public sealed class ReconciliationEngine
                 return _ghCli.HasWriteAccess(session.Repo, commentAuthor);
 
             case CommentTrustLevel.IssueAuthor:
-                return session.IssueAuthor is not null
-                    && string.Equals(session.IssueAuthor, commentAuthor, StringComparison.OrdinalIgnoreCase);
+                return session.SubjectAuthor is not null
+                    && string.Equals(session.SubjectAuthor, commentAuthor, StringComparison.OrdinalIgnoreCase);
 
             case CommentTrustLevel.Assignees:
-                var assignees = _ghCli.GetIssueAssignees(session.Repo, session.IssueNumber);
+                if (session.SubjectKind == DispatchSubjectKind.PullRequest)
+                    return _ghCli.HasWriteAccess(session.Repo, commentAuthor);
+
+                var assignees = _ghCli.GetIssueAssignees(session.Repo, session.SubjectNumber);
                 if (assignees is null)
                     return null; // API failure — retry next cycle
                 return assignees.Exists(a => string.Equals(a, commentAuthor, StringComparison.OrdinalIgnoreCase));
 
             case CommentTrustLevel.IssueAuthorAndCollaborators:
-                if (session.IssueAuthor is not null
-                    && string.Equals(session.IssueAuthor, commentAuthor, StringComparison.OrdinalIgnoreCase))
+                if (session.SubjectAuthor is not null
+                    && string.Equals(session.SubjectAuthor, commentAuthor, StringComparison.OrdinalIgnoreCase))
                     return true;
                 return _ghCli.HasWriteAccess(session.Repo, commentAuthor);
 
             case CommentTrustLevel.MatchDispatchRule:
-                if (rule is null)
+                if (issueRule is null && pullRequestRule is null)
                     return _ghCli.HasWriteAccess(session.Repo, commentAuthor);
-                return rule.AuthorMode switch
+                var authorMode = session.SubjectKind == DispatchSubjectKind.PullRequest
+                    ? pullRequestRule!.AuthorMode
+                    : issueRule!.AuthorMode;
+                var authors = session.SubjectKind == DispatchSubjectKind.PullRequest
+                    ? pullRequestRule!.Authors
+                    : issueRule!.Authors;
+                return authorMode switch
                 {
                     // AuthorMode.Any means "no author filtering on dispatch" — but for re-dispatch
                     // trust, allowing anyone would be a security risk. Fall back to collaborators.
                     AuthorMode.Any => _ghCli.HasWriteAccess(session.Repo, commentAuthor),
-                    AuthorMode.Allowed => rule.Authors.Contains(commentAuthor, StringComparer.OrdinalIgnoreCase),
+                    AuthorMode.Allowed => authors.Contains(commentAuthor, StringComparer.OrdinalIgnoreCase),
                     AuthorMode.WriteAccess => _ghCli.HasWriteAccess(session.Repo, commentAuthor),
                     _ => _ghCli.HasWriteAccess(session.Repo, commentAuthor),
                 };

--- a/src/copilotd/Services/ReconciliationEngine.cs
+++ b/src/copilotd/Services/ReconciliationEngine.cs
@@ -308,7 +308,16 @@ public sealed class ReconciliationEngine
             }
 
             if (session.IsTerminal)
+            {
+                if (!desiredContainsSession && repoWasQueried
+                    && (!string.IsNullOrEmpty(session.WorktreePath) || !string.IsNullOrEmpty(session.BranchName)))
+                {
+                    _logger.LogInformation("{Subject} {Key} no longer matches issue/PR rules, cleaning up terminal session worktree", subjectLabel, key);
+                    _processManager.CleanupWorktree(session, config, state);
+                    session.UpdatedAt = DateTimeOffset.UtcNow;
+                }
                 continue;
+            }
 
             // Never terminate user-controlled sessions
             if (session.Status is SessionStatus.Joined)


### PR DESCRIPTION
## Summary
- add first-class pull request dispatch rules alongside existing issue rules, with PR-specific filters and no default PR rule
- add subject-aware session state while preserving legacy issueKey/issueNumber/issueAuthor/pullRequestNumber JSON compatibility
- add PR worktree branch strategies, PR prompt tokens, PR feedback detection, and separate issue/PR rule display/docs
- clean up terminal PR-root worktrees after closed or otherwise unmatched PRs fall out of configured dispatch rules
- add a copilotd E2E verification skill documenting the live issue/PR orchestration workflow used to validate this change

Fixes #55

## Validation
- dotnet build .\\src\\copilotd\\copilotd.csproj -nologo
- git diff --check
- isolated config/state CLI checks for issue and PR rule add/list/update/delete
- isolated daemon reconciliation checks for PR dispatch and issue dispatch
- isolated startup reconciliation smoke for terminal PR-root worktree cleanup
- PR checks: validate-powershell-scripts, validate-shell-scripts, publish-aot matrix
