### PR TITLE
Use Copilot CLI hooks to enhance session coordination

### DIFF
--- a/src/copilotd/Commands/SessionCommand.cs
+++ b/src/copilotd/Commands/SessionCommand.cs
@@ -2,6 +2,8 @@ using System.CommandLine;
 using System.CommandLine.Help;
 using System.CommandLine.Parsing;
 using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
 using Copilotd.Infrastructure;
 using Copilotd.Models;
 using Copilotd.Services;
@@ -27,6 +29,7 @@ public static class SessionCommand
         command.Subcommands.Add(CreateConnectCommand(services));
         command.Subcommands.Add(CreateCommentCommand(services));
         command.Subcommands.Add(CreateCompleteCommand(services));
+        command.Subcommands.Add(CreateEventCommand(services));
         command.Subcommands.Add(CreatePrCommand(services));
         command.Subcommands.Add(CreateResetCommand(services));
 
@@ -64,6 +67,218 @@ public static class SessionCommand
         });
 
         return command;
+    }
+
+    // ---- event subcommand ----
+
+    private static Command CreateEventCommand(IServiceProvider services)
+    {
+        var command = new Command("event", "Internal hook callback for dispatched copilot sessions")
+        {
+            Hidden = true,
+        };
+
+        var eventArg = new Argument<string>("event") { Description = "Hook event type" };
+        command.Arguments.Add(eventArg);
+
+        var issueArg = new Argument<string>("issue") { Description = "Issue key (e.g., owner/repo#123)" };
+        command.Arguments.Add(issueArg);
+
+        var sessionIdOption = new Option<string?>("--session-id")
+        {
+            Description = "Expected copilotd session ID",
+        };
+        command.Options.Add(sessionIdOption);
+
+        command.SetAction(async (ParseResult parseResult, CancellationToken ct) =>
+        {
+            var logger = services.GetRequiredService<ILogger<Program>>();
+            try
+            {
+                var stateStore = services.GetRequiredService<StateStore>();
+                var runtimeContext = services.GetRequiredService<RuntimeContext>();
+                var eventName = parseResult.GetValue(eventArg)!;
+                var issueKey = parseResult.GetValue(issueArg)!;
+                var expectedSessionId = parseResult.GetValue(sessionIdOption);
+                var payload = Console.IsInputRedirected
+                    ? await Console.In.ReadToEndAsync(ct)
+                    : "";
+
+                return HandleSessionEvent(stateStore, runtimeContext.GetCopilotdCallbackCommand(), eventName, issueKey, expectedSessionId, payload, ct);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Session hook event callback failed");
+                if (string.Equals(parseResult.GetValue(eventArg), "agent-stop", StringComparison.OrdinalIgnoreCase))
+                    WriteAgentStopAllow();
+                return 0;
+            }
+        });
+
+        return command;
+    }
+
+    private static int HandleSessionEvent(
+        StateStore stateStore,
+        string copilotdCommand,
+        string eventName,
+        string issueKey,
+        string? expectedSessionId,
+        string payload,
+        CancellationToken ct)
+    {
+        var normalizedEvent = NormalizeHookEventName(eventName);
+        var detail = ExtractHookDetail(normalizedEvent, payload);
+        var decision = AgentStopDecision.Allow;
+
+        stateStore.WithStateLock(() =>
+        {
+            var state = stateStore.LoadState();
+            if (!state.Sessions.TryGetValue(issueKey, out var session))
+                return;
+
+            if (!string.IsNullOrWhiteSpace(expectedSessionId)
+                && !string.Equals(session.CopilotSessionId, expectedSessionId, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            session.LastHookEvent = normalizedEvent;
+            session.LastHookEventAt = DateTimeOffset.UtcNow;
+            session.LastHookDetail = detail;
+            session.UpdatedAt = DateTimeOffset.UtcNow;
+
+            if (normalizedEvent == "agent-stop"
+                && session.Status is SessionStatus.Running or SessionStatus.Dispatching)
+            {
+                decision = AgentStopDecision.Block;
+            }
+            else if (normalizedEvent == "session-end"
+                     && session.Status is SessionStatus.Running or SessionStatus.Dispatching)
+            {
+                var reason = ExtractString(payload, "reason") ?? "unknown";
+                session.Status = SessionStatus.Orphaned;
+                session.FailureDetail = $"Copilot hook reported sessionEnd reason '{reason}' before the session reached a completed or waiting state.";
+                session.LastFailureAt = DateTimeOffset.UtcNow;
+                ClearTrackedProcess(session);
+            }
+
+            stateStore.SaveState(state);
+        }, ct);
+
+        if (normalizedEvent == "agent-stop")
+        {
+            if (decision == AgentStopDecision.Block)
+                WriteAgentStopBlock(issueKey, copilotdCommand);
+            else
+                WriteAgentStopAllow();
+        }
+
+        return 0;
+    }
+
+    private static string NormalizeHookEventName(string eventName)
+        => eventName.Trim().ToLowerInvariant() switch
+        {
+            "agentstop" or "agent-stop" or "stop" => "agent-stop",
+            "sessionend" or "session-end" => "session-end",
+            "erroroccurred" or "error-occurred" => "error-occurred",
+            _ => eventName.Trim(),
+        };
+
+    private static string? ExtractHookDetail(string normalizedEvent, string payload)
+        => normalizedEvent switch
+        {
+            "session-end" => ExtractString(payload, "reason") is { } reason ? $"reason={reason}" : null,
+            "error-occurred" => ExtractErrorDetail(payload),
+            "agent-stop" => ExtractString(payload, "stopReason") is { } reason
+                ? $"stopReason={reason}"
+                : ExtractString(payload, "stop_reason") is { } snakeReason
+                    ? $"stopReason={snakeReason}"
+                    : null,
+            _ => null,
+        };
+
+    private static string? ExtractErrorDetail(string payload)
+    {
+        if (string.IsNullOrWhiteSpace(payload))
+            return null;
+
+        try
+        {
+            using var document = JsonDocument.Parse(payload);
+            if (!document.RootElement.TryGetProperty("error", out var error))
+                return null;
+
+            var name = error.TryGetProperty("name", out var nameElement)
+                ? nameElement.GetString()
+                : null;
+            var message = error.TryGetProperty("message", out var messageElement)
+                ? messageElement.GetString()
+                : null;
+
+            return string.IsNullOrWhiteSpace(name)
+                ? message
+                : string.IsNullOrWhiteSpace(message)
+                    ? name
+                    : $"{name}: {message}";
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string? ExtractString(string payload, string propertyName)
+    {
+        if (string.IsNullOrWhiteSpace(payload))
+            return null;
+
+        try
+        {
+            using var document = JsonDocument.Parse(payload);
+            return document.RootElement.TryGetProperty(propertyName, out var value)
+                ? value.GetString()
+                : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static void WriteAgentStopBlock(string issueKey, string copilotdCommand)
+    {
+        var reason = $"""
+            copilotd is still tracking {issueKey} as an active session. Before ending this turn, run one of the copilotd lifecycle commands and verify it succeeds:
+            - `{copilotdCommand} session complete {issueKey}` when all requested work is finished
+            - `{copilotdCommand} session pr <pr-number> {issueKey}` after opening or updating a pull request that should be monitored for review feedback
+            - `{copilotdCommand} session comment {issueKey} --message "..."` when you need clarification or feedback before continuing
+
+            Do not stop until the session has transitioned to completed, waiting for feedback, or waiting for review.
+            """;
+
+        Console.WriteLine($$"""{"decision":"block","reason":{{ToJsonStringLiteral(reason)}}}""");
+    }
+
+    private static void WriteAgentStopAllow()
+        => Console.WriteLine("""{"decision":"allow"}""");
+
+    private static string ToJsonStringLiteral(string value)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStringValue(value);
+        }
+
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private enum AgentStopDecision
+    {
+        Allow,
+        Block,
     }
 
     // ---- list subcommand ----
@@ -979,6 +1194,9 @@ public static class SessionCommand
         table.AddRow("Repo path", Markup.Escape(NormalizeDisplayPath(repoPath) ?? "-"));
         table.AddRow("Worktree path", Markup.Escape(NormalizeDisplayPath(session.WorktreePath) ?? "-"));
         table.AddRow("Branch", Markup.Escape(session.BranchName ?? "-"));
+        table.AddRow("Last hook event", Markup.Escape(session.LastHookEvent ?? "-"));
+        table.AddRow("Last hook event at", Markup.Escape(FormatOptionalTime(session.LastHookEventAt)));
+        table.AddRow("Last hook detail", Markup.Escape(session.LastHookDetail ?? "-"));
         table.AddRow("Failure detail", Markup.Escape(session.FailureDetail ?? "(none)"));
 
         AnsiConsole.Write(table);
@@ -1074,6 +1292,9 @@ public static class SessionCommand
             LastRedispatchWasIssueComment = session.LastRedispatchWasIssueComment,
             WorktreePath = session.WorktreePath,
             BranchName = session.BranchName,
+            LastHookEvent = session.LastHookEvent,
+            LastHookEventAt = session.LastHookEventAt,
+            LastHookDetail = session.LastHookDetail,
             IssueReactionId = session.IssueReactionId,
             ReactionTargetType = session.ReactionTargetType,
             ReactionTargetCommentId = session.ReactionTargetCommentId,

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Text.Json;
 using Copilotd.Commands;
 using Copilotd.Models;
 using Copilotd.Services;
@@ -20,6 +21,7 @@ public sealed partial class ProcessManager
     private static readonly TimeSpan WindowsCopilotChildDiscoveryTimeout = TimeSpan.FromSeconds(3);
     private static readonly TimeSpan WindowsCopilotChildDiscoveryPollInterval = TimeSpan.FromMilliseconds(100);
     private static readonly NuGetVersion MinimumNamedSessionVersion = new(1, 0, 35);
+    private const string HookConfigRelativePath = ".github/hooks/copilotd.hooks.json";
 
     private readonly StateStore _stateStore;
     private readonly RepoPathResolver _repoResolver;
@@ -1160,11 +1162,21 @@ public sealed partial class ProcessManager
         // If the session already has a worktree (PR review re-dispatch), refresh it
         if (!string.IsNullOrEmpty(session.WorktreePath) && Directory.Exists(session.WorktreePath))
         {
-            return RefreshWorktree(session) ? WorktreeResult.Refreshed : WorktreeResult.Failed;
+            if (!RefreshWorktree(session))
+                return WorktreeResult.Failed;
+
+            InstallSessionHooks(session);
+            return WorktreeResult.Refreshed;
         }
 
         if (session.SubjectKind == DispatchSubjectKind.PullRequest)
-            return PreparePullRequestWorktree(session, config, state);
+        {
+            var result = PreparePullRequestWorktree(session, config, state);
+            if (result != WorktreeResult.Failed)
+                InstallSessionHooks(session);
+
+            return result;
+        }
 
         var mainRepoPath = _repoResolver.ResolveRepoPath(session.Repo, config, state);
         if (mainRepoPath is null || !Directory.Exists(mainRepoPath))
@@ -1239,7 +1251,177 @@ public sealed partial class ProcessManager
 
         session.WorktreePath = worktreePath;
         _logger.LogInformation("Worktree ready for {Key} at {Path}", session.IssueKey, worktreePath);
+        InstallSessionHooks(session);
         return WorktreeResult.CreatedNew;
+    }
+
+    private bool InstallSessionHooks(DispatchSession session)
+    {
+        if (string.IsNullOrWhiteSpace(session.WorktreePath))
+        {
+            _logger.LogWarning("Cannot install Copilot hooks for {Key}: session has no worktree path", session.SubjectKey);
+            return false;
+        }
+
+        try
+        {
+            var hooksDir = Path.Combine(session.WorktreePath, ".github", "hooks");
+            Directory.CreateDirectory(hooksDir);
+
+            var hookConfigPath = Path.Combine(session.WorktreePath, HookConfigRelativePath);
+            WriteHookConfig(hookConfigPath, session);
+            AddWorktreeExclude(session.WorktreePath, HookConfigRelativePath);
+
+            _logger.LogDebug("Installed Copilot hook config for {Key} at {Path}", session.SubjectKey, hookConfigPath);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to install Copilot hooks for {Key}", session.SubjectKey);
+            return false;
+        }
+    }
+
+    private void WriteHookConfig(string hookConfigPath, DispatchSession session)
+    {
+        using var stream = File.Create(hookConfigPath);
+        using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true });
+
+        writer.WriteStartObject();
+        writer.WriteNumber("version", 1);
+        writer.WritePropertyName("hooks");
+        writer.WriteStartObject();
+
+        WriteHookCommand(writer, "agentStop", session, "agent-stop");
+        WriteHookCommand(writer, "sessionEnd", session, "session-end");
+        WriteHookCommand(writer, "errorOccurred", session, "error-occurred");
+
+        writer.WriteEndObject();
+        writer.WriteEndObject();
+    }
+
+    private void WriteHookCommand(Utf8JsonWriter writer, string hookName, DispatchSession session, string eventName)
+    {
+        writer.WritePropertyName(hookName);
+        writer.WriteStartArray();
+        writer.WriteStartObject();
+        writer.WriteString("type", "command");
+        writer.WriteString("bash", BuildSessionEventHookCommand(session, eventName, HookShell.Bash));
+        writer.WriteString("powershell", BuildSessionEventHookCommand(session, eventName, HookShell.PowerShell));
+        writer.WriteString("cwd", ".");
+        writer.WriteNumber("timeoutSec", 30);
+        writer.WriteEndObject();
+        writer.WriteEndArray();
+    }
+
+    private string BuildSessionEventHookCommand(DispatchSession session, string eventName, HookShell shell)
+    {
+        var parts = new List<string>();
+        if (shell == HookShell.PowerShell)
+            parts.Add("&");
+
+        if (_runtimeContext.IsDotnetHosted && !string.IsNullOrWhiteSpace(_runtimeContext.SourceProjectPath))
+        {
+            parts.Add(ShellQuote(_runtimeContext.ProcessPath ?? "dotnet", shell));
+            parts.Add("run");
+            parts.Add("--project");
+            parts.Add(ShellQuote(_runtimeContext.SourceProjectPath, shell));
+            parts.Add("--no-build");
+            parts.Add("--");
+        }
+        else
+        {
+            parts.Add(ShellQuote(_runtimeContext.ProcessPath ?? "copilotd", shell));
+        }
+
+        parts.Add("session");
+        parts.Add("event");
+        parts.Add(eventName);
+        parts.Add(ShellQuote(session.SubjectKey, shell));
+        parts.Add("--session-id");
+        parts.Add(ShellQuote(session.CopilotSessionId, shell));
+
+        return string.Join(' ', parts);
+    }
+
+    private static string ShellQuote(string value, HookShell shell)
+        => shell == HookShell.PowerShell
+            ? $"'{value.Replace("'", "''", StringComparison.Ordinal)}'"
+            : $"'{value.Replace("'", "'\\''", StringComparison.Ordinal)}'";
+
+    private void AddWorktreeExclude(string worktreePath, string relativePath)
+    {
+        var excludePath = GetGitPath(worktreePath, "info/exclude");
+        if (excludePath is null)
+        {
+            _logger.LogWarning("Could not resolve git exclude path for worktree {Path}", worktreePath);
+            return;
+        }
+
+        Directory.CreateDirectory(Path.GetDirectoryName(excludePath)!);
+        var normalizedRelativePath = relativePath.Replace(Path.DirectorySeparatorChar, '/');
+        var existingLines = File.Exists(excludePath)
+            ? File.ReadAllLines(excludePath)
+            : [];
+
+        if (existingLines.Any(line => string.Equals(line.Trim(), normalizedRelativePath, StringComparison.Ordinal)))
+            return;
+
+        File.AppendAllText(excludePath, $"{Environment.NewLine}{normalizedRelativePath}{Environment.NewLine}");
+    }
+
+    private string? GetGitPath(string workingDir, string gitPath)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "git",
+                Arguments = $"rev-parse --git-path \"{gitPath}\"",
+                WorkingDirectory = workingDir,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+            };
+
+            using var process = Process.Start(psi);
+            if (process is null)
+                return null;
+
+            var stdoutTask = process.StandardOutput.ReadToEndAsync();
+            var stderrTask = process.StandardError.ReadToEndAsync();
+            if (!process.WaitForExit(TimeSpan.FromSeconds(10)))
+            {
+                try { process.Kill(); } catch { }
+                return null;
+            }
+
+            var output = stdoutTask.GetAwaiter().GetResult().Trim();
+            var stderr = stderrTask.GetAwaiter().GetResult();
+
+            if (process.ExitCode != 0 || string.IsNullOrWhiteSpace(output))
+            {
+                if (!string.IsNullOrWhiteSpace(stderr))
+                    _logger.LogDebug("git rev-parse --git-path {GitPath} failed: {StdErr}", gitPath, stderr.Trim());
+                return null;
+            }
+
+            return Path.IsPathRooted(output)
+                ? output
+                : Path.GetFullPath(Path.Combine(workingDir, output));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to resolve git path {GitPath} in {WorkingDir}", gitPath, workingDir);
+            return null;
+        }
+    }
+
+    private enum HookShell
+    {
+        Bash,
+        PowerShell,
     }
 
     private WorktreeResult PreparePullRequestWorktree(DispatchSession session, CopilotdConfig config, DaemonState state)

--- a/src/copilotd/Models/SessionState.cs
+++ b/src/copilotd/Models/SessionState.cs
@@ -290,6 +290,15 @@ public sealed class DispatchSession
     /// </summary>
     public string? BranchName { get; set; }
 
+    /// <summary>The last Copilot hook event reported for this session.</summary>
+    public string? LastHookEvent { get; set; }
+
+    /// <summary>When the last Copilot hook event was reported.</summary>
+    public DateTimeOffset? LastHookEventAt { get; set; }
+
+    /// <summary>Short diagnostic detail from the last Copilot hook event.</summary>
+    public string? LastHookDetail { get; set; }
+
     /// <summary>
     /// The GitHub reaction ID currently posted by copilotd for lifecycle tracking.
     /// Kept under its legacy name for persisted-state compatibility.


### PR DESCRIPTION
## Summary
- Inject a copilotd-owned .github/hooks/copilotd.hooks.json into each session worktree and exclude it from git
- Add hidden \copilotd session event\ callbacks for agentStop, sessionEnd, and errorOccurred hook events
- Block agentStop when copilotd still tracks the session as active, and mark active sessionEnd events as orphaned for reconciliation
- Surface last hook event diagnostics in session info

Closes #162

## Verification
- dotnet build .\\src\\copilotd\\copilotd.csproj -nologo
- git --no-pager diff --check
- Manual COPILOTD_HOME hook callback exercise for agent-stop and session-end