### PR TITLE
Document PowerShell $home footgun

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,6 +32,10 @@ State converges through this loop — every inconsistency (crashed process, stal
 
 ## Key Conventions
 
+### PowerShell Safety
+
+PowerShell variable names are case-insensitive, so `$home` resolves to the built-in read-only `$HOME` variable. Never use `$home` as a scratch or target variable name in scripts. Use specific names such as `$userProfile`, `$homeDir`, `$copilotHomePath`, or `$targetRoot` instead, especially before destructive operations like `Remove-Item -Recurse`.
+
 ### System.CommandLine v2.0.5 API
 
 This version has non-obvious differences from older/newer versions:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,7 +34,7 @@ State converges through this loop — every inconsistency (crashed process, stal
 
 ### PowerShell Safety
 
-PowerShell variable names are case-insensitive, so `$home` resolves to the built-in read-only `$HOME` variable. Never use `$home` as a scratch or target variable name in scripts. Use specific names such as `$userProfile`, `$homeDir`, `$copilotHomePath`, or `$targetRoot` instead, especially before destructive operations like `Remove-Item -Recurse`.
+PowerShell variable names are case-insensitive, so `$home` resolves to the built-in read-only `$HOME` variable. Never use `$home` as a scratch or target variable name in scripts. Use specific names relative to the context at hand instead, especially before destructive operations like `Remove-Item -Recurse`.
 
 ### System.CommandLine v2.0.5 API
 


### PR DESCRIPTION
## Summary

- Add a copilot-instructions warning that PowerShell variable names are case-insensitive
- Call out that $home resolves to the built-in $HOME variable and must not be used as a scratch path
- Suggest safer variable names before destructive operations such as Remove-Item -Recurse

## Testing

- Not run (documentation-only change)

Related https://github.com/github/copilot-cli/issues/3098