### PR TITLE
Add PR monitoring wakeups and scheduling windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Available for Windows, macOS, and Linux.
 - **Terminal-safe automation** — dispatched work sessions suppress browser launch environment variables so unattended agents stay in terminal/API workflows instead of popping open web pages
 - **Named dispatch rules** — flexible, composable rules with per-rule launch options (`--yolo`, `--allow-all-tools`, `--allow-all-urls`, `--model`, extra prompts, repo assignments)
 - **Session lifecycle** — full state machine with retry, backoff, orphan recovery, investigation feedback loops, PR review monitoring, and explicit completion signaling
-- **PR review feedback** — sessions that create PRs can wait for review comments and automatically re-dispatch to address feedback
+- **PR review feedback** — sessions that create PRs can wait for review comments and automatically re-dispatch to address feedback, newly unresolved review threads, or failing CI on the current head SHA
 - **Self-healing state** — reconciles persisted state, live process status, and GitHub issue matches on every poll cycle and at startup
 - **Crash-resilient** — dispatched `copilot` sessions run as independent processes that survive daemon restarts; state is persisted atomically
 - **Interactive connection** — connect to any running remote-enabled session with `copilotd session connect` without stopping the orchestrated session (requires Copilot CLI 1.0.32+)
@@ -311,7 +311,7 @@ The default prompt instructs copilot sessions to use `session pr` after creating
 
 ### PR dispatch rules
 
-Pull request dispatch rules live in the separate `pull_request_rules` config collection and are opt-in. They can be created from `copilotd init` when you choose PR dispatch, or later with `copilotd rules add <name> --kind pr`. They use the same `org/repo#number` session key format as issue sessions, with a stored subject kind to distinguish PR-root sessions from issue-root sessions.
+Pull request dispatch rules live in the separate `pull_request_rules` config collection and are opt-in. They can be created from `copilotd init` when you choose PR dispatch, or later with `copilotd rules add <name> --kind pr`. They use the same `org/repo#number` session key format as issue sessions, with a stored subject kind to distinguish PR-root sessions from issue-root sessions. When a PR-root session returns itself to `copilotd session pr`, copilotd keeps watching that PR for new review feedback, newly unresolved review threads, and failing CI on the current head SHA.
 
 PR rules support three worktree strategies:
 
@@ -449,6 +449,9 @@ When running from a source checkout via `copilotd.sh`, `copilotd.ps1`, or `copil
 | `custom_prompt` | *(none)* | Per-rule custom prompt text (appended to or overrides global custom prompt) |
 | `custom_prompt_mode` | `append` | How rule custom prompt interacts with global: `append` or `override` |
 | `trust_level` | `collaborators` | Which comment authors can trigger session re-dispatch: `collaborators` (write access required), `all`, `issueAuthor`, `assignees`, `issueAuthorAndCollaborators`, or `matchDispatchRule` |
+| `active_start_hour` | *(none)* | Optional local-hour start for the rule's dispatch window (0-23) |
+| `active_end_hour` | *(none)* | Optional local-hour end for the rule's dispatch window (0-23, midnight-wrapping supported) |
+| `active_time_zone` | *(none)* | Time zone used with `active_start_hour`/`active_end_hour` (for example `America/Chicago`) |
 
 Pull request rules support the shared settings above except issue-only `milestone` and `type`, and add these PR-specific settings:
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.107",
+    "version": "10.0.100",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }

--- a/scripts/Get-CopilotdActivity.ps1
+++ b/scripts/Get-CopilotdActivity.ps1
@@ -1,0 +1,710 @@
+#!/usr/bin/env pwsh
+[CmdletBinding()]
+param(
+    [string]$CopilotdHome,
+    [string]$CopilotdPath,
+    [int]$RecentSessionCount = 6,
+    [int]$RecentEventCount = 8,
+    [switch]$IncludeRawStatus,
+    [switch]$Json
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Resolve-CopilotdHome {
+    param([string]$ExplicitHome)
+
+    if (-not [string]::IsNullOrWhiteSpace($ExplicitHome))
+    {
+        return [System.IO.Path]::GetFullPath($ExplicitHome)
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($env:COPILOTD_HOME))
+    {
+        return [System.IO.Path]::GetFullPath($env:COPILOTD_HOME)
+    }
+
+    return [System.IO.Path]::GetFullPath((Join-Path $HOME '.copilotd'))
+}
+
+function Resolve-CopilotdExecutable {
+    param(
+        [string]$ExplicitPath,
+        [string]$ResolvedHome
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($ExplicitPath))
+    {
+        return $ExplicitPath
+    }
+
+    $installedPath = Join-Path $ResolvedHome 'bin/copilotd'
+    if (Test-Path -LiteralPath $installedPath)
+    {
+        return $installedPath
+    }
+
+    $command = Get-Command copilotd -ErrorAction SilentlyContinue
+    if ($null -ne $command)
+    {
+        return $command.Source
+    }
+
+    return $installedPath
+}
+
+function Read-JsonFile {
+    param([string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path))
+    {
+        return $null
+    }
+
+    $raw = Get-Content -LiteralPath $Path -Raw -ErrorAction Stop
+    if ([string]::IsNullOrWhiteSpace($raw))
+    {
+        return $null
+    }
+
+    return $raw | ConvertFrom-Json -Depth 100
+}
+
+function Get-OptionalPropertyValue {
+    param(
+        $Object,
+        [string]$Name
+    )
+
+    if ($null -eq $Object)
+    {
+        return $null
+    }
+
+    $property = $Object.PSObject.Properties[$Name]
+    if ($null -eq $property)
+    {
+        return $null
+    }
+
+    return $property.Value
+}
+
+function Get-DateTimeOffsetOrNull {
+    param($Value)
+
+    if ($null -eq $Value)
+    {
+        return $null
+    }
+
+    $text = [string]$Value
+    if ([string]::IsNullOrWhiteSpace($text))
+    {
+        return $null
+    }
+
+    return [DateTimeOffset]::Parse(
+        $text,
+        [System.Globalization.CultureInfo]::InvariantCulture,
+        [System.Globalization.DateTimeStyles]::RoundtripKind)
+}
+
+function Format-AbsoluteTime {
+    param($Value)
+
+    if ($null -eq $Value)
+    {
+        return 'n/a'
+    }
+
+    $timestamp = if ($Value -is [DateTimeOffset]) { $Value } else { [DateTimeOffset]$Value }
+    return $timestamp.ToLocalTime().ToString('yyyy-MM-dd HH:mm:ss zzz')
+}
+
+function Format-RelativeTime {
+    param($Value)
+
+    if ($null -eq $Value)
+    {
+        return 'n/a'
+    }
+
+    $timestamp = if ($Value -is [DateTimeOffset]) { $Value } else { [DateTimeOffset]$Value }
+    $span = [DateTimeOffset]::Now - $timestamp.ToLocalTime()
+    if ($span.TotalSeconds -lt 0)
+    {
+        $span = [TimeSpan]::Zero
+    }
+
+    if ($span.TotalSeconds -lt 45)
+    {
+        return 'just now'
+    }
+
+    if ($span.TotalMinutes -lt 60)
+    {
+        return '{0}m ago' -f [int][Math]::Floor($span.TotalMinutes)
+    }
+
+    if ($span.TotalHours -lt 24)
+    {
+        $hours = [int][Math]::Floor($span.TotalHours)
+        $minutes = $span.Minutes
+        if ($minutes -eq 0)
+        {
+            return '{0}h ago' -f $hours
+        }
+
+        return '{0}h {1}m ago' -f $hours, $minutes
+    }
+
+    $days = [int][Math]::Floor($span.TotalDays)
+    if ($span.Hours -eq 0)
+    {
+        return '{0}d ago' -f $days
+    }
+
+    return '{0}d {1}h ago' -f $days, $span.Hours
+}
+
+function Get-WatchedRepos {
+    param($Config)
+
+    $repos = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
+
+    foreach ($collectionName in @('issueRules', 'pullRequestRules'))
+    {
+        $collection = Get-OptionalPropertyValue -Object $Config -Name $collectionName
+        if ($null -eq $collection)
+        {
+            continue
+        }
+
+        foreach ($rule in $collection.PSObject.Properties)
+        {
+            foreach ($repo in @($rule.Value.repos))
+            {
+                if (-not [string]::IsNullOrWhiteSpace([string]$repo))
+                {
+                    $null = $repos.Add([string]$repo)
+                }
+            }
+        }
+    }
+
+    return @($repos | Sort-Object)
+}
+
+function Get-Sessions {
+    param($State)
+
+    if ($null -eq $State -or $null -eq $State.sessions)
+    {
+        return @()
+    }
+
+    $sessions = foreach ($property in $State.sessions.PSObject.Properties)
+    {
+        $session = $property.Value
+        [pscustomobject]@{
+            Subject = $property.Name
+            SubjectKind = [string](Get-OptionalPropertyValue -Object $session -Name 'subjectKind')
+            Status = [string](Get-OptionalPropertyValue -Object $session -Name 'status')
+            Title = [string](Get-OptionalPropertyValue -Object $session -Name 'subjectTitle')
+            RuleName = [string](Get-OptionalPropertyValue -Object $session -Name 'ruleName')
+            UpdatedAt = Get-DateTimeOffsetOrNull (Get-OptionalPropertyValue -Object $session -Name 'updatedAt')
+            CreatedAt = Get-DateTimeOffsetOrNull (Get-OptionalPropertyValue -Object $session -Name 'createdAt')
+            WaitingSince = Get-DateTimeOffsetOrNull (Get-OptionalPropertyValue -Object $session -Name 'waitingSince')
+            LastVerifiedAt = Get-DateTimeOffsetOrNull (Get-OptionalPropertyValue -Object $session -Name 'lastVerifiedAt')
+            LastHookEvent = [string](Get-OptionalPropertyValue -Object $session -Name 'lastHookEvent')
+            LastHookDetail = [string](Get-OptionalPropertyValue -Object $session -Name 'lastHookDetail')
+            ProcessId = if ($null -ne (Get-OptionalPropertyValue -Object $session -Name 'processId')) { [int](Get-OptionalPropertyValue -Object $session -Name 'processId') } else { $null }
+            RetryCount = if ($null -ne (Get-OptionalPropertyValue -Object $session -Name 'retryCount')) { [int](Get-OptionalPropertyValue -Object $session -Name 'retryCount') } else { 0 }
+            RedispatchCount = if ($null -ne (Get-OptionalPropertyValue -Object $session -Name 'redispatchCount')) { [int](Get-OptionalPropertyValue -Object $session -Name 'redispatchCount') } else { 0 }
+            FailureDetail = [string](Get-OptionalPropertyValue -Object $session -Name 'failureDetail')
+            WorktreePath = [string](Get-OptionalPropertyValue -Object $session -Name 'worktreePath')
+            BaseBranch = [string](Get-OptionalPropertyValue -Object $session -Name 'pullRequestBaseBranch')
+            HeadBranch = [string](Get-OptionalPropertyValue -Object $session -Name 'pullRequestHeadBranch')
+        }
+    }
+
+    return @($sessions | Sort-Object UpdatedAt -Descending)
+}
+
+function Get-LatestDaemonLogDirectory {
+    param([string]$ResolvedHome)
+
+    $logRoot = Join-Path $ResolvedHome 'logs'
+    if (-not (Test-Path -LiteralPath $logRoot))
+    {
+        return $null
+    }
+
+    return Get-ChildItem -LiteralPath $logRoot -Directory -Filter 'daemon_*' |
+        Sort-Object LastWriteTimeUtc -Descending |
+        Select-Object -First 1
+}
+
+function Get-ParsedLogEntries {
+    param($LogDirectory)
+
+    if ($null -eq $LogDirectory)
+    {
+        return @()
+    }
+
+    $entries = foreach ($logFile in (Get-ChildItem -LiteralPath $LogDirectory.FullName -File -Filter '*.log' | Sort-Object Name))
+    {
+        foreach ($line in Get-Content -LiteralPath $logFile.FullName)
+        {
+            if ($line -match '^\[(?<timestamp>[^\]]+)\] \[(?<level>[A-Z]+)\] \[(?<source>[^\]]+)\] (?<message>.*)$')
+            {
+                [pscustomobject]@{
+                    Timestamp = [DateTimeOffset]::Parse(
+                        $matches.timestamp,
+                        [System.Globalization.CultureInfo]::InvariantCulture,
+                        [System.Globalization.DateTimeStyles]::AssumeUniversal)
+                    Level = $matches.level
+                    Source = $matches.source
+                    Message = $matches.message
+                }
+            }
+        }
+    }
+
+    return @($entries)
+}
+
+function Test-IgnoredLogEntry {
+    param($Entry)
+
+    if ($Entry.Source -eq 'Copilotd.Services.GhCliService')
+    {
+        return $true
+    }
+
+    if ($Entry.Source -eq 'Copilotd.Infrastructure.StateStore')
+    {
+        return $true
+    }
+
+    if ($Entry.Message -like 'Running: gh *')
+    {
+        return $true
+    }
+
+    if ($Entry.Message -like 'copilot --remote *')
+    {
+        return $true
+    }
+
+    return $false
+}
+
+function Get-LastLogEventForSubject {
+    param(
+        [object[]]$Entries,
+        [string]$Subject
+    )
+
+    for ($i = $Entries.Count - 1; $i -ge 0; $i--)
+    {
+        $entry = $Entries[$i]
+        if (Test-IgnoredLogEntry $entry)
+        {
+            continue
+        }
+
+        if ($entry.Message -like "*$Subject*" -and $entry.Message -notlike 'Desired PR dispatch:*')
+        {
+            return $entry
+        }
+    }
+
+    for ($i = $Entries.Count - 1; $i -ge 0; $i--)
+    {
+        $entry = $Entries[$i]
+        if (Test-IgnoredLogEntry $entry)
+        {
+            continue
+        }
+
+        if ($entry.Message -like "*$Subject*")
+        {
+            return $entry
+        }
+    }
+
+    return $null
+}
+
+function Get-RecentNotableLogEvents {
+    param(
+        [object[]]$Entries,
+        [int]$Count
+    )
+
+    $patterns = @(
+        'Queueing ',
+        'Launching copilot',
+        'Copilot launched',
+        'Worktree ',
+        'Reconciliation complete',
+        'max instances',
+        'Skipping large PR split retry',
+        'Failed',
+        'orphaned'
+    )
+
+    $events = foreach ($entry in $Entries)
+    {
+        if (Test-IgnoredLogEntry $entry)
+        {
+            continue
+        }
+
+        if ($patterns.Where({ $entry.Message -like "*$_*" }, 'First').Count -gt 0)
+        {
+            $entry
+        }
+    }
+
+    return @($events | Sort-Object Timestamp -Descending | Select-Object -First $Count)
+}
+
+function Get-SessionCounts {
+    param([object[]]$Sessions)
+
+    [pscustomobject]@{
+        Running = @($Sessions | Where-Object Status -eq 'Running').Count
+        Pending = @($Sessions | Where-Object Status -eq 'Pending').Count
+        Dispatching = @($Sessions | Where-Object Status -eq 'Dispatching').Count
+        WaitingForFeedback = @($Sessions | Where-Object Status -eq 'WaitingForFeedback').Count
+        WaitingForReview = @($Sessions | Where-Object Status -eq 'WaitingForReview').Count
+        Failed = @($Sessions | Where-Object Status -eq 'Failed').Count
+        Orphaned = @($Sessions | Where-Object Status -eq 'Orphaned').Count
+        Completed = @($Sessions | Where-Object Status -eq 'Completed').Count
+        Terminal = @($Sessions | Where-Object { $_.Status -in @('Completed', 'Failed') }).Count
+        Total = $Sessions.Count
+    }
+}
+
+function Join-Subjects {
+    param([object[]]$Sessions)
+
+    $subjects = @($Sessions | ForEach-Object Subject)
+    if ($subjects.Count -eq 0)
+    {
+        return ''
+    }
+
+    if ($subjects.Count -eq 1)
+    {
+        return $subjects[0]
+    }
+
+    if ($subjects.Count -eq 2)
+    {
+        return '{0} and {1}' -f $subjects[0], $subjects[1]
+    }
+
+    return '{0}, {1}, and {2} more' -f $subjects[0], $subjects[1], ($subjects.Count - 2)
+}
+
+function Get-Headline {
+    param(
+        $Counts,
+        [object[]]$RunningSessions,
+        [object[]]$PendingSessions
+    )
+
+    if ($Counts.Total -eq 0)
+    {
+        return 'copilotd is not tracking any sessions right now.'
+    }
+
+    if ($RunningSessions.Count -gt 0 -and $PendingSessions.Count -gt 0)
+    {
+        return 'copilotd is actively working on {0} and has {1} queued next; {2} other PRs are parked in WaitingForReview.' -f `
+            (Join-Subjects $RunningSessions),
+            (Join-Subjects $PendingSessions),
+            $Counts.WaitingForReview
+    }
+
+    if ($RunningSessions.Count -gt 0)
+    {
+        return 'copilotd is actively working on {0}; {1} PRs are parked in WaitingForReview.' -f `
+            (Join-Subjects $RunningSessions),
+            $Counts.WaitingForReview
+    }
+
+    if ($PendingSessions.Count -gt 0)
+    {
+        return 'copilotd is between runs right now: {0} is queued next, and {1} PRs are parked in WaitingForReview.' -f `
+            (Join-Subjects $PendingSessions),
+            $Counts.WaitingForReview
+    }
+
+    if ($Counts.WaitingForReview -gt 0)
+    {
+        return 'copilotd is currently monitoring {0} PRs in WaitingForReview and waiting for new review work to appear.' -f $Counts.WaitingForReview
+    }
+
+    if ($Counts.WaitingForFeedback -gt 0)
+    {
+        return 'copilotd is currently waiting on feedback for {0} session(s).' -f $Counts.WaitingForFeedback
+    }
+
+    return 'copilotd is idle right now; there are no running or queued sessions.'
+}
+
+function Get-RawStatusSnapshot {
+    param([string]$ExecutablePath)
+
+    if ([string]::IsNullOrWhiteSpace($ExecutablePath))
+    {
+        return $null
+    }
+
+    try
+    {
+        $output = & $ExecutablePath status 2>&1
+        return [pscustomobject]@{
+            ExitCode = $LASTEXITCODE
+            Output = @($output)
+        }
+    }
+    catch
+    {
+        return [pscustomobject]@{
+            ExitCode = 1
+            Output = @($_.Exception.Message)
+        }
+    }
+}
+
+$resolvedHome = Resolve-CopilotdHome -ExplicitHome $CopilotdHome
+$resolvedCopilotdPath = Resolve-CopilotdExecutable -ExplicitPath $CopilotdPath -ResolvedHome $resolvedHome
+
+$config = Read-JsonFile -Path (Join-Path $resolvedHome 'config.json')
+$state = Read-JsonFile -Path (Join-Path $resolvedHome 'state.json')
+$sessions = Get-Sessions -State $state
+$counts = Get-SessionCounts -Sessions $sessions
+$watchedRepos = if ($null -ne $config) { Get-WatchedRepos -Config $config } else { @() }
+$runningSessions = @($sessions | Where-Object Status -eq 'Running')
+$pendingSessions = @($sessions | Where-Object Status -eq 'Pending')
+$needsAttention = @($sessions | Where-Object { $_.Status -in @('Failed', 'Orphaned') } | Select-Object -First $RecentSessionCount)
+$recentWaiting = @(
+    $sessions |
+        Where-Object { $_.Status -in @('WaitingForReview', 'WaitingForFeedback') } |
+        Sort-Object UpdatedAt -Descending |
+        Select-Object -First $RecentSessionCount
+)
+
+$latestDaemonLogDirectory = Get-LatestDaemonLogDirectory -ResolvedHome $resolvedHome
+$parsedLogEntries = Get-ParsedLogEntries -LogDirectory $latestDaemonLogDirectory
+$recentEvents = Get-RecentNotableLogEvents -Entries $parsedLogEntries -Count $RecentEventCount
+$rawStatus = Get-RawStatusSnapshot -ExecutablePath $resolvedCopilotdPath
+$daemonStatus = 'unknown'
+if ($null -ne $rawStatus -and $rawStatus.ExitCode -eq 0)
+{
+    $rawJoined = $rawStatus.Output -join "`n"
+    if ($rawJoined -match 'Daemon is running')
+    {
+        $daemonStatus = 'running'
+    }
+    elseif ($rawJoined -match 'Daemon is not running')
+    {
+        $daemonStatus = 'stopped'
+    }
+}
+
+$summary = [pscustomobject]@{
+    Headline = Get-Headline -Counts $counts -RunningSessions $runningSessions -PendingSessions $pendingSessions
+    DaemonStatus = $daemonStatus
+    LastPollAt = Get-DateTimeOffsetOrNull (Get-OptionalPropertyValue -Object $state -Name 'lastPollTime')
+    Home = $resolvedHome
+    WatchedRepos = $watchedRepos
+    LatestDaemonLogDirectory = if ($null -ne $latestDaemonLogDirectory) { $latestDaemonLogDirectory.FullName } else { $null }
+    Counts = $counts
+    RunningSessions = @(
+        $runningSessions | ForEach-Object {
+            $lastEvent = Get-LastLogEventForSubject -Entries $parsedLogEntries -Subject $_.Subject
+            [pscustomobject]@{
+                Subject = $_.Subject
+                Title = $_.Title
+                Status = $_.Status
+                UpdatedAt = $_.UpdatedAt
+                LastEventAt = if ($null -ne $lastEvent) { $lastEvent.Timestamp } else { $null }
+                LastEvent = if ($null -ne $lastEvent) { $lastEvent.Message } else { $null }
+                ProcessId = $_.ProcessId
+            }
+        }
+    )
+    PendingSessions = @(
+        $pendingSessions | ForEach-Object {
+            $lastEvent = Get-LastLogEventForSubject -Entries $parsedLogEntries -Subject $_.Subject
+            [pscustomobject]@{
+                Subject = $_.Subject
+                Title = $_.Title
+                Status = $_.Status
+                UpdatedAt = $_.UpdatedAt
+                LastEventAt = if ($null -ne $lastEvent) { $lastEvent.Timestamp } else { $null }
+                LastEvent = if ($null -ne $lastEvent) { $lastEvent.Message } else { $null }
+            }
+        }
+    )
+    RecentWaitingSessions = @(
+        $recentWaiting | ForEach-Object {
+            $lastEvent = Get-LastLogEventForSubject -Entries $parsedLogEntries -Subject $_.Subject
+            [pscustomobject]@{
+                Subject = $_.Subject
+                Title = $_.Title
+                Status = $_.Status
+                UpdatedAt = $_.UpdatedAt
+                LastHookEvent = $_.LastHookEvent
+                LastHookDetail = $_.LastHookDetail
+                LastEventAt = if ($null -ne $lastEvent) { $lastEvent.Timestamp } else { $null }
+                LastEvent = if ($null -ne $lastEvent) { $lastEvent.Message } else { $null }
+            }
+        }
+    )
+    NeedsAttention = @(
+        $needsAttention | ForEach-Object {
+            [pscustomobject]@{
+                Subject = $_.Subject
+                Title = $_.Title
+                Status = $_.Status
+                UpdatedAt = $_.UpdatedAt
+                RetryCount = $_.RetryCount
+                FailureDetail = $_.FailureDetail
+            }
+        }
+    )
+    RecentEvents = @(
+        $recentEvents | ForEach-Object {
+            [pscustomobject]@{
+                Timestamp = $_.Timestamp
+                Source = $_.Source
+                Message = $_.Message
+            }
+        }
+    )
+    RawStatus = if ($IncludeRawStatus) { $rawStatus.Output } else { $null }
+}
+
+if ($Json)
+{
+    $summary | ConvertTo-Json -Depth 8
+    exit 0
+}
+
+Write-Output $summary.Headline
+Write-Output ''
+Write-Output ('Daemon:         {0}' -f $summary.DaemonStatus)
+Write-Output ('Last poll:      {0} ({1})' -f (Format-RelativeTime $summary.LastPollAt), (Format-AbsoluteTime $summary.LastPollAt))
+Write-Output ('Home:           {0}' -f $summary.Home)
+if ($summary.WatchedRepos.Count -gt 0)
+{
+    Write-Output ('Watching:       {0}' -f ($summary.WatchedRepos -join ', '))
+}
+if (-not [string]::IsNullOrWhiteSpace([string]$summary.LatestDaemonLogDirectory))
+{
+    Write-Output ('Latest log dir: {0}' -f $summary.LatestDaemonLogDirectory)
+}
+Write-Output ('Sessions:       running={0}, pending={1}, dispatching={2}, waitingForReview={3}, waitingForFeedback={4}, failed={5}, orphaned={6}, terminal={7}' -f `
+    $summary.Counts.Running,
+    $summary.Counts.Pending,
+    $summary.Counts.Dispatching,
+    $summary.Counts.WaitingForReview,
+    $summary.Counts.WaitingForFeedback,
+    $summary.Counts.Failed,
+    $summary.Counts.Orphaned,
+    $summary.Counts.Terminal)
+
+if ($summary.RunningSessions.Count -gt 0)
+{
+    Write-Output ''
+    Write-Output 'Current work:'
+    foreach ($session in $summary.RunningSessions)
+    {
+        Write-Output ('- {0} — {1}' -f $session.Subject, $session.Title)
+        Write-Output ('  status: running (PID {0}), updated {1}' -f $session.ProcessId, (Format-RelativeTime $session.UpdatedAt))
+        if (-not [string]::IsNullOrWhiteSpace([string]$session.LastEvent))
+        {
+            Write-Output ('  last event: {0} — {1}' -f (Format-AbsoluteTime $session.LastEventAt), $session.LastEvent)
+        }
+    }
+}
+
+if ($summary.PendingSessions.Count -gt 0)
+{
+    Write-Output ''
+    Write-Output 'Queued next:'
+    foreach ($session in $summary.PendingSessions)
+    {
+        Write-Output ('- {0} — {1}' -f $session.Subject, $session.Title)
+        Write-Output ('  status: pending, updated {0}' -f (Format-RelativeTime $session.UpdatedAt))
+        if (-not [string]::IsNullOrWhiteSpace([string]$session.LastEvent))
+        {
+            Write-Output ('  last event: {0} — {1}' -f (Format-AbsoluteTime $session.LastEventAt), $session.LastEvent)
+        }
+    }
+}
+
+if ($summary.RecentWaitingSessions.Count -gt 0)
+{
+    Write-Output ''
+    Write-Output ('Recently touched waiting sessions (top {0}):' -f $summary.RecentWaitingSessions.Count)
+    foreach ($session in $summary.RecentWaitingSessions)
+    {
+        Write-Output ('- {0} — {1}' -f $session.Subject, $session.Title)
+        Write-Output ('  status: {0}, updated {1}' -f $session.Status, (Format-RelativeTime $session.UpdatedAt))
+        if (-not [string]::IsNullOrWhiteSpace([string]$session.LastHookEvent))
+        {
+            $hookDetail = if ([string]::IsNullOrWhiteSpace([string]$session.LastHookDetail)) { '' } else { " ($($session.LastHookDetail))" }
+            Write-Output ('  last hook: {0}{1}' -f $session.LastHookEvent, $hookDetail)
+        }
+        if (-not [string]::IsNullOrWhiteSpace([string]$session.LastEvent))
+        {
+            Write-Output ('  last event: {0} — {1}' -f (Format-AbsoluteTime $session.LastEventAt), $session.LastEvent)
+        }
+    }
+}
+
+if ($summary.NeedsAttention.Count -gt 0)
+{
+    Write-Output ''
+    Write-Output 'Needs attention:'
+    foreach ($session in $summary.NeedsAttention)
+    {
+        Write-Output ('- {0} — {1}' -f $session.Subject, $session.Status)
+        Write-Output ('  updated {0}; retries={1}' -f (Format-RelativeTime $session.UpdatedAt), $session.RetryCount)
+        if (-not [string]::IsNullOrWhiteSpace([string]$session.FailureDetail))
+        {
+            Write-Output ('  failure: {0}' -f $session.FailureDetail)
+        }
+    }
+}
+
+if ($summary.RecentEvents.Count -gt 0)
+{
+    Write-Output ''
+    Write-Output ('Recent notable daemon events (top {0}):' -f $summary.RecentEvents.Count)
+    foreach ($event in $summary.RecentEvents)
+    {
+        Write-Output ('- {0} [{1}] {2}' -f (Format-AbsoluteTime $event.Timestamp), $event.Source, $event.Message)
+    }
+}
+
+if ($IncludeRawStatus -and $null -ne $summary.RawStatus)
+{
+    Write-Output ''
+    Write-Output 'Raw copilotd status:'
+    foreach ($line in $summary.RawStatus)
+    {
+        Write-Output $line
+    }
+}

--- a/src/copilotd/Commands/ConfigCommand.cs
+++ b/src/copilotd/Commands/ConfigCommand.cs
@@ -1,4 +1,5 @@
 using System.CommandLine;
+using System.Linq;
 using Copilotd.Infrastructure;
 using Copilotd.Models;
 using Copilotd.Services;
@@ -48,6 +49,7 @@ public static class ConfigCommand
                     table.AddRow("session_shutdown_delay_seconds", Markup.Escape(config.SessionShutdownDelaySeconds.ToString()));
                     table.AddRow("issue_rules", Markup.Escape($"{config.IssueRules.Count} rule(s)"));
                     table.AddRow("pull_request_rules", Markup.Escape($"{config.PullRequestRules.Count} rule(s)"));
+                    table.AddRow("env_vars", Markup.Escape(config.EnvVars is null || config.EnvVars.Count == 0 ? "(not set)" : string.Join(", ", config.EnvVars.Select(kv => $"{kv.Key}={kv.Value}"))));
 
                     if (config.IssueRules.Count > 0)
                     {
@@ -226,9 +228,37 @@ public static class ConfigCommand
                         }
                         break;
 
+                    case "env_vars":
+                        // Format: env_vars=KEY1=val1,KEY2=val2  or  env_vars=  to clear
+                        if (string.IsNullOrWhiteSpace(value))
+                        {
+                            cfg.EnvVars = null;
+                            ConsoleOutput.Success("env_vars cleared.");
+                        }
+                        else
+                        {
+                            cfg.EnvVars ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                            cfg.EnvVars.Clear();
+                            var pairs = value.Split(',');
+                            foreach (var pair in pairs)
+                            {
+                                var eq = pair.IndexOf('=');
+                                if (eq <= 0)
+                                {
+                                    ConsoleOutput.Error($"Invalid env var pair: '{pair.Trim()}'. Expected KEY=VALUE");
+                                    return 1;
+                                }
+                                var k = pair[..eq].Trim();
+                                var v = pair[(eq + 1)..].Trim();
+                                cfg.EnvVars[k] = v;
+                            }
+                            ConsoleOutput.Success($"env_vars set: {string.Join(", ", cfg.EnvVars.Select(kv => $"{kv.Key}={kv.Value}"))}");
+                        }
+                        break;
+
                     default:
                         ConsoleOutput.Error($"Unknown config key: {key}");
-                        ConsoleOutput.Info("Valid keys: repo_home, default_model, custom_prompt, session_name_format, current_user, enable_control_session, max_instances, session_shutdown_delay_seconds");
+                        ConsoleOutput.Info("Valid keys: repo_home, default_model, custom_prompt, session_name_format, current_user, enable_control_session, max_instances, session_shutdown_delay_seconds, env_vars");
                         return 1;
                 }
 

--- a/src/copilotd/Commands/InitCommand.cs
+++ b/src/copilotd/Commands/InitCommand.cs
@@ -612,6 +612,7 @@ public static class InitCommand
                 AddNextStep(nextStepsTable, "copilotd rules add MyPrRule --kind pr --label review", "Create a new PR dispatch rule");
                 AddNextStep(nextStepsTable, "copilotd config --set max_instances=5", "Change concurrency limit");
                 AddNextStep(nextStepsTable, "copilotd config --set default_model=claude-sonnet-4", "Set the default model");
+                AddNextStep(nextStepsTable, "copilotd config --set env_vars=COPILIT_MODEL=local,COPILIT_API_URL=http://localhost:8080", "Set custom environment variables for copilot processes");
                 AddNextStep(nextStepsTable, "copilotd status", "Check daemon health and sessions");
                 AnsiConsole.Write(nextStepsTable);
                 AnsiConsole.WriteLine();

--- a/src/copilotd/Commands/SessionCommand.cs
+++ b/src/copilotd/Commands/SessionCommand.cs
@@ -104,7 +104,7 @@ public static class SessionCommand
                     ? await Console.In.ReadToEndAsync(ct)
                     : "";
 
-                return HandleSessionEvent(stateStore, runtimeContext.GetCopilotdCallbackCommand(), eventName, issueKey, expectedSessionId, payload, ct);
+                return HandleSessionEvent(stateStore, runtimeContext.GetCopilotdCallbackCommand(), eventName, issueKey, expectedSessionId, payload, logger, ct);
             }
             catch (Exception ex)
             {
@@ -125,6 +125,7 @@ public static class SessionCommand
         string issueKey,
         string? expectedSessionId,
         string payload,
+        ILogger<Program> logger,
         CancellationToken ct)
     {
         var normalizedEvent = NormalizeHookEventName(eventName);
@@ -156,11 +157,19 @@ public static class SessionCommand
             else if (normalizedEvent == "session-end"
                      && session.Status is SessionStatus.Running or SessionStatus.Dispatching)
             {
-                var reason = ExtractString(payload, "reason") ?? "unknown";
+                var detail = ExtractSessionEndDetail(payload) ?? ExtractString(payload, "reason") ?? "unknown";
                 session.Status = SessionStatus.Orphaned;
-                session.FailureDetail = $"Copilot hook reported sessionEnd reason '{reason}' before the session reached a completed or waiting state.";
+                session.FailureDetail = $"Copilot hook reported sessionEnd ({detail}) before the session reached a completed or waiting state.";
                 session.LastFailureAt = DateTimeOffset.UtcNow;
                 ClearTrackedProcess(session);
+
+                var hookModel = ExtractString(payload, "model");
+                var hookError = ExtractString(payload, "error");
+                if (!string.IsNullOrEmpty(hookError))
+                    logger.LogWarning("  [HOOK ERROR] {IssueKey} session-end error: {Error}", issueKey, hookError);
+                if (!string.IsNullOrEmpty(hookModel))
+                    logger.LogInformation("  [HOOK MODEL] {IssueKey} session-end model: {Model}", issueKey, hookModel);
+                logger.LogWarning("  [HOOK PAYLOAD] {IssueKey} session-end detail: {Detail} | raw_payload: {Payload}", issueKey, detail, payload);
             }
 
             stateStore.SaveState(state);
@@ -189,7 +198,7 @@ public static class SessionCommand
     private static string? ExtractHookDetail(string normalizedEvent, string payload)
         => normalizedEvent switch
         {
-            "session-end" => ExtractString(payload, "reason") is { } reason ? $"reason={reason}" : null,
+            "session-end" => ExtractSessionEndDetail(payload),
             "error-occurred" => ExtractErrorDetail(payload),
             "agent-stop" => ExtractString(payload, "stopReason") is { } reason
                 ? $"stopReason={reason}"
@@ -198,6 +207,27 @@ public static class SessionCommand
                     : null,
             _ => null,
         };
+
+    private static string? ExtractSessionEndDetail(string payload)
+    {
+        if (string.IsNullOrWhiteSpace(payload))
+            return null;
+
+        var reason = ExtractString(payload, "reason") ?? "unknown";
+        var error = ExtractString(payload, "error");
+        var message = ExtractString(payload, "message");
+        var model = ExtractString(payload, "model");
+
+        var parts = new List<string> { $"reason={reason}" };
+        if (!string.IsNullOrEmpty(model))
+            parts.Add($"model={model}");
+        if (!string.IsNullOrEmpty(error))
+            parts.Add($"error={error}");
+        if (!string.IsNullOrEmpty(message))
+            parts.Add($"message={message}");
+
+        return string.Join(", ", parts);
+    }
 
     private static string? ExtractErrorDetail(string payload)
     {

--- a/src/copilotd/Commands/SessionCommand.cs
+++ b/src/copilotd/Commands/SessionCommand.cs
@@ -926,6 +926,9 @@ public static class SessionCommand
                     session.RetryCount = 0;
                     session.RedispatchCount = 0;
                     session.LastRedispatchWasIssueComment = false;
+                    session.SeenUnresolvedReviewThreadIds = [];
+                    session.HasEstablishedUnresolvedReviewThreadBaseline = false;
+                    session.LastTriggeredFailingChecksHeadSha = null;
                     session.LastFailureAt = null;
                     session.WaitingSince = null;
                     session.SetReactionAnchor(ReactionAnchor.IssueBody);
@@ -1288,6 +1291,9 @@ public static class SessionCommand
             PullRequestHeadRepo = session.PullRequestHeadRepo,
             PullRequestHeadSha = session.PullRequestHeadSha,
             PullRequestBranchStrategy = session.PullRequestBranchStrategy,
+            SeenUnresolvedReviewThreadIds = [.. session.SeenUnresolvedReviewThreadIds],
+            HasEstablishedUnresolvedReviewThreadBaseline = session.HasEstablishedUnresolvedReviewThreadBaseline,
+            LastTriggeredFailingChecksHeadSha = session.LastTriggeredFailingChecksHeadSha,
             RedispatchCount = session.RedispatchCount,
             LastRedispatchWasIssueComment = session.LastRedispatchWasIssueComment,
             WorktreePath = session.WorktreePath,

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -233,7 +233,13 @@ public sealed partial class ProcessManager
         }
         catch (ArgumentException)
         {
-            // Process not found
+            // Process not found (already gone from process table)
+            var uptime = session.ProcessStartTime is { } start
+                ? (DateTimeOffset.UtcNow - start).TotalSeconds
+                : -1;
+            _logger.LogInformation(
+                "Session {Key} PID {Pid} not found in process table (uptime={Uptime:F0}s)",
+                session.IssueKey, pid, uptime);
             return ProcessLivenessResult.Dead;
         }
         catch (Exception ex)

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -111,7 +111,8 @@ public sealed partial class ProcessManager
 
                 var cmdLine = $"copilot {args}";
                 var flags = CREATE_NEW_CONSOLE | CREATE_NEW_PROCESS_GROUP | CREATE_UNICODE_ENVIRONMENT;
-                var environmentBlock = BuildWindowsEnvironmentBlockWithOverrides(BrowserLaunchSuppressionEnvironment);
+                var allOverrides = MergeEnvironmentOverrides(BrowserLaunchSuppressionEnvironment, config.EnvVars);
+                var environmentBlock = BuildWindowsEnvironmentBlockWithOverrides(allOverrides);
 
                 try
                 {
@@ -152,7 +153,7 @@ public sealed partial class ProcessManager
                     RedirectStandardInput = false,
                     CreateNoWindow = true,
                 };
-                ApplyBrowserLaunchSuppressionEnvironment(psi);
+                ApplyEnvironmentOverrides(psi, config.EnvVars);
 
                 process = Process.Start(psi);
                 if (process is null)
@@ -557,24 +558,32 @@ public sealed partial class ProcessManager
                 si.wShowWindow = SW_HIDE;
 
                 var cmdLine = $"copilot {args}";
-                var flags = CREATE_NEW_CONSOLE | CREATE_NEW_PROCESS_GROUP;
+                var flags = CREATE_NEW_CONSOLE | CREATE_NEW_PROCESS_GROUP | CREATE_UNICODE_ENVIRONMENT;
+                var controlEnvironmentBlock = BuildWindowsEnvironmentBlockWithOverrides(config.EnvVars?.Keys.Select(k => new KeyValuePair<string, string>(k, config.EnvVars[k])) ?? Enumerable.Empty<KeyValuePair<string, string>>());
 
-                if (!CreateProcessW(null, cmdLine, IntPtr.Zero, IntPtr.Zero, false,
-                    flags, IntPtr.Zero, workingDir, ref si, out var pi))
+                try
                 {
-                    _logger.LogError("CreateProcessW failed for control session (error: {Error})",
-                        Marshal.GetLastWin32Error());
-                    return null;
+                    if (!CreateProcessW(null, cmdLine, IntPtr.Zero, IntPtr.Zero, false,
+                        flags, controlEnvironmentBlock, workingDir, ref si, out var pi))
+                    {
+                        _logger.LogError("CreateProcessW failed for control session (error: {Error})",
+                            Marshal.GetLastWin32Error());
+                        return null;
+                    }
+
+                    session.ProcessId = pi.dwProcessId;
+                    CloseHandle(pi.hProcess);
+                    CloseHandle(pi.hThread);
+                    AssignTrackedWindowsCopilotProcess("control session", pi.dwProcessId, tracked =>
+                    {
+                        session.ProcessId = tracked.ProcessId;
+                        session.ProcessStartTime = tracked.ProcessStartTime;
+                    });
                 }
-
-                session.ProcessId = pi.dwProcessId;
-                CloseHandle(pi.hProcess);
-                CloseHandle(pi.hThread);
-                AssignTrackedWindowsCopilotProcess("control session", pi.dwProcessId, tracked =>
+                finally
                 {
-                    session.ProcessId = tracked.ProcessId;
-                    session.ProcessStartTime = tracked.ProcessStartTime;
-                });
+                    Marshal.FreeHGlobal(controlEnvironmentBlock);
+                }
             }
             else
             {
@@ -589,6 +598,7 @@ public sealed partial class ProcessManager
                     RedirectStandardInput = false,
                     CreateNoWindow = true,
                 };
+                ApplyEnvVarsToProcessInfo(psi, config.EnvVars);
 
                 var process = Process.Start(psi);
                 if (process is null)
@@ -1045,6 +1055,71 @@ public sealed partial class ProcessManager
     {
         foreach (var (name, value) in BrowserLaunchSuppressionEnvironment)
             psi.Environment[name] = value;
+    }
+
+    /// <summary>
+    /// Applies browser-launch suppression env vars AND any custom env vars from config.
+    /// Copies the current process environment, then merges overrides on top.
+    /// </summary>
+    private static void ApplyEnvironmentOverrides(ProcessStartInfo psi, Dictionary<string, string>? envVars)
+    {
+        // Start with a copy of the current process environment
+        foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
+        {
+            var key = entry.Key?.ToString();
+            if (!string.IsNullOrWhiteSpace(key))
+                psi.Environment[key!] = entry.Value?.ToString() ?? string.Empty;
+        }
+
+        // Apply browser launch suppression
+        foreach (var (name, value) in BrowserLaunchSuppressionEnvironment)
+            psi.Environment[name] = value;
+
+        // Apply custom env vars from config
+        if (envVars is not null)
+        {
+            foreach (var (name, value) in envVars)
+                psi.Environment[name] = value;
+        }
+    }
+
+    /// <summary>
+    /// Applies custom env vars from config to a ProcessStartInfo (for control sessions
+    /// that don't need browser launch suppression). Copies the current process environment first.
+    /// </summary>
+    private static void ApplyEnvVarsToProcessInfo(ProcessStartInfo psi, Dictionary<string, string>? envVars)
+    {
+        // Start with a copy of the current process environment
+        foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
+        {
+            var key = entry.Key?.ToString();
+            if (!string.IsNullOrWhiteSpace(key))
+                psi.Environment[key!] = entry.Value?.ToString() ?? string.Empty;
+        }
+
+        // Apply custom env vars from config
+        if (envVars is not null)
+        {
+            foreach (var (name, value) in envVars)
+                psi.Environment[name] = value;
+        }
+    }
+
+    /// <summary>
+    /// Merges multiple env var collections into a single sequence (for Windows CreateProcessW).
+    /// </summary>
+    private static IEnumerable<KeyValuePair<string, string>> MergeEnvironmentOverrides(
+        IEnumerable<KeyValuePair<string, string>> baseOverrides,
+        Dictionary<string, string>? customEnvVars)
+    {
+        foreach (var kvp in baseOverrides)
+            yield return kvp;
+
+        if (customEnvVars is not null)
+        {
+            foreach (var kvp in customEnvVars)
+                yield return kvp;
+        }
     }
 
     private static IntPtr BuildWindowsEnvironmentBlockWithOverrides(IEnumerable<KeyValuePair<string, string>> overrides)

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -95,6 +95,13 @@ public sealed partial class ProcessManager
             session.CopilotSessionName ?? session.CopilotSessionId);
         _logger.LogDebug("copilot {Args}", args);
 
+        if (config.EnvVars is not null && config.EnvVars.Count > 0)
+        {
+            var maskedKeys = string.Join(", ", config.EnvVars.Keys.Select(k => $"{k}=***"));
+            _logger.LogInformation("Injecting {Count} env var(s) into copilot process: {Vars}",
+                config.EnvVars.Count, maskedKeys);
+        }
+
         try
         {
             Process? process;
@@ -209,6 +216,18 @@ public sealed partial class ProcessManager
             }
 
             var alive = !process.HasExited;
+            if (!alive)
+            {
+                var exitCode = GetProcessExitCodeSafe(process);
+                var exitTime = process.ExitTime;
+                var uptime = session.ProcessStartTime is { } start
+                    ? (exitTime - start).TotalSeconds
+                    : -1;
+                _logger.LogInformation(
+                    "Session {Key} PID {Pid} exited (code={ExitCode}, exitTime={ExitTime:F}, uptime={Uptime:F0}s)",
+                    session.IssueKey, pid, exitCode, exitTime, uptime);
+            }
+
             process.Dispose();
             return alive ? ProcessLivenessResult.Alive : ProcessLivenessResult.Dead;
         }
@@ -222,6 +241,12 @@ public sealed partial class ProcessManager
             _logger.LogDebug(ex, "Error checking process {Pid}", pid);
             return ProcessLivenessResult.Dead;
         }
+    }
+
+    static int GetProcessExitCodeSafe(Process p)
+    {
+        try { return p.HasExited ? p.ExitCode : -1; }
+        catch { return -1; }
     }
 
     /// <summary>
@@ -548,6 +573,13 @@ public sealed partial class ProcessManager
         var args = BuildControlSessionArguments(session, prompt, config.DefaultModel, _runtimeContext);
         _logger.LogInformation("Launching control session {SessionName}", session.CopilotSessionName);
         _logger.LogDebug("copilot {Args}", args);
+
+        if (config.EnvVars is not null && config.EnvVars.Count > 0)
+        {
+            var maskedKeys = string.Join(", ", config.EnvVars.Keys.Select(k => $"{k}=***"));
+            _logger.LogInformation("Injecting {Count} env var(s) into control session: {Vars}",
+                config.EnvVars.Count, maskedKeys);
+        }
 
         try
         {

--- a/src/copilotd/Infrastructure/ProcessManager.cs
+++ b/src/copilotd/Infrastructure/ProcessManager.cs
@@ -726,9 +726,11 @@ public sealed partial class ProcessManager
 
             Important:
             - You are on the same branch that was used to create the PR. Your changes will be pushed to the existing PR.
+            - Start by checking the PR's unresolved review threads and the current CI/check status for the PR head SHA.
             - Address each review comment by making the requested changes.
             - If a review comment includes a suggested change (```suggestion block), apply it directly to the relevant file.
             - Stay in terminal/CLI workflows. Do not open browsers or run browser-launching commands such as `open`, `xdg-open`, `start`, `gh ... --web`, `gh browse`, or similar; inspect PR metadata with terminal/API commands such as `gh pr view --json` and `gh api graphql`.
+            - If the PR branch has drifted from its base branch or needs conflict resolution, use this isolated worktree to fetch, rebase, and resolve conflicts before pushing.
             - After addressing all review feedback, push your changes to update the PR.
             - Then run `$(copilotd.command) session pr $(pr.id) $(issue.repo)#$(issue.id)` to continue monitoring for further review feedback.
             - If the changes are complete and no more reviews are expected, run `$(copilotd.command) session complete $(issue.repo)#$(issue.id)` instead.
@@ -761,8 +763,11 @@ public sealed partial class ProcessManager
             - {{branchInstruction}}
             - Focus only on changes relevant to this pull request.
             - Stay in terminal/CLI workflows. Do not open browsers or run browser-launching commands such as `open`, `xdg-open`, `start`, `gh ... --web`, `gh browse`, or similar; inspect PR metadata with terminal/API commands such as `gh pr view --json` and `gh api`.
+            - Start by checking unresolved review threads and the current CI/check status for the PR head SHA.
+            - If the branch needs rebasing or conflict resolution against the base branch, do that work in this isolated worktree before pushing.
             - If you need clarification, run `$(copilotd.command) session comment $(issue.repo)#$(pr.id) --message "Your question or findings here"`.
-            - When the work is complete, run `$(copilotd.command) session complete $(issue.repo)#$(pr.id)`.
+            - When you have handled the current actionable work and want copilotd to keep monitoring this PR, run `$(copilotd.command) session pr $(pr.id) $(issue.repo)#$(pr.id)`.
+            - Only run `$(copilotd.command) session complete $(issue.repo)#$(pr.id)` if the PR is closed, merged, or should stop being monitored.
             """;
     }
 
@@ -776,15 +781,17 @@ public sealed partial class ProcessManager
         };
 
         return $$"""
-            You are resuming work on pull request #$(pr.id) in the $(issue.repo) repository because new PR feedback or commits were detected.
-            Read the new PR comments, review feedback, and current diff carefully.
+            You are resuming work on pull request #$(pr.id) in the $(issue.repo) repository because new PR feedback, unresolved review threads, failing CI, or new commits were detected.
+            Read the new PR comments, review feedback, current CI/check status, and current diff carefully.
 
             Important:
             - {{branchInstruction}}
-            - Focus on the new PR feedback or new commits since the previous dispatch.
+            - Focus on the new PR feedback, failing CI, unresolved review threads, or new commits since the previous dispatch.
             - Stay in terminal/CLI workflows. Do not open browsers or run browser-launching commands such as `open`, `xdg-open`, `start`, `gh ... --web`, `gh browse`, or similar; inspect PR metadata with terminal/API commands such as `gh pr view --json` and `gh api`.
+            - If the branch needs rebasing or conflict resolution against the base branch, do that work in this isolated worktree before pushing.
             - If you need more clarification, run `$(copilotd.command) session comment $(issue.repo)#$(pr.id) --message "Your question or findings here"`.
-            - When the work is complete, run `$(copilotd.command) session complete $(issue.repo)#$(pr.id)`.
+            - When you have handled the current actionable work and want copilotd to keep monitoring this PR, run `$(copilotd.command) session pr $(pr.id) $(issue.repo)#$(pr.id)`.
+            - Only run `$(copilotd.command) session complete $(issue.repo)#$(pr.id)` if the PR is closed, merged, or should stop being monitored.
             """;
     }
 

--- a/src/copilotd/Models/CopilotdConfig.cs
+++ b/src/copilotd/Models/CopilotdConfig.cs
@@ -412,6 +412,24 @@ public abstract class DispatchRuleOptions
     /// to the global <see cref="CopilotdConfig.EnableReactions"/> setting.
     /// </summary>
     public bool? EnableReactions { get; set; }
+
+    /// <summary>
+    /// Optional local-hour start for this rule's dispatch window (0-23).
+    /// When both start and end are set, pending sessions only dispatch inside the window.
+    /// </summary>
+    public int? ActiveStartHour { get; set; }
+
+    /// <summary>
+    /// Optional local-hour end for this rule's dispatch window (0-23).
+    /// Windows that cross midnight are supported.
+    /// </summary>
+    public int? ActiveEndHour { get; set; }
+
+    /// <summary>
+    /// Time zone used with <see cref="ActiveStartHour"/> and <see cref="ActiveEndHour"/>,
+    /// for example <c>America/Chicago</c>.
+    /// </summary>
+    public string? ActiveTimeZone { get; set; }
 }
 
 /// <summary>

--- a/src/copilotd/Models/CopilotdConfig.cs
+++ b/src/copilotd/Models/CopilotdConfig.cs
@@ -98,6 +98,13 @@ public sealed class CopilotdConfig
     /// </summary>
     public Dictionary<string, PullRequestDispatchRule> PullRequestRules { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>
+    /// Custom environment variables to pass to copilot CLI processes launched by copilotd.
+    /// The environment starts as a copy of the current process environment, then these values
+    /// are merged on top. Example: { "COPILIT_MODEL": "local", "COPILIT_API_URL": "http://localhost:8080" }.
+    /// </summary>
+    public Dictionary<string, string>? EnvVars { get; set; }
+
     public const string DefaultRuleName = "Default";
 
     /// <summary>

--- a/src/copilotd/Models/SessionState.cs
+++ b/src/copilotd/Models/SessionState.cs
@@ -267,6 +267,24 @@ public sealed class DispatchSession
     public PullRequestBranchStrategy? PullRequestBranchStrategy { get; set; }
 
     /// <summary>
+    /// Review thread IDs that have already been observed in an unresolved state for this session.
+    /// Used to wake the session only when new unresolved review threads appear.
+    /// </summary>
+    public List<string> SeenUnresolvedReviewThreadIds { get; set; } = [];
+
+    /// <summary>
+    /// True once copilotd has captured the initial unresolved-review-thread baseline for this session.
+    /// This distinguishes "no unresolved threads yet" from "baseline not captured yet".
+    /// </summary>
+    public bool HasEstablishedUnresolvedReviewThreadBaseline { get; set; }
+
+    /// <summary>
+    /// The PR head SHA for which copilotd most recently queued a redispatch because CI was failing.
+    /// Used to avoid repeatedly waking on the same failing head revision.
+    /// </summary>
+    public string? LastTriggeredFailingChecksHeadSha { get; set; }
+
+    /// <summary>
     /// Number of times this session has been re-dispatched via comment/review feedback loops.
     /// Used to enforce <see cref="CopilotdConfig.MaxRedispatches"/> and prevent unbounded loops.
     /// </summary>

--- a/src/copilotd/Services/GhCliService.cs
+++ b/src/copilotd/Services/GhCliService.cs
@@ -603,6 +603,20 @@ public sealed class GhCliService
     public sealed record NewCommentInfo(string Author, DateTimeOffset CreatedAt, long? IssueCommentId = null);
 
     /// <summary>
+    /// Snapshot of a PR review thread used to detect newly unresolved threads.
+    /// </summary>
+    public sealed record PullRequestReviewThreadInfo(
+        string ThreadId,
+        bool IsResolved,
+        string LatestCommentAuthor,
+        DateTimeOffset? LatestCommentCreatedAt);
+
+    /// <summary>
+    /// Summary of failing CI checks for the current PR head SHA.
+    /// </summary>
+    public sealed record PullRequestFailingChecksInfo(string HeadSha, IReadOnlyList<string> FailingChecks);
+
+    /// <summary>
     /// Checks whether there are new comments on an issue since the given timestamp,
     /// excluding comments posted by copilotd itself (identified by the hidden copilotd marker).
     /// </summary>
@@ -929,6 +943,263 @@ public sealed class GhCliService
     }
 
     /// <summary>
+    /// Gets the current review thread snapshot for a pull request.
+    /// Returns null when the snapshot cannot be queried.
+    /// </summary>
+    public List<PullRequestReviewThreadInfo>? GetPullRequestReviewThreads(string repo, int prNumber)
+    {
+        var repoParts = repo.Split('/', 2);
+        if (repoParts.Length != 2)
+            return null;
+
+        var request = new JsonObject
+        {
+            ["query"] = """
+                query($owner: String!, $name: String!, $number: Int!) {
+                  repository(owner: $owner, name: $name) {
+                    pullRequest(number: $number) {
+                      reviewThreads(first: 100) {
+                        nodes {
+                          id
+                          isResolved
+                          comments(last: 1) {
+                            nodes {
+                              createdAt
+                              author {
+                                login
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                """,
+            ["variables"] = new JsonObject
+            {
+                ["owner"] = repoParts[0],
+                ["name"] = repoParts[1],
+                ["number"] = prNumber,
+            },
+        };
+
+        var (exitCode, output) = RunGhWithStdin("api graphql --input -", request.ToJsonString());
+        if (exitCode != 0)
+        {
+            _logger.LogWarning("Failed to query PR review threads on {Repo}!{Pr}: {Output}", repo, prNumber, output);
+            return null;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(output);
+            if (doc.RootElement.TryGetProperty("errors", out var errors))
+            {
+                _logger.LogWarning("GraphQL errors querying PR review threads on {Repo}!{Pr}: {Errors}", repo, prNumber, errors.ToString());
+                return null;
+            }
+
+            if (!doc.RootElement.TryGetProperty("data", out var data)
+                || !data.TryGetProperty("repository", out var repository)
+                || !repository.TryGetProperty("pullRequest", out var pullRequest)
+                || !pullRequest.TryGetProperty("reviewThreads", out var reviewThreads)
+                || !reviewThreads.TryGetProperty("nodes", out var threadNodes))
+            {
+                return [];
+            }
+
+            var result = new List<PullRequestReviewThreadInfo>();
+            foreach (var thread in threadNodes.EnumerateArray())
+            {
+                if (!thread.TryGetProperty("id", out var idEl))
+                    continue;
+
+                var threadId = idEl.GetString();
+                if (string.IsNullOrWhiteSpace(threadId))
+                    continue;
+
+                var isResolved = thread.TryGetProperty("isResolved", out var resolvedEl)
+                    && resolvedEl.ValueKind is JsonValueKind.True or JsonValueKind.False
+                    && resolvedEl.GetBoolean();
+
+                var latestAuthor = "unknown";
+                DateTimeOffset? latestCreatedAt = null;
+                if (thread.TryGetProperty("comments", out var comments)
+                    && comments.TryGetProperty("nodes", out var commentNodes))
+                {
+                    foreach (var comment in commentNodes.EnumerateArray())
+                    {
+                        if (comment.TryGetProperty("author", out var author)
+                            && author.TryGetProperty("login", out var login))
+                        {
+                            latestAuthor = login.GetString() ?? "unknown";
+                        }
+
+                        if (comment.TryGetProperty("createdAt", out var createdAtEl)
+                            && DateTimeOffset.TryParse(createdAtEl.GetString(), out var createdAt))
+                        {
+                            latestCreatedAt = createdAt;
+                        }
+                    }
+                }
+
+                result.Add(new PullRequestReviewThreadInfo(threadId, isResolved, latestAuthor, latestCreatedAt));
+            }
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse PR review threads JSON for {Repo}!{Pr}", repo, prNumber);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Gets the current failing CI checks for the pull request's head SHA.
+    /// Returns null if there are no failing checks or the status cannot be queried.
+    /// </summary>
+    public PullRequestFailingChecksInfo? GetPullRequestFailingChecks(string repo, int prNumber)
+    {
+        var repoParts = repo.Split('/', 2);
+        if (repoParts.Length != 2)
+            return null;
+
+        var request = new JsonObject
+        {
+            ["query"] = """
+                query($owner: String!, $name: String!, $number: Int!) {
+                  repository(owner: $owner, name: $name) {
+                    pullRequest(number: $number) {
+                      headRefOid
+                      commits(last: 1) {
+                        nodes {
+                          commit {
+                            statusCheckRollup {
+                              contexts(first: 100) {
+                                nodes {
+                                  __typename
+                                  ... on CheckRun {
+                                    name
+                                    conclusion
+                                    status
+                                  }
+                                  ... on StatusContext {
+                                    context
+                                    state
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                """,
+            ["variables"] = new JsonObject
+            {
+                ["owner"] = repoParts[0],
+                ["name"] = repoParts[1],
+                ["number"] = prNumber,
+            },
+        };
+
+        var (exitCode, output) = RunGhWithStdin("api graphql --input -", request.ToJsonString());
+        if (exitCode != 0)
+        {
+            _logger.LogWarning("Failed to query PR checks on {Repo}!{Pr}: {Output}", repo, prNumber, output);
+            return null;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(output);
+            if (doc.RootElement.TryGetProperty("errors", out var errors))
+            {
+                _logger.LogWarning("GraphQL errors querying PR checks on {Repo}!{Pr}: {Errors}", repo, prNumber, errors.ToString());
+                return null;
+            }
+
+            if (!doc.RootElement.TryGetProperty("data", out var data)
+                || !data.TryGetProperty("repository", out var repository)
+                || !repository.TryGetProperty("pullRequest", out var pullRequest))
+            {
+                return null;
+            }
+
+            var headSha = pullRequest.TryGetProperty("headRefOid", out var headRefOidEl)
+                ? headRefOidEl.GetString()
+                : null;
+
+            if (string.IsNullOrWhiteSpace(headSha)
+                || !pullRequest.TryGetProperty("commits", out var commits)
+                || !commits.TryGetProperty("nodes", out var commitNodes))
+            {
+                return null;
+            }
+
+            var failingChecks = new List<string>();
+            foreach (var commitNode in commitNodes.EnumerateArray())
+            {
+                if (!commitNode.TryGetProperty("commit", out var commit)
+                    || !commit.TryGetProperty("statusCheckRollup", out var rollup)
+                    || rollup.ValueKind == JsonValueKind.Null
+                    || !rollup.TryGetProperty("contexts", out var contexts)
+                    || !contexts.TryGetProperty("nodes", out var contextNodes))
+                {
+                    continue;
+                }
+
+                foreach (var contextNode in contextNodes.EnumerateArray())
+                {
+                    if (!contextNode.TryGetProperty("__typename", out var typeEl))
+                        continue;
+
+                    var typeName = typeEl.GetString();
+                    if (typeName == "CheckRun")
+                    {
+                        var conclusion = contextNode.TryGetProperty("conclusion", out var conclusionEl)
+                            ? conclusionEl.GetString()
+                            : null;
+                        if (conclusion is null || !IsFailingCheckRunConclusion(conclusion))
+                            continue;
+
+                        var name = contextNode.TryGetProperty("name", out var nameEl)
+                            ? nameEl.GetString()
+                            : "check run";
+                        failingChecks.Add(name ?? "check run");
+                    }
+                    else if (typeName == "StatusContext")
+                    {
+                        var state = contextNode.TryGetProperty("state", out var stateEl)
+                            ? stateEl.GetString()
+                            : null;
+                        if (state is null || !IsFailingStatusContextState(state))
+                            continue;
+
+                        var name = contextNode.TryGetProperty("context", out var contextEl)
+                            ? contextEl.GetString()
+                            : "status";
+                        failingChecks.Add(name ?? "status");
+                    }
+                }
+            }
+
+            return failingChecks.Count == 0
+                ? null
+                : new PullRequestFailingChecksInfo(headSha!, failingChecks);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse PR checks JSON for {Repo}!{Pr}", repo, prNumber);
+            return null;
+        }
+    }
+
+    /// <summary>
     /// Gets the current state of a pull request (e.g., OPEN, CLOSED, MERGED).
     /// Returns null if the PR state cannot be determined.
     /// </summary>
@@ -994,6 +1265,12 @@ public sealed class GhCliService
         => body is not null
            && (body.Contains(CommentMarkerPrefix, StringComparison.Ordinal)
                || body.Contains(LegacyCommentMarker, StringComparison.Ordinal));
+
+    private static bool IsFailingCheckRunConclusion(string conclusion)
+        => conclusion is "FAILURE" or "TIMED_OUT" or "ACTION_REQUIRED" or "CANCELLED" or "STARTUP_FAILURE";
+
+    private static bool IsFailingStatusContextState(string state)
+        => state is "ERROR" or "FAILURE";
 
     // Reaction content constants for GitHub issue reactions
     internal const string ReactionEyes = "eyes";

--- a/src/copilotd/Services/ReconciliationEngine.cs
+++ b/src/copilotd/Services/ReconciliationEngine.cs
@@ -161,7 +161,8 @@ public sealed class ReconciliationEngine
                     break;
 
                 case ProcessLivenessResult.Dead:
-                    _logger.LogInformation("Session {Key} PID {Pid} is dead, marking orphaned", key, session.ProcessId);
+                    var hookCtx = session.LastHookEvent is { } he ? $" (lastHook={he}/{session.LastHookDetail})" : "";
+                    _logger.LogInformation("Session {Key} PID {Pid} is dead, marking orphaned{Ctx}", key, session.ProcessId, hookCtx);
                     session.Status = SessionStatus.Orphaned;
                     session.FailureDetail = null;
                     session.UpdatedAt = DateTimeOffset.UtcNow;
@@ -547,7 +548,9 @@ public sealed class ReconciliationEngine
                     case SessionStatus.Failed:
                         if (!existing.CanRetry)
                         {
-                            _logger.LogWarning("Session {Key} exceeded max retries, marking failed", issueKey);
+                            _logger.LogWarning(
+                                "Session {Key} exceeded max retries, marking failed (lastHook={Hook}, reason={Detail})",
+                                issueKey, existing.LastHookEvent, existing.LastHookDetail);
                             existing.Status = SessionStatus.Failed;
                             existing.FailureDetail ??= $"The session exceeded the maximum retry count ({DispatchSession.MaxRetries}). " +
                                 $"Resolve the underlying issue, then run 'copilotd session reset {issueKey}'.";

--- a/src/copilotd/Services/ReconciliationEngine.cs
+++ b/src/copilotd/Services/ReconciliationEngine.cs
@@ -492,49 +492,14 @@ public sealed class ReconciliationEngine
                                 var reviewInfo = _ghCli.GetNewPrReviewCommentSince(existing.Repo, existing.PullRequestNumber.Value, existing.WaitingSince.Value);
                                 if (reviewInfo is not null)
                                 {
-                                    // Check re-dispatch rate limit
-                                    if (existing.RedispatchCount >= config.MaxRedispatches)
-                                    {
-                                        _logger.LogWarning("Session {Key} has reached the maximum re-dispatch limit ({Max}). " +
-                                            "Use 'copilotd session reset' to re-enable. Ignoring PR review from {Author}",
-                                            issueKey, config.MaxRedispatches, reviewInfo.Author);
+                                    if (!TryQueueFeedbackRedispatch(existing, issueKey, reviewInfo, config, isIssueComment: false))
                                         continue;
-                                    }
-
-                                    // Check author trust level
-                                    var trusted = IsCommentTrusted(existing, reviewInfo.Author, config, out var trustLevel);
-
-                                    if (trusted is null)
-                                    {
-                                        _logger.LogWarning("Could not evaluate trust for {Author} on {Key} (trust_level={TrustLevel}), will retry next cycle",
-                                            reviewInfo.Author, issueKey, trustLevel);
-                                        continue;
-                                    }
-
-                                    if (trusted == false)
-                                    {
-                                        _logger.LogInformation("Ignoring PR review from untrusted author {Author} on {Key} (trust_level={TrustLevel})",
-                                            reviewInfo.Author, issueKey, trustLevel);
-                                        // Advance WaitingSince past this review so the next poll can find later trusted reviews
-                                        existing.WaitingSince = reviewInfo.CreatedAt;
-                                        existing.UpdatedAt = DateTimeOffset.UtcNow;
-                                        continue;
-                                    }
-
-                                    _logger.LogInformation("New PR review from {Author} detected on PR #{Pr} for {Key}, re-dispatching session (redispatch {N}/{Max})",
-                                        reviewInfo.Author, existing.PullRequestNumber, issueKey, existing.RedispatchCount + 1, config.MaxRedispatches);
-                                    // Keep the same resume target so --resume preserves context
-                                    existing.Status = SessionStatus.Pending;
-                                    existing.FailureDetail = null;
-                                    existing.RedispatchCount++;
-                                    existing.LastRedispatchWasIssueComment = false;
-                                    existing.WaitingSince = null;
-                                    existing.ProcessId = null;
-                                    existing.ProcessStartTime = null;
-                                    existing.UpdatedAt = DateTimeOffset.UtcNow;
                                     continue;
                                 }
                             }
+
+                            if (TryQueuePullRequestMonitoringRedispatch(existing, issueKey, existing.PullRequestNumber.Value, config))
+                                continue;
                         }
 
                         // Also check for new issue comments (maintainer may respond on the issue)
@@ -543,49 +508,9 @@ public sealed class ReconciliationEngine
                             var issueCommentInfo = _ghCli.GetNewCommentSince(existing.Repo, existing.IssueNumber, existing.WaitingSince.Value);
                             if (issueCommentInfo is not null)
                             {
-                                // Check re-dispatch rate limit
-                                if (existing.RedispatchCount >= config.MaxRedispatches)
-                                {
-                                    _logger.LogWarning("Session {Key} has reached the maximum re-dispatch limit ({Max}). " +
-                                        "Use 'copilotd session reset' to re-enable. Ignoring issue comment from {Author}",
-                                        issueKey, config.MaxRedispatches, issueCommentInfo.Author);
+                                if (!TryQueueFeedbackRedispatch(existing, issueKey, issueCommentInfo, config, isIssueComment: true))
                                     continue;
-                                }
-
-                                // Check author trust level
-                                var trusted = IsCommentTrusted(existing, issueCommentInfo.Author, config, out var trustLevel);
-
-                                if (trusted is null)
-                                {
-                                    _logger.LogWarning("Could not evaluate trust for {Author} on {Key} (trust_level={TrustLevel}), will retry next cycle",
-                                        issueCommentInfo.Author, issueKey, trustLevel);
-                                    continue;
-                                }
-
-                                if (trusted == false)
-                                {
-                                    _logger.LogInformation("Ignoring issue comment from untrusted author {Author} on {Key} while waiting for PR review (trust_level={TrustLevel})",
-                                        issueCommentInfo.Author, issueKey, trustLevel);
-                                    // Advance WaitingSince past this comment so the next poll can find later trusted comments
-                                    existing.WaitingSince = issueCommentInfo.CreatedAt;
-                                    existing.UpdatedAt = DateTimeOffset.UtcNow;
-                                    continue;
-                                }
-
-                                _logger.LogInformation("New issue comment from {Author} detected on {Key} while waiting for PR review, re-dispatching session (redispatch {N}/{Max})",
-                                    issueCommentInfo.Author, issueKey, existing.RedispatchCount + 1, config.MaxRedispatches);
-                                existing.Status = SessionStatus.Pending;
-                                existing.FailureDetail = null;
-                                existing.RedispatchCount++;
-                                existing.LastRedispatchWasIssueComment = true;
-                                existing.WaitingSince = null;
-                                existing.ProcessId = null;
-                                existing.ProcessStartTime = null;
-                                existing.UpdatedAt = DateTimeOffset.UtcNow;
-                                if (issueCommentInfo.IssueCommentId.HasValue)
-                                    TransitionReactionToIssueComment(existing, config, issueCommentInfo.IssueCommentId.Value, GhCliService.ReactionEyes);
-                                else
-                                    TransitionReactionToIssue(existing, config, GhCliService.ReactionEyes);
+                                continue;
                             }
                             else
                             {
@@ -604,6 +529,9 @@ public sealed class ReconciliationEngine
                         existing.PullRequestNumber = null;
                         existing.RedispatchCount = 0;
                         existing.LastRedispatchWasIssueComment = false;
+                        existing.SeenUnresolvedReviewThreadIds = [];
+                        existing.HasEstablishedUnresolvedReviewThreadBaseline = false;
+                        existing.LastTriggeredFailingChecksHeadSha = null;
                         existing.CopilotSessionId = Guid.NewGuid().ToString();
                         existing.CopilotSessionName = null;
                         existing.HasStarted = false;
@@ -644,6 +572,9 @@ public sealed class ReconciliationEngine
                         existing.PullRequestNumber = null;
                         existing.RedispatchCount = 0;
                         existing.LastRedispatchWasIssueComment = false;
+                        existing.SeenUnresolvedReviewThreadIds = [];
+                        existing.HasEstablishedUnresolvedReviewThreadBaseline = false;
+                        existing.LastTriggeredFailingChecksHeadSha = null;
                         existing.CopilotSessionId = Guid.NewGuid().ToString();
                         existing.CopilotSessionName = null;
                         existing.HasStarted = false;
@@ -706,12 +637,15 @@ public sealed class ReconciliationEngine
                             {
                                 if (!TryQueueFeedbackRedispatch(existing, prKey, feedbackInfo, config, isIssueComment: false))
                                     continue;
-                            }
-                            else
-                            {
-                                _logger.LogDebug("PR-root session {Key} still waiting for feedback", prKey);
+
+                                continue;
                             }
                         }
+
+                        if (TryQueuePullRequestMonitoringRedispatch(existing, prKey, existing.SubjectNumber, config))
+                            continue;
+
+                        _logger.LogDebug("PR-root session {Key} still waiting for feedback", prKey);
                         continue;
 
                     case SessionStatus.Orphaned when existing.CanRetry:
@@ -741,6 +675,9 @@ public sealed class ReconciliationEngine
                         if (existing.CompletedBySession
                             && string.Equals(existing.PullRequestHeadSha, pullRequest.HeadSha, StringComparison.OrdinalIgnoreCase))
                         {
+                            if (TryQueuePullRequestMonitoringRedispatch(existing, prKey, existing.SubjectNumber, config))
+                                continue;
+
                             _logger.LogDebug("PR-root session {Key} was explicitly completed and head SHA did not change, skipping re-dispatch", prKey);
                             continue;
                         }
@@ -810,6 +747,135 @@ public sealed class ReconciliationEngine
         session.UpdatedAt = DateTimeOffset.UtcNow;
     }
 
+    private bool TryQueuePullRequestMonitoringRedispatch(
+        DispatchSession session,
+        string sessionKey,
+        int prNumber,
+        CopilotdConfig config)
+    {
+        if (TryQueueNewUnresolvedReviewThreadRedispatch(session, sessionKey, prNumber, config))
+            return true;
+
+        return TryQueueFailingChecksRedispatch(session, sessionKey, prNumber, config);
+    }
+
+    private bool TryQueueNewUnresolvedReviewThreadRedispatch(
+        DispatchSession session,
+        string sessionKey,
+        int prNumber,
+        CopilotdConfig config)
+    {
+        var reviewThreads = _ghCli.GetPullRequestReviewThreads(session.Repo, prNumber);
+        if (reviewThreads is null)
+            return false;
+
+        var unresolvedThreads = reviewThreads
+            .Where(thread => !thread.IsResolved)
+            .ToList();
+
+        if (!session.HasEstablishedUnresolvedReviewThreadBaseline)
+        {
+            session.HasEstablishedUnresolvedReviewThreadBaseline = true;
+            if (session.Status is SessionStatus.WaitingForReview or SessionStatus.WaitingForFeedback)
+            {
+                session.SeenUnresolvedReviewThreadIds = unresolvedThreads
+                    .Select(thread => thread.ThreadId)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+                session.UpdatedAt = DateTimeOffset.UtcNow;
+
+                if (unresolvedThreads.Count > 0)
+                {
+                    _logger.LogDebug("Initialized unresolved review thread baseline for {Key} on PR #{Pr} with {Count} thread(s)",
+                        sessionKey, prNumber, unresolvedThreads.Count);
+                }
+
+                return false;
+            }
+        }
+
+        var seenThreadIds = new HashSet<string>(session.SeenUnresolvedReviewThreadIds, StringComparer.OrdinalIgnoreCase);
+        var unseenThreads = unresolvedThreads
+            .Where(thread => !seenThreadIds.Contains(thread.ThreadId))
+            .OrderByDescending(thread => thread.LatestCommentCreatedAt ?? DateTimeOffset.MinValue)
+            .ToList();
+
+        if (unseenThreads.Count == 0)
+            return false;
+
+        if (session.RedispatchCount >= config.MaxRedispatches)
+        {
+            session.SeenUnresolvedReviewThreadIds = session.SeenUnresolvedReviewThreadIds
+                .Concat(unseenThreads.Select(thread => thread.ThreadId))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            session.UpdatedAt = DateTimeOffset.UtcNow;
+
+            _logger.LogWarning("Session {Key} has reached the maximum re-dispatch limit ({Max}). " +
+                "Ignoring {Count} new unresolved review thread(s) on PR #{Pr}",
+                sessionKey, config.MaxRedispatches, unseenThreads.Count, prNumber);
+            return false;
+        }
+
+        var newestThread = unseenThreads[0];
+        var trusted = IsCommentTrusted(session, newestThread.LatestCommentAuthor, config, out var trustLevel);
+        if (trusted is null)
+        {
+            _logger.LogWarning("Could not evaluate trust for unresolved review thread author {Author} on {Key} (trust_level={TrustLevel}), will retry next cycle",
+                newestThread.LatestCommentAuthor, sessionKey, trustLevel);
+            return false;
+        }
+
+        session.SeenUnresolvedReviewThreadIds = session.SeenUnresolvedReviewThreadIds
+            .Concat(unseenThreads.Select(thread => thread.ThreadId))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        session.UpdatedAt = DateTimeOffset.UtcNow;
+
+        if (trusted == false)
+        {
+            _logger.LogInformation("Ignoring {Count} new unresolved review thread(s) from untrusted author {Author} on {Key} (trust_level={TrustLevel})",
+                unseenThreads.Count, newestThread.LatestCommentAuthor, sessionKey, trustLevel);
+            return false;
+        }
+
+        _logger.LogInformation("Detected {Count} new unresolved review thread(s) on PR #{Pr} for {Key}, re-dispatching session (redispatch {N}/{Max})",
+            unseenThreads.Count, prNumber, sessionKey, session.RedispatchCount + 1, config.MaxRedispatches);
+        QueueSessionRedispatch(session, config, isIssueComment: false);
+        return true;
+    }
+
+    private bool TryQueueFailingChecksRedispatch(
+        DispatchSession session,
+        string sessionKey,
+        int prNumber,
+        CopilotdConfig config)
+    {
+        var failingChecks = _ghCli.GetPullRequestFailingChecks(session.Repo, prNumber);
+        if (failingChecks is null
+            || string.Equals(session.LastTriggeredFailingChecksHeadSha, failingChecks.HeadSha, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        session.LastTriggeredFailingChecksHeadSha = failingChecks.HeadSha;
+        session.UpdatedAt = DateTimeOffset.UtcNow;
+
+        if (session.RedispatchCount >= config.MaxRedispatches)
+        {
+            _logger.LogWarning("Session {Key} has reached the maximum re-dispatch limit ({Max}). " +
+                "Ignoring failing CI on PR #{Pr} for head {HeadSha}",
+                sessionKey, config.MaxRedispatches, prNumber, failingChecks.HeadSha);
+            return false;
+        }
+
+        _logger.LogInformation("Detected failing CI on PR #{Pr} for {Key} at head {HeadSha}, re-dispatching session (redispatch {N}/{Max}). Failing checks: {Checks}",
+            prNumber, sessionKey, failingChecks.HeadSha, session.RedispatchCount + 1, config.MaxRedispatches,
+            string.Join(", ", failingChecks.FailingChecks));
+        QueueSessionRedispatch(session, config, isIssueComment: false);
+        return true;
+    }
+
     private bool TryQueueFeedbackRedispatch(
         DispatchSession session,
         string sessionKey,
@@ -844,6 +910,17 @@ public sealed class ReconciliationEngine
 
         _logger.LogInformation("New feedback from {Author} detected on {Key}, re-dispatching session (redispatch {N}/{Max})",
             commentInfo.Author, sessionKey, session.RedispatchCount + 1, config.MaxRedispatches);
+        QueueSessionRedispatch(session, config, isIssueComment, commentInfo.IssueCommentId);
+
+        return true;
+    }
+
+    private void QueueSessionRedispatch(
+        DispatchSession session,
+        CopilotdConfig config,
+        bool isIssueComment,
+        long? issueCommentId = null)
+    {
         session.Status = SessionStatus.Pending;
         session.FailureDetail = null;
         session.RedispatchCount++;
@@ -853,12 +930,12 @@ public sealed class ReconciliationEngine
         session.ProcessStartTime = null;
         session.UpdatedAt = DateTimeOffset.UtcNow;
 
-        if (isIssueComment && commentInfo.IssueCommentId.HasValue)
-            TransitionReactionToIssueComment(session, config, commentInfo.IssueCommentId.Value, GhCliService.ReactionEyes);
+        if (isIssueComment && issueCommentId.HasValue)
+            TransitionReactionToIssueComment(session, config, issueCommentId.Value, GhCliService.ReactionEyes);
+        else if (isIssueComment)
+            TransitionReactionToIssue(session, config, GhCliService.ReactionEyes);
         else
             TransitionReactionOnCurrentAnchor(session, config, GhCliService.ReactionEyes);
-
-        return true;
     }
 
     private static void ResetForFreshDispatch(DispatchSession session, bool preserveReviewPullRequest)
@@ -870,6 +947,9 @@ public sealed class ReconciliationEngine
             session.PullRequestNumber = null;
         session.RedispatchCount = 0;
         session.LastRedispatchWasIssueComment = false;
+        session.SeenUnresolvedReviewThreadIds = [];
+        session.HasEstablishedUnresolvedReviewThreadBaseline = false;
+        session.LastTriggeredFailingChecksHeadSha = null;
         session.CopilotSessionId = Guid.NewGuid().ToString();
         session.CopilotSessionName = null;
         session.HasStarted = false;
@@ -887,22 +967,28 @@ public sealed class ReconciliationEngine
     {
         var runningCount = state.Sessions.Values.Count(s => s.Status == SessionStatus.Running);
         var availableSlots = Math.Max(0, config.MaxInstances - runningCount);
+        var nowUtc = DateTimeOffset.UtcNow;
 
         var pending = state.Sessions.Values
             .Where(s => s.Status == SessionStatus.Pending)
             .Where(s => !IsInBackoffWindow(s))
+            .ToList();
+
+        var dispatchablePending = pending
+            .Where(s => IsWithinDispatchWindow(s, config, nowUtc))
             .OrderBy(s => s.CreatedAt)
             .ToList();
 
-        if (pending.Count > 0 && availableSlots == 0)
+        if (dispatchablePending.Count > 0 && availableSlots == 0)
         {
             _logger.LogInformation("{Count} session(s) queued but max instances ({Max}) reached",
-                pending.Count, config.MaxInstances);
+                dispatchablePending.Count, config.MaxInstances);
             return;
         }
 
-        var toDispatch = pending.Take(availableSlots).ToList();
-        var skippedByLimit = pending.Count - toDispatch.Count;
+        var toDispatch = dispatchablePending.Take(availableSlots).ToList();
+        var skippedByLimit = dispatchablePending.Count - toDispatch.Count;
+        var skippedBySchedule = pending.Count - dispatchablePending.Count;
 
         foreach (var session in toDispatch)
         {
@@ -994,6 +1080,11 @@ public sealed class ReconciliationEngine
         {
             _logger.LogInformation("{Count} session(s) still queued, waiting for instance slots", skippedByLimit);
         }
+
+        if (skippedBySchedule > 0)
+        {
+            _logger.LogInformation("{Count} session(s) remain queued until their dispatch window opens", skippedBySchedule);
+        }
     }
 
     /// <summary>
@@ -1069,6 +1160,82 @@ public sealed class ReconciliationEngine
         }
     }
 
+    private bool IsWithinDispatchWindow(DispatchSession session, CopilotdConfig config, DateTimeOffset nowUtc)
+    {
+        var ruleOptions = GetDispatchRuleOptions(config, session);
+        if (ruleOptions is null
+            || (!ruleOptions.ActiveStartHour.HasValue && !ruleOptions.ActiveEndHour.HasValue))
+        {
+            return true;
+        }
+
+        if (!ruleOptions.ActiveStartHour.HasValue
+            || !ruleOptions.ActiveEndHour.HasValue
+            || string.IsNullOrWhiteSpace(ruleOptions.ActiveTimeZone))
+        {
+            _logger.LogWarning("Ignoring incomplete active dispatch window on rule '{Rule}' for {Key}", session.RuleName, session.SubjectKey);
+            return true;
+        }
+
+        if (ruleOptions.ActiveStartHour is < 0 or > 23
+            || ruleOptions.ActiveEndHour is < 0 or > 23)
+        {
+            _logger.LogWarning("Ignoring invalid active dispatch window hours on rule '{Rule}' for {Key}: start={Start}, end={End}",
+                session.RuleName, session.SubjectKey, ruleOptions.ActiveStartHour, ruleOptions.ActiveEndHour);
+            return true;
+        }
+
+        if (!TryResolveTimeZone(ruleOptions.ActiveTimeZone, out var timeZone))
+        {
+            _logger.LogWarning("Ignoring active dispatch window on rule '{Rule}' for {Key}: unknown time zone '{TimeZone}'",
+                session.RuleName, session.SubjectKey, ruleOptions.ActiveTimeZone);
+            return true;
+        }
+
+        var localNow = TimeZoneInfo.ConvertTime(nowUtc, timeZone);
+        var currentHour = localNow.Hour;
+        var startHour = ruleOptions.ActiveStartHour.Value;
+        var endHour = ruleOptions.ActiveEndHour.Value;
+
+        if (startHour == endHour)
+            return true;
+
+        return startHour < endHour
+            ? currentHour >= startHour && currentHour < endHour
+            : currentHour >= startHour || currentHour < endHour;
+    }
+
+    private static bool TryResolveTimeZone(string timeZoneId, out TimeZoneInfo timeZone)
+    {
+        try
+        {
+            timeZone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+            return true;
+        }
+        catch (TimeZoneNotFoundException)
+        {
+            if (OperatingSystem.IsWindows()
+                && TimeZoneInfo.TryConvertIanaIdToWindowsId(timeZoneId, out var windowsId))
+            {
+                timeZone = TimeZoneInfo.FindSystemTimeZoneById(windowsId);
+                return true;
+            }
+
+            if (!OperatingSystem.IsWindows()
+                && TimeZoneInfo.TryConvertWindowsIdToIanaId(timeZoneId, out var ianaId))
+            {
+                timeZone = TimeZoneInfo.FindSystemTimeZoneById(ianaId);
+                return true;
+            }
+        }
+        catch (InvalidTimeZoneException)
+        {
+        }
+
+        timeZone = TimeZoneInfo.Utc;
+        return false;
+    }
+
     private static void MarkSessionFailed(DispatchSession session, string detail)
     {
         session.Status = SessionStatus.Failed;
@@ -1112,14 +1279,17 @@ public sealed class ReconciliationEngine
     /// </summary>
     private static bool AreReactionsEnabled(CopilotdConfig config, DispatchSession session)
     {
-        var ruleOptions = session.SubjectKind == DispatchSubjectKind.PullRequest
-            ? (DispatchRuleOptions?)config.PullRequestRules.GetValueOrDefault(session.RuleName)
-            : config.IssueRules.GetValueOrDefault(session.RuleName);
+        var ruleOptions = GetDispatchRuleOptions(config, session);
         if (ruleOptions?.EnableReactions is { } enableReactions)
             return enableReactions;
 
         return config.EnableReactions;
     }
+
+    private static DispatchRuleOptions? GetDispatchRuleOptions(CopilotdConfig config, DispatchSession session)
+        => session.SubjectKind == DispatchSubjectKind.PullRequest
+            ? config.PullRequestRules.GetValueOrDefault(session.RuleName)
+            : config.IssueRules.GetValueOrDefault(session.RuleName);
 
     /// <summary>
     /// Transitions the lifecycle reaction while keeping the current anchor.


### PR DESCRIPTION
## Summary
- wake PR sessions when newly unresolved review threads appear or the current head SHA first enters a failing CI state
- allow PR-root sessions that return to `session pr` to stay watchable, and gate pending dispatches behind a per-rule active window/time zone
- update PR prompts and docs so automated sessions keep monitoring review/CI work in their isolated worktrees

## Validation
- dotnet build src/copilotd/copilotd.csproj --nologo
