### PR TITLE
Update remote control GA docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ File logs live under `~/.copilotd/logs` by default (or `COPILOTD_HOME/logs`). Ea
 
 ### Rules options
 
-Issue rules support conditions (`--assignee`, `--label`, `--milestone`, `--type`) and launch options (`--yolo`, `--allow-all-tools`, `--allow-all-urls`, `--model`, `--prompt`, `--custom-prompt`, `--custom-prompt-mode`, `--repo`). Pull request rules are opt-in with `--kind pr` and support PR-specific conditions (`--base`, `--head`, `--head-repo`, `--draft`, `--review-decision`) plus `--branch-strategy`. All conditions are logical AND. `copilotd init` asks whether to create a default issue rule, a default PR rule, or both.
+Issue rules support conditions (`--assignee`, `--label`, `--milestone`, `--type`) and launch options (`--yolo`, `--allow-all-tools`, `--allow-all-urls`, `--model`, `--prompt`, `--custom-prompt`, `--custom-prompt-mode`, `--repo`). `--yolo` is Copilot CLI's full auto-approval mode and implies all tool, path, and URL permissions. Pull request rules are opt-in with `--kind pr` and support PR-specific conditions (`--base`, `--head`, `--head-repo`, `--draft`, `--review-decision`) plus `--branch-strategy`. All conditions are logical AND. `copilotd init` asks whether to create a default issue rule, a default PR rule, or both.
 
 Aliases: `rule` for `rules`, `create`/`new` for `add`, and `edit` for `update`.
 
@@ -375,8 +375,8 @@ sessions, and more — all via natural language.
 **How it works:**
 
 - The control session is launched automatically on `copilotd run` startup (when `enable_control_session` is `true`)
-- It runs in the context of a clone of the copilotd repo at `<repo_home>/DamianEdwards/copilotd` (cloned automatically if not already present)
-- Tool access is restricted to `copilotd`, `gh`, and `git` commands only — no general shell access
+- It runs from copilotd's own control-session folder under the configured copilotd home directory
+- Shell access is restricted to `copilotd`, `gh`, and `git` commands only — no general shell access
 - If the control session process dies, the daemon automatically relaunches it on the next poll cycle
 - It does not count against the `max_instances` limit
 - It is tracked separately from dispatch sessions and shown in the `copilotd status` output, including its GitHub remote session URL

--- a/src/copilotd/Commands/InitCommand.cs
+++ b/src/copilotd/Commands/InitCommand.cs
@@ -233,7 +233,7 @@ public static class InitCommand
                     AnsiConsole.WriteLine();
 
                     // Yolo / tool permissions
-                    AnsiConsole.MarkupLine("[grey]Yolo mode skips all confirmation prompts (implies --allow-all-tools and --allow-all-urls).[/]");
+                    AnsiConsole.MarkupLine("[grey]Yolo mode skips all confirmation prompts (implies --allow-all-tools, --allow-all-paths, and --allow-all-urls).[/]");
                     var existingYolo = existingIssueRule?.Yolo ?? false;
                     var yolo = AnsiConsole.Confirm("Enable yolo mode?", existingYolo);
                     AnsiConsole.MarkupLine($"  Yolo mode: [blue]{(yolo ? "yes" : "no")}[/]");
@@ -410,7 +410,7 @@ public static class InitCommand
                     AnsiConsole.MarkupLine($"  PR branch strategy: [blue]{Markup.Escape(branchStrategyChoice)}[/]");
                     AnsiConsole.WriteLine();
 
-                    AnsiConsole.MarkupLine("[grey]Yolo mode skips all confirmation prompts (implies --allow-all-tools and --allow-all-urls).[/]");
+                    AnsiConsole.MarkupLine("[grey]Yolo mode skips all confirmation prompts (implies --allow-all-tools, --allow-all-paths, and --allow-all-urls).[/]");
                     var existingPrYolo = existingPullRequestRule?.Yolo ?? false;
                     var prYolo = AnsiConsole.Confirm("Enable yolo mode for PR sessions?", existingPrYolo);
                     AnsiConsole.MarkupLine($"  Yolo mode: [blue]{(prYolo ? "yes" : "no")}[/]");

--- a/src/copilotd/Commands/RulesCommand.cs
+++ b/src/copilotd/Commands/RulesCommand.cs
@@ -241,7 +241,7 @@ public static class RulesCommand
         var labelOption = new Option<string[]>("--label") { Description = "Label condition (can be specified multiple times)", AllowMultipleArgumentsPerToken = true };
         var milestoneOption = new Option<string?>("--milestone") { Description = "Milestone condition" };
         var typeOption = new Option<string?>("--type") { Description = "Issue type condition" };
-        var yoloOption = new Option<bool>("--yolo") { Description = "Pass --yolo to copilot (implies --allow-all-tools and --allow-all-urls)" };
+        var yoloOption = new Option<bool>("--yolo") { Description = "Pass --yolo to copilot (implies --allow-all-tools, --allow-all-paths, and --allow-all-urls)" };
         var allowAllToolsOption = new Option<bool?>("--allow-all-tools") { Description = "Pass --allow-all-tools to copilot (default: true)" };
         var allowAllUrlsOption = new Option<bool?>("--allow-all-urls") { Description = "Pass --allow-all-urls to copilot (default: false)" };
         var promptOption = new Option<string?>("--prompt") { Description = "Extra prompt for this rule" };

--- a/src/copilotd/Models/CopilotdConfig.cs
+++ b/src/copilotd/Models/CopilotdConfig.cs
@@ -370,7 +370,7 @@ public abstract class DispatchRuleOptions
     /// <summary>Repositories this rule applies to (org/repo format).</summary>
     public List<string> Repos { get; set; } = [];
 
-    /// <summary>Whether to pass --yolo to copilot, which implies --allow-all-tools and --allow-all-urls.</summary>
+    /// <summary>Whether to pass --yolo to copilot, which implies --allow-all-tools, --allow-all-paths, and --allow-all-urls.</summary>
     public bool Yolo { get; set; }
 
     /// <summary>Whether to pass --allow-all-tools to copilot. Defaults to true. Implied by Yolo.</summary>


### PR DESCRIPTION
## Summary
- Clarify that `--yolo` implies tool, path, and URL auto-approval in current Copilot CLI
- Correct the README description of where the control remote session runs

## Validation
- `dotnet build src\copilotd\copilotd.csproj --nologo`