### PR TITLE
Handle missing Copilot trustedFolders config

### DIFF
--- a/src/copilotd/Infrastructure/CopilotTrustService.cs
+++ b/src/copilotd/Infrastructure/CopilotTrustService.cs
@@ -229,7 +229,13 @@ public sealed class CopilotTrustService
                 };
             }
 
-            if (root["trustedFolders"] is not JsonArray trustedFoldersNode)
+            if (!root.TryGetPropertyValue("trustedFolders", out var trustedFoldersNode))
+            {
+                trustedFoldersNode = new JsonArray();
+                root["trustedFolders"] = trustedFoldersNode;
+            }
+
+            if (trustedFoldersNode is not JsonArray trustedFoldersArray)
             {
                 return new ConfigReadResult
                 {
@@ -239,7 +245,7 @@ public sealed class CopilotTrustService
             }
 
             var trustedFolders = new List<string>();
-            foreach (var item in trustedFoldersNode)
+            foreach (var item in trustedFoldersArray)
             {
                 if (item is not JsonValue jsonValue)
                 {


### PR DESCRIPTION
## Summary
- Treat a missing Copilot trustedFolders config property as an empty array
- Preserve validation for malformed non-array trustedFolders values
- Allow copilotd to add trust entries when Copilot CLI has not created the node yet

Fixes #190

## Validation
- dotnet build .\src\copilotd\copilotd.csproj -nologo