### PR TITLE
Launch control session from copilotd home

### DIFF
--- a/src/copilotd/Commands/ConfigCommand.cs
+++ b/src/copilotd/Commands/ConfigCommand.cs
@@ -176,6 +176,20 @@ public static class ConfigCommand
                         if (TryParseBoolean(value, out var enableControlSession))
                         {
                             cfg.EnableControlSession = enableControlSession;
+                            if (cfg.EnableControlSession)
+                            {
+                                CopilotTrustCommandHelper.EnsureTrustedFoldersForRepositories(
+                                    copilotTrust,
+                                    repoResolver,
+                                    copilotCli,
+                                    cfg,
+                                    stateStore.LoadState(),
+                                    cfg.IssueRules.Values.Cast<DispatchRuleOptions>()
+                                        .Concat(cfg.PullRequestRules.Values)
+                                        .SelectMany(dispatchRule => dispatchRule.Repos)
+                                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                                        .ToList());
+                            }
                             ConsoleOutput.Success($"enable_control_session set to: {cfg.EnableControlSession.ToString().ToLowerInvariant()}");
                         }
                         else

--- a/src/copilotd/Commands/CopilotTrustCommandHelper.cs
+++ b/src/copilotd/Commands/CopilotTrustCommandHelper.cs
@@ -14,11 +14,28 @@ internal static class CopilotTrustCommandHelper
         Copilotd.Models.DaemonState state,
         IEnumerable<string> repoSlugs)
     {
-        var requiredFolders = repoSlugs
+        var requiredFolders = new List<string>();
+        if (config.EnableControlSession)
+        {
+            var controlSessionDirectory = CopilotdPaths.GetControlSessionDirectory();
+            try
+            {
+                Directory.CreateDirectory(controlSessionDirectory);
+                requiredFolders.AddRange(trustService.GetRequiredTrustedFoldersForControlSession());
+            }
+            catch (Exception ex)
+            {
+                ConsoleOutput.Warning($"Could not create control session folder '{controlSessionDirectory}': {ex.Message}");
+            }
+        }
+
+        requiredFolders.AddRange(repoSlugs
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .Select(repoSlug => repoResolver.ResolveRepoPath(repoSlug, config, state))
             .Where(path => !string.IsNullOrWhiteSpace(path) && Directory.Exists(path))
-            .SelectMany(path => trustService.GetRequiredTrustedFolders(path!))
+            .SelectMany(path => trustService.GetRequiredTrustedFolders(path!)));
+
+        requiredFolders = requiredFolders
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
             .ToList();
@@ -47,12 +64,12 @@ internal static class CopilotTrustCommandHelper
         CopilotCliService copilotCli,
         CopilotTrustCheckResult trustCheck)
     {
-        ConsoleOutput.Warning("Copilot needs these folders trusted before copilotd can dispatch sessions reliably:");
+        ConsoleOutput.Warning("Copilot needs these folders trusted before copilotd can launch sessions reliably:");
         RenderFolderList(trustCheck.MissingFolders);
 
         if (!AnsiConsole.Confirm("Add the missing folders to Copilot trustedFolders now?", true))
         {
-            ConsoleOutput.Warning("copilotd will keep monitoring these repositories, but dispatched sessions may fail until these folders are trusted.");
+            ConsoleOutput.Warning("copilotd will keep monitoring configured repositories, but sessions may fail until these folders are trusted.");
             RenderManualTrustInstructions(trustCheck.MissingFolders, copilotCli, includeIssueReportGuidance: false);
             return;
         }

--- a/src/copilotd/Commands/RunCommand.cs
+++ b/src/copilotd/Commands/RunCommand.cs
@@ -42,9 +42,11 @@ public static class RunCommand
                 var runtimeContext = services.GetRequiredService<RuntimeContext>();
                 var logFileManager = services.GetRequiredService<LogFileManager>();
                 var remoteSessionUrls = services.GetRequiredService<GitHubRemoteSessionUrlResolver>();
+                var copilotTrust = services.GetRequiredService<CopilotTrustService>();
 
                 var interval = parseResult.GetValue(intervalOption);
                 var disableSelfUpdates = runtimeContext.IsAutomaticSelfUpdateDisabled(parseResult.GetValue(disableSelfUpdatesOption));
+                var controlSessionTrustWarningShown = false;
 
                 // Pre-flight checks
                 var preflightResult = PreflightChecks.Run(ghCli, copilotCli, stateStore);
@@ -145,6 +147,20 @@ public static class RunCommand
 
                             if (state.ControlSession?.ProcessId is not null)
                                 processManager.TerminateControlSession(state.ControlSession);
+
+                            var trustDecision = CheckControlSessionTrust(copilotTrust, logger, controlSessionTrustWarningShown);
+                            controlSessionTrustWarningShown = trustDecision.WarningShown;
+                            if (!trustDecision.CanLaunch)
+                            {
+                                state.ControlSession = new ControlSessionInfo
+                                {
+                                    Status = ControlSessionStatus.Failed,
+                                    UpdatedAt = DateTimeOffset.UtcNow,
+                                };
+                                launchFailed = true;
+                                stateStore.SaveState(state);
+                                return;
+                            }
 
                             var controlSession = processManager.LaunchControlSession(config, machineIdentifier);
                             if (controlSession is not null)
@@ -255,6 +271,23 @@ public static class RunCommand
                                                 }
 
                                                 processManager.TerminateControlSession(state.ControlSession);
+                                            }
+
+                                            var trustDecision = CheckControlSessionTrust(copilotTrust, logger, controlSessionTrustWarningShown);
+                                            controlSessionTrustWarningShown = trustDecision.WarningShown;
+                                            if (!trustDecision.CanLaunch)
+                                            {
+                                                if (state.ControlSession?.Status != ControlSessionStatus.Failed)
+                                                {
+                                                    state.ControlSession = new ControlSessionInfo
+                                                    {
+                                                        Status = ControlSessionStatus.Failed,
+                                                        UpdatedAt = DateTimeOffset.UtcNow,
+                                                    };
+                                                    stateStore.SaveState(state);
+                                                }
+
+                                                return;
                                             }
 
                                             logger.LogInformation("Relaunching control session...");
@@ -385,6 +418,39 @@ public static class RunCommand
 
         ConsoleOutput.Info("Remote:");
         ConsoleOutput.Info($"  {url ?? "unavailable"}");
+    }
+
+    private static (bool CanLaunch, bool WarningShown) CheckControlSessionTrust(
+        CopilotTrustService copilotTrust,
+        ILogger logger,
+        bool warningShown)
+    {
+        var trustCheck = copilotTrust.CheckTrustedFolders(copilotTrust.GetRequiredTrustedFoldersForControlSession());
+        switch (trustCheck.Status)
+        {
+            case CopilotTrustStatus.Trusted:
+                return (true, warningShown);
+
+            case CopilotTrustStatus.Unknown:
+                logger.LogWarning("Could not verify Copilot folder trust for control session: {Message}",
+                    trustCheck.Message ?? "unknown trust verification error");
+                return (true, warningShown);
+
+            case CopilotTrustStatus.Untrusted:
+                var missingFolders = string.Join(", ", trustCheck.MissingFolders);
+                if (!warningShown)
+                {
+                    ConsoleOutput.Warning("Control session folder is not trusted by Copilot. Run 'copilotd init' or trust the folder manually before the control session can launch.");
+                    logger.LogWarning("Copilot folder trust missing for control session: {Folders}", missingFolders);
+                    return (false, true);
+                }
+
+                logger.LogDebug("Copilot folder trust still missing for control session: {Folders}", missingFolders);
+                return (false, warningShown);
+
+            default:
+                return (true, warningShown);
+        }
     }
 
     private static bool IsControlSessionHealthy(

--- a/src/copilotd/Infrastructure/CopilotTrustService.cs
+++ b/src/copilotd/Infrastructure/CopilotTrustService.cs
@@ -46,6 +46,9 @@ public sealed class CopilotTrustService
 
     public string ConfigPath => _configPath;
 
+    public IReadOnlyList<string> GetRequiredTrustedFoldersForControlSession()
+        => [NormalizePath(CopilotdPaths.GetControlSessionDirectory())];
+
     public IReadOnlyList<string> GetRequiredTrustedFolders(string repoPath)
     {
         var normalizedRepoPath = NormalizePath(repoPath);

--- a/src/copilotd/Infrastructure/CopilotdPaths.cs
+++ b/src/copilotd/Infrastructure/CopilotdPaths.cs
@@ -58,4 +58,7 @@ public static class CopilotdPaths
 
     public static string GetLogsDirectory()
         => Path.Combine(GetCopilotdHomeDirectory(), "logs");
+
+    public static string GetControlSessionDirectory()
+        => Path.Combine(GetCopilotdHomeDirectory(), "control-session");
 }

--- a/src/copilotd/Infrastructure/GitHubRemoteSessionUrlResolver.cs
+++ b/src/copilotd/Infrastructure/GitHubRemoteSessionUrlResolver.cs
@@ -20,8 +20,6 @@ public sealed class GitHubRemoteSessionUrlResolver
     private readonly string _sessionStateDir;
     private readonly ILogger<GitHubRemoteSessionUrlResolver> _logger;
 
-    public const string ControlSessionRepo = "DamianEdwards/copilotd";
-
     public GitHubRemoteSessionUrlResolver(ILogger<GitHubRemoteSessionUrlResolver> logger)
     {
         _logger = logger;

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -508,10 +508,7 @@ public sealed partial class ProcessManager
     /// </summary>
     public ControlSessionInfo? LaunchControlSession(CopilotdConfig config, string machineIdentifier)
     {
-        // Clone the copilotd repo to <RepoHome>/DamianEdwards/copilotd if needed, then
-        // launch from a dedicated subdirectory so repo-root wrapper scripts don't shadow
-        // the installed copilotd command inside the remote session harness.
-        var workingDir = EnsureControlSessionWorkingDirectory(config);
+        var workingDir = EnsureControlSessionWorkingDirectory();
         if (workingDir is null)
         {
             _logger.LogError("Cannot launch control session: failed to set up control session working directory");
@@ -646,28 +643,9 @@ public sealed partial class ProcessManager
     private static string BuildControlSessionName(string machineIdentifier)
         => $"(copilotd control) {machineIdentifier}";
 
-    /// <summary>
-    /// The copilotd repo to clone for the control session's working directory.
-    /// </summary>
-    private const string ControlSessionRepo = GitHubRemoteSessionUrlResolver.ControlSessionRepo;
-
-    /// <summary>
-    /// Dedicated subdirectory under the control-session repo clone used as the cwd for the
-    /// remote session, avoiding repo-root wrapper scripts like copilotd.ps1.
-    /// </summary>
-    private const string ControlSessionWorkingDirectoryName = ".control-session";
-
-    /// <summary>
-    /// Ensures the control session repo exists locally and returns a dedicated working
-    /// directory within that repo for launching the remote session.
-    /// </summary>
-    private string? EnsureControlSessionWorkingDirectory(CopilotdConfig config)
+    private string? EnsureControlSessionWorkingDirectory()
     {
-        var repoPath = EnsureControlSessionRepo(config);
-        if (repoPath is null)
-            return null;
-
-        var workingDir = Path.Combine(repoPath, ControlSessionWorkingDirectoryName);
+        var workingDir = CopilotdPaths.GetControlSessionDirectory();
 
         try
         {
@@ -677,75 +655,6 @@ public sealed partial class ProcessManager
         catch (Exception ex)
         {
             _logger.LogError(ex, "Exception creating control session working directory at {Path}", workingDir);
-            return null;
-        }
-    }
-
-    /// <summary>
-    /// Ensures the copilotd repo is cloned to <c>&lt;RepoHome&gt;/DamianEdwards/copilotd</c>.
-    /// Clones it if not already present.
-    /// </summary>
-    private string? EnsureControlSessionRepo(CopilotdConfig config)
-    {
-        if (string.IsNullOrEmpty(config.RepoHome))
-        {
-            _logger.LogError("RepoHome is not configured; cannot set up control session repo");
-            return null;
-        }
-
-        var repoPath = Path.Combine(config.RepoHome, "DamianEdwards", "copilotd");
-
-        if (Directory.Exists(Path.Combine(repoPath, ".git")))
-        {
-            _logger.LogDebug("Control session repo already exists at {Path}", repoPath);
-            return repoPath;
-        }
-
-        _logger.LogInformation("Cloning {Repo} for control session...", ControlSessionRepo);
-
-        try
-        {
-            Directory.CreateDirectory(Path.GetDirectoryName(repoPath)!);
-
-            var psi = new ProcessStartInfo
-            {
-                FileName = "gh",
-                Arguments = $"repo clone {ControlSessionRepo} \"{repoPath}\"",
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                CreateNoWindow = true,
-            };
-
-            using var process = Process.Start(psi);
-            if (process is null)
-            {
-                _logger.LogError("Failed to start gh repo clone for control session");
-                return null;
-            }
-
-            process.WaitForExit(TimeSpan.FromSeconds(60));
-
-            if (!process.HasExited)
-            {
-                _logger.LogWarning("gh repo clone timed out for control session");
-                process.Kill(entireProcessTree: true);
-                return null;
-            }
-
-            if (process.ExitCode != 0)
-            {
-                var stderr = process.StandardError.ReadToEnd();
-                _logger.LogError("gh repo clone failed (exit {Code}): {Stderr}", process.ExitCode, stderr);
-                return null;
-            }
-
-            _logger.LogInformation("Cloned {Repo} to {Path}", ControlSessionRepo, repoPath);
-            return repoPath;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Exception cloning {Repo} for control session", ControlSessionRepo);
             return null;
         }
     }


### PR DESCRIPTION
Closes #208

## Summary
- launch the control remote session from the copilotd home control-session folder instead of cloning the copilotd repo
- include the control-session folder in trusted folder setup/checks
- block control session launch when the control folder is explicitly untrusted, with suppressed repeat warnings

## Verification
- Reviewed by code-review agent
- `git diff --check`
- `dotnet build src\copilotd\copilotd.csproj`
- Temp-home smoke: `config --set enable_control_session=false`, `status`, `session list`
- Live daemon verification with isolated `COPILOTD_HOME`:
  - enabled `enable_control_session=true` and accepted trust for `%TEMP%\copilotd-issue-208-control-e2e\control-session`
  - started `copilotd run --interval 15 --log-level debug --disable-self-updates`
  - confirmed daemon launched a real control remote session and resolved a GitHub remote task URL
  - confirmed `copilotd status` reported `Control: Running` with the remote URL
  - confirmed state persisted `controlSession.status = Running` with the tracked control PID
  - stopped the daemon, confirmed `Control: Stopped`, removed isolated home, and removed the temporary trustedFolders entry